### PR TITLE
docs: highlight outpost deployments feature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,13 @@ BAMF is **GPLv3** — no usage restrictions, no feature gating:
   tunnels with zero data loss during scale-in, maintenance, and spot
   termination.
 
+- **Multi-region outpost deployments** — deploy proxy+bridge clusters in
+  multiple regions with a central API as the single source of truth. Agents
+  relay to all outposts simultaneously so any outpost can serve any resource.
+  GeoIP-based routing directs users to the nearest outpost. Region-pinned
+  resources get stable per-outpost URLs.
+  [Architecture](docs/architecture/outpost-deployments.md)
+
 - **Certificate-based trust model** — BAMF CA issues short-lived x509 and SSH
   certificates. No long-lived secrets. Session certs encode the authorization
   decision directly — the bridge validates certs locally during tunnel operation.
@@ -261,6 +268,7 @@ kubectl --context bamf-prod-cluster get pods
 | [Tunnels](docs/architecture/tunnels.md) | Tunnel protocol, reliable streams |
 | [Authentication](docs/architecture/authentication.md) | Auth flows, connectors, sessions |
 | [Security](docs/architecture/security.md) | Certificate model, trust bootstrap |
+| [Outpost Deployments](docs/architecture/outpost-deployments.md) | Multi-region proxy+bridge topology |
 | **Reference** | |
 | [CLI](docs/reference/cli.md) | Complete CLI reference |
 | [API](docs/reference/api.md) | REST API endpoints |


### PR DESCRIPTION
## Summary

- Add multi-region outpost deployment feature bullet to the Features section (after reliable tunnel streams)
- Add outpost architecture doc link to the Documentation table under Architecture

## Test plan

- [ ] Verify rendered README formatting on the PR Files tab
- [ ] Confirm `docs/architecture/outpost-deployments.md` link resolves