### PR TITLE
chore: relicense to MPL-2.0 + port Terrapod dev-process scaffolding

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# BAMF pre-commit hook — fast, local checks on staged files before every commit.
+# Install with `make hooks` (sets core.hooksPath to .githooks). Runs whichever
+# of gitleaks / gofmt / ruff are available; blocks the commit on any failure.
+# Do NOT bypass with `git commit --no-verify` — fix the issue instead.
+set -euo pipefail
+
+fail=0
+staged() { git diff --cached --name-only --diff-filter=ACM -- "$@"; }
+
+# 1. Secret scan (highest value; config: .gitleaks.toml). Blocks on any leak.
+if command -v gitleaks >/dev/null 2>&1; then
+  if ! gitleaks protect --staged --redact --no-banner >/dev/null 2>&1; then
+    echo "pre-commit: gitleaks found a potential secret in staged changes." >&2
+    gitleaks protect --staged --redact --no-banner >&2 || true
+    fail=1
+  fi
+else
+  echo "pre-commit: gitleaks not installed — skipping secret scan (install it: https://github.com/gitleaks/gitleaks)." >&2
+fi
+
+# 2. Go formatting (gofmt ships with Go; trivially fast).
+go_files=$(staged '*.go' || true)
+if [ -n "$go_files" ] && command -v gofmt >/dev/null 2>&1; then
+  unformatted=$(gofmt -l $go_files || true)
+  if [ -n "$unformatted" ]; then
+    echo "pre-commit: gofmt — these Go files need formatting (run: gofmt -w <file>):" >&2
+    echo "$unformatted" >&2
+    fail=1
+  fi
+fi
+
+# 3. Python lint + format (ruff, if installed locally for speed).
+py_files=$(staged '*.py' || true)
+if [ -n "$py_files" ] && command -v ruff >/dev/null 2>&1; then
+  if ! ruff check $py_files; then fail=1; fi
+  if ! ruff format --check $py_files; then
+    echo "pre-commit: ruff format — run: ruff format <files>" >&2
+    fail=1
+  fi
+fi
+
+if [ "$fail" -ne 0 ]; then
+  echo "pre-commit: checks failed — fix the issues above and re-stage. (Do not use --no-verify.)" >&2
+  exit 1
+fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
       is_pr: ${{ steps.meta.outputs.is_pr }}
       version: ${{ steps.meta.outputs.version }}
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Compute metadata
         id: meta
@@ -59,7 +59,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -89,7 +89,7 @@ jobs:
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: scripts/lint.sh go
 
   go-test:
@@ -98,7 +98,7 @@ jobs:
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: scripts/test.sh go
 
   go-build:
@@ -107,7 +107,7 @@ jobs:
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: scripts/build.sh binaries
 
   go-security:
@@ -116,7 +116,7 @@ jobs:
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: scripts/security-scan.sh go
 
   # ── Python ──────────────────────────────────────────────
@@ -126,7 +126,7 @@ jobs:
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: scripts/lint.sh python
 
   python-test:
@@ -135,7 +135,7 @@ jobs:
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: scripts/test.sh python
 
   python-security:
@@ -144,7 +144,7 @@ jobs:
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: scripts/security-scan.sh python
 
   # ── Web ─────────────────────────────────────────────────
@@ -154,7 +154,7 @@ jobs:
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - run: scripts/lint.sh web
 
   web-audit:
@@ -167,7 +167,7 @@ jobs:
       run:
         working-directory: web
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Install dependencies
         run: npm ci
       - name: Run npm audit
@@ -180,7 +180,7 @@ jobs:
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Helm lint (containerized)
         run: |
           docker run --rm -v "$PWD:/chart" -w /chart \
@@ -197,7 +197,7 @@ jobs:
       contents: read
       security-events: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Run Semgrep
         run: |
           docker run --rm \
@@ -218,7 +218,7 @@ jobs:
               --output "/src/semgrep-results.sarif"
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           sarif_file: semgrep-results.sarif
           category: semgrep
@@ -230,7 +230,7 @@ jobs:
     runs-on: ubuntu-latest
     container: zricethezav/gitleaks:latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Run gitleaks
         run: gitleaks detect --source . --no-git --config .gitleaks.toml
 
@@ -254,9 +254,9 @@ jobs:
           - language: javascript-typescript
             build-mode: none
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@v4
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -268,7 +268,7 @@ jobs:
               - exclude:
                   id: py/partial-ssrf
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@v4
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           category: codeql-${{ matrix.language }}
 
@@ -280,9 +280,9 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Review dependency changes
-        uses: actions/dependency-review-action@v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
         with:
           fail-on-severity: high
           comment-summary-in-pr: on-failure
@@ -313,20 +313,20 @@ jobs:
           - image: bamf-proxy
             dockerfile: docker/Dockerfile.proxy
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v4
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
-        uses: docker/build-push-action@v7
+        uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
         with:
           context: .
           file: ${{ matrix.dockerfile }}
@@ -355,17 +355,17 @@ jobs:
       matrix:
         image: [bamf-api, bamf-bridge, bamf-agent, bamf-web, bamf-proxy]
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Scan with Trivy
-        uses: aquasecurity/trivy-action@0.35.0
+        uses: aquasecurity/trivy-action@57a97c7e7821a5776cebc9bb87c984fa69cba8f1 # 0.35.0
         with:
           image-ref: ghcr.io/mattrobinsonsre/${{ matrix.image }}:sha-${{ needs.prepare.outputs.sha_short }}-amd64
           format: sarif
@@ -378,7 +378,7 @@ jobs:
 
       - name: Upload SARIF
         if: always()
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4
         with:
           sarif_file: trivy-${{ matrix.image }}.sarif
           category: trivy-${{ matrix.image }}
@@ -417,7 +417,7 @@ jobs:
         image: [bamf-api, bamf-bridge, bamf-agent, bamf-web, bamf-proxy]
     steps:
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -445,12 +445,12 @@ jobs:
       contents: write
       packages: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
         with:
           fetch-depth: 0
 
       - name: Log in to GHCR
-        uses: docker/login-action@v4
+        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -470,7 +470,7 @@ jobs:
           done
 
       - name: Install Helm
-        uses: azure/setup-helm@v5
+        uses: azure/setup-helm@9bc31f4ebc9c6b171d7bfbaa5d006ae7abdb4310 # v5
 
       - name: Publish Helm chart
         run: |
@@ -576,7 +576,7 @@ jobs:
     permissions:
       contents: write
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
       - name: Delete tag and release
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -201,8 +201,11 @@ Routing rules of thumb:
 
 Releases are automated in `.github/workflows/ci.yml`: pushing a semver tag
 (`vX.Y.Z`) builds multi-arch images, publishes the Helm chart to the OCI
-registry, attaches Go binaries + DEB/RPM packages, and creates the GitHub
-Release. A failed tag pipeline auto-deletes the tag (reuse the version).
+registry, attaches Go binaries + SBOMs, and creates the GitHub Release. A failed
+tag pipeline auto-deletes the tag (reuse the version). The full mechanical
+how-to — cutting, verifying artifacts, the version flow, and the release-notes
+template — is in [`docs/releasing.md`](docs/releasing.md); the gates below run
+**before** you tag.
 
 **Before tagging any minor or major release, run a pre-release audit and land
 its fixes as a dedicated `docs:`/`chore:` PR.** Enumerate everything merged

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,277 @@
+# AGENTS.md
+
+Guidance for contributors and AI coding assistants working in the BAMF
+repository. If you are using an AI assistant (Claude Code, Cursor, Copilot,
+Aider, etc.), point it at this file — it captures the architecture, the
+contracts, the test tiers, and the conventions that keep changes consistent.
+For a quick, machine-friendly map of the whole repo — entry points, the
+codebase layout, the feature catalogue, and how to enable each feature — see
+[`llms.txt`](llms.txt) at the repo root.
+
+New here? Start with [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup and the
+contribution workflow, then come back here for the deeper architecture and
+contract rules. **Contributions are very welcome — including AI-assisted
+("vibe") contributions** — as long as they follow the contracts below and ship
+with tests.
+
+---
+
+## What BAMF is
+
+BAMF (Bridge Access Management Fabric) is a free, open-source **infrastructure
+access platform** — an alternative to Teleport that gives teams secure, audited
+access to SSH servers, databases, Kubernetes clusters, and internal web
+applications through short-lived certificates, centralized audit, session
+recording, and zero-trust tunnels, with SSO and role-based access control.
+
+It is licensed **MPL-2.0** (file-level copyleft) with no usage, size, or revenue
+restrictions.
+
+## Repository layout
+
+| Path | What it is | Language |
+|---|---|---|
+| `services/` | API server (FastAPI) **and** the HTTP reverse proxy for web-app access — one codebase. Poetry-managed. | Python 3.13 |
+| `cmd/` | Go binaries: `bamf` (CLI), `bamf-bridge` (tunnel gateway), `bamf-agent` (target-side agent). | Go |
+| `pkg/` | Shared Go packages: `bridge`, `agent`, `ssh`, `dbproxy`, `tunnel`, `certs`, `apiclient` (typed HTTP client for the Python API), `config`. | Go |
+| `web/` | Next.js 16 frontend (React 19, TypeScript). | TypeScript |
+| `proto/` | Protobuf/gRPC definitions; generated code under `pkg/pb/`. | proto |
+| `alembic/` | Async Alembic database migrations. | Python |
+| `helm/bamf/` | The Helm chart (the primary, supported deployment mechanism). | YAML |
+| `docker/` | One Dockerfile per component (`api`, `bridge`, `agent`, `web`). | Dockerfile |
+| `docs/` | User + operator + architecture documentation. | Markdown |
+| `packaging/` | DEB/RPM packaging for the agent (nfpm). | YAML |
+| `pentest/` | SAST (Semgrep), image-scan (Trivy), DAST (Nuclei) config. | mixed |
+
+The Go module is `github.com/mattrobinsonsre/bamf`.
+
+## Build, lint, and test
+
+**Everything runs in Docker via `make` — there is no local toolchain to set up.**
+Run `make help` for the full list. The essentials:
+
+```sh
+make lint          # lint all (Go + Python + Web) in Docker
+make test          # test all (Go + Python) in Docker
+make build         # cross-compile the Go binaries for all platforms
+make dev           # local Kubernetes dev stack (Tilt on Rancher Desktop)
+make dev-down      # stop the dev stack
+make security-scan # govulncheck (Go) + pip-audit (Python)
+make pentest       # SAST + image CVE scan + DAST (DAST needs a running stack)
+make db-migrate    # run Alembic migrations
+make proto         # regenerate protobuf code
+```
+
+Per-surface verification before you push (lint alone is **not** enough):
+
+- **Go** changes → `make test-go` (+ `make build-local` if you touched build tags/entrypoints).
+- **Python** changes → `make test-python`.
+- **Web** changes → `npm run build` from `web/` (the Next.js prerender step
+  catches things `tsc` and ESLint cannot).
+- **Helm** changes → `helm lint ./helm/bamf` + `helm template ./helm/bamf`
+  (and the values profiles it ships).
+
+## Architecture principles
+
+1. **Certificate-based, short-lived access.** Every access path is authorized
+   by a BAMF-CA-issued, short-lived certificate — never a long-lived shared
+   secret. User certs default to 12h, service certs to 24h.
+2. **mTLS is the tunnel security boundary.** CLI ↔ Bridge ↔ Agent all speak
+   mTLS with BAMF-CA-issued certs. Internal cluster traffic (Bridge → API, API →
+   Postgres/Redis) is plain within the cluster, protected by network policy
+   (optionally a service mesh for internal mTLS).
+3. **Python for the control plane, Go for the data plane.** The API server,
+   auth, RBAC, audit, and the HTTP proxy are Python/FastAPI (string-heavy web
+   work). The bridge, agent, and CLI — anything on the hot byte-splicing path —
+   are Go. The Go side talks to the API only through `pkg/apiclient`.
+4. **Kubernetes-native, Helm-first.** The Helm chart is the supported
+   deployment mechanism; there is no separate installer.
+5. **Bring your own auth.** Every identity provider (local, OIDC, SAML) is a
+   `Connector` behind one abstraction; MFA is delegated to the IdP.
+6. **Audit everything.** SSH sessions, DB queries, and HTTP access are recorded
+   to an immutable audit log with session recording and redaction.
+7. **Reject by default.** Input validation at every API boundary; RBAC denies
+   unless a rule allows.
+8. **RFC3339 / ISO8601-UTC timestamps.** All datetimes are timezone-aware UTC,
+   serialized ISO8601 with a `Z` suffix — never naive datetimes.
+9. **Multi-replica safe.** The API runs behind a load balancer with multiple
+   replicas; never rely on in-process state for cross-replica coordination.
+10. **No sync work in async handlers (hard requirement).** FastAPI + uvicorn
+    runs a single event loop per worker. Any synchronous CPU-heavy or blocking
+    I/O call inside an `async def` handler starves the whole replica. Wrap such
+    calls in `asyncio.to_thread(...)` / `run_in_executor(...)`, or use an
+    async-native alternative (`httpx.AsyncClient`, `asyncpg`, `redis.asyncio`).
+    When a plain `def` endpoint genuinely needs sync libraries, prefer `def` —
+    FastAPI runs it in a threadpool for you; that rescue does **not** apply to
+    `async def`.
+
+## The API ↔ Consumer contract (hard)
+
+The Python API (`/api/v1/`) has several classes of consumer, each with its own
+contract. **Every API change must update every consumer it affects.** Breaking
+the API without updating consumers creates silent failures that are hard to
+debug.
+
+- **Web UI** (`web/`) — SSR fetches + client `fetch()` calls (`web/src/lib/`).
+- **`pkg/apiclient`** (Go) — the typed HTTP client the CLI, bridge, and agent
+  use for every API call. This is the source of truth for the Go-side view of
+  every endpoint; the Go components do **not** roll their own request shapes.
+- **CLI / bridge / agent** (`cmd/`) — consume the API through `pkg/apiclient`.
+
+The workflow when extending the API:
+
+1. Add the endpoint to the appropriate router (`services/bamf/api/routers/`),
+   with a Pydantic request/response model (no raw dicts) under
+   `bamf/api/models/`.
+2. Add/adjust the typed method in **`pkg/apiclient`** + a Go test if any Go
+   component consumes it.
+3. Add the consumer code that needs it (web page, CLI command).
+
+When a response field name changes, update `pkg/apiclient`'s struct/tag, every
+`web` `fetch` that references it, and the CLI. Responses are **flat** (no
+envelope): `GET /users` returns `[...]`, not `{"data": [...]}`. Errors use the
+FastAPI default shape (`{"detail": "..."}`).
+
+## The Code ↔ Tests contract (hard)
+
+Every code change ships with tests at the right tier(s). **No new endpoint,
+service function, CLI command, protocol handler, UI surface, or hard invariant
+lands without its accompanying tests.**
+
+| Tier | Where | What it exercises | DB / stack |
+|---|---|---|---|
+| **Go unit** | `pkg/**/*_test.go`, `cmd/**/*_test.go` | Protocol handlers, routing, cert parsing, tunnel splicing, CLI logic. Table-driven, `testify/require`. | none / fakes |
+| **Python unit / services-API** | `services/tests/{test_api,test_auth,test_services}` | Router contracts, auth/RBAC, service-layer rules with mocked DB. The bulk of Python tests. | mocked |
+| **Integration** | `services/tests/` (real engine) + `test/` | Multi-row workflows needing a real Postgres; end-to-end tunnel/agent flows. | `docker-compose.test.yml` |
+| **Web E2E** | `web/` (Playwright) | Full user flows through the real UI + API. | full stack |
+| **Pentest** | `pentest/` (SAST/Trivy/DAST) | Static analysis, image CVEs, live DAST. | `make pentest` |
+
+Routing rules of thumb:
+
+- A **router** endpoint → a services-API test (happy path + auth/RBAC + error
+  responses). Then a `pkg/apiclient` method + Go test if a Go component uses it.
+- A **service function** with mockable deps → a services-API test (mocked DB).
+  Reach for integration only when it depends on real Postgres semantics.
+- A **new Go protocol handler / tunnel path** → a table-driven Go unit test;
+  add an integration test if it crosses the CLI↔Bridge↔Agent boundary.
+- A **new frontend page / RBAC gate / user-facing flow** → a Playwright E2E
+  spec (RBAC gets a negative-path spec with a non-privileged session). `tsc` +
+  ESLint are necessary but **not** sufficient — the page must render in the E2E
+  stack.
+- A **new hard invariant** ("X must never happen") → a source-introspection
+  test that asserts the absence of the forbidden pattern, so it fails CI loudly
+  if a future change violates it.
+- A **behaviour-changing fix for a reported bug** → a regression test named
+  after the failure mode that fails pre-fix and passes after.
+
+## Conventions
+
+- **Issue-first** — every change beyond a genuinely trivial tweak (typo,
+  one-line comment, formatting) starts with a GitHub issue, and the PR
+  references it (`closes #N`). Flow: **issue → branch → PR → squash-merge**.
+- **Conventional commits** — `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`,
+  `test:`, `ci:`.
+- **Branches** — feature branches off `main`; never push directly to `main`;
+  never stack a PR on another open feature branch (always base on `main`). All
+  PRs require passing CI (lint, test, build).
+- **Python** — FastAPI app via `create_application()` factory + lifespan;
+  Pydantic `BaseSettings` for config; `structlog` only (no `print`/stdlib
+  `logging`); async everywhere (asyncpg, httpx); Ruff for lint+format; type
+  annotations on all signatures; pytest + pytest-asyncio.
+- **Go** — follow Effective Go + Go Code Review Comments; `slog` for logging;
+  wrap errors with context (`fmt.Errorf("bridge: ...: %w", err)`); table-driven
+  tests with `testify/require`; no global mutable state (explicit deps);
+  `context.Context` as the first argument.
+- **TypeScript / React** — strict TS; functional components + custom hooks
+  only; no `any` without an explanatory comment.
+- **Migrations** — Alembic with async SQLAlchemy; every migration has a real
+  `upgrade()` **and** `downgrade()`.
+- **The Helm values-schema contract (hard requirement)** —
+  `helm/bamf/values.schema.json` validates chart values with
+  `additionalProperties: false` on BAMF-specific objects, so `helm lint` fails
+  if `values.yaml` carries an undeclared key. When you add, rename, or remove a
+  `values.yaml` key you MUST update the schema to match — including keys that
+  only appear in templates via `| default` (e.g. `proxy.internalToken`,
+  `postgresql.existingSecretKey`). Kubernetes pass-through objects
+  (`podSecurityContext`, `nodeSelector`, `affinity`, `tolerations`) use schema
+  `type: object` with no property restrictions. Secrets flow via `secretKeyRef`
+  / `existingSecret`, never into a ConfigMap.
+
+## Release discipline
+
+Releases are automated in `.github/workflows/ci.yml`: pushing a semver tag
+(`vX.Y.Z`) builds multi-arch images, publishes the Helm chart to the OCI
+registry, attaches Go binaries + DEB/RPM packages, and creates the GitHub
+Release. A failed tag pipeline auto-deletes the tag (reuse the version).
+
+**Before tagging any minor or major release, run a pre-release audit and land
+its fixes as a dedicated `docs:`/`chore:` PR.** Enumerate everything merged
+since the previous tag (`git log vPREV..HEAD`) and audit:
+
+- **A. Docs completeness** — every user-visible feature/endpoint/flag merged
+  since the last tag is documented across `docs/` and reflected in `README.md`,
+  `docs/index.md`, and [`llms.txt`](llms.txt) (see below).
+- **B. Helm values↔schema sync** — every added/renamed/removed `values.yaml`
+  key is reflected in `values.schema.json` (`additionalProperties: false` ⇒
+  `helm lint` fails otherwise).
+- **C. Test coverage** — each new endpoint/service/handler/column has tests at
+  the right tier.
+- **D. Content-hygiene scan (hard gate)** — scan commits + added diff lines for
+  the forbidden internal identifiers and for any disparaging framing of peer
+  OSS projects (see Content hygiene). Any hit blocks the release.
+- **E. Version strings** — no doc hardcodes a stale version.
+- **F. Live smoke for destructive / high-blast-radius surfaces** — anything
+  that mutates infrastructure, issues certificates, or opens tunnels is smoke-
+  tested end-to-end on the live Tilt stack, not only unit-tested.
+- **G. Ignored-vulnerability review** — sweep the scanner suppressions
+  (`pentest/trivy/`, pip-audit/govulncheck allowlists) and drop any that a
+  version bump now fixes.
+- **H. AI-agent onboarding** — confirm a fresh, repo-only agent pointed at the
+  clone can accurately summarise BAMF, enumerate features, and give correct
+  getting-started guidance **without hallucinating endpoints or Helm values**.
+  The entry-point hierarchy (`README.md` → `AGENTS.md` → `docs/index.md`),
+  `llms.txt`, and the feature catalogue must be current with what shipped.
+
+Then run an **independent, adversarial third-party review** of `git diff
+vPREV..HEAD` (parallel read-only reviewers per dimension — API/service
+correctness + security, consumer-contract drift, test coverage, docs/ops — each
+told to find gaps and cite `file:line`). Verify their findings against the code
+before acting; fix the blocker tier; re-confirm CI is green; **then** tag. This
+review is required for **every** release, patch included — it scales with the
+diff.
+
+- **Keep [`llms.txt`](llms.txt) current (first-class deliverable).** It's the
+  machine-friendly map AI assistants land on. A change that adds, renames, or
+  removes a user-visible feature, a doc page, or a top-level entry point MUST
+  update `llms.txt` in the same PR (and the matching feature tables in
+  `README.md` / `docs/index.md`). Every entry must resolve to something real in
+  the repo — no hallucinated endpoints, Helm values, or config keys.
+
+## Content hygiene (hard requirements)
+
+These protect the public repository. Git history, PRs, and source are
+world-readable forever.
+
+- **No internal references** — commit messages, PR text, **and source comments
+  / docstrings** must never reference any company, internal hostname, internal
+  repo/project name, internal cluster name, or specific customer/deployment
+  (this includes `acrolinx`, `acrolinx-cloud.net`, `markup.ai`, `markupai`, and
+  anything under a private tailnet). When describing an issue motivated by a
+  real deployment, anonymise it ("a multi-cluster estate", "an internal CI
+  cluster"), never name the source. If you catch a leak in your own draft,
+  scrub it before pushing.
+- **Respect peer open-source projects** — Teleport (and any peer project) is a
+  respected fellow project, not an enemy to disparage. Never denigrate it — not
+  in commits, PRs, comments, docs, issues, release notes, or conversation — and
+  never passive-aggressively. Honest, factual, neutral technical/licensing
+  comparison is fine (and is core to BAMF's positioning); comparison framed to
+  rank or belittle is not. Position BAMF on its own merits.
+
+## Where to learn more
+
+- [`CONTRIBUTING.md`](CONTRIBUTING.md) — setup + the contribution workflow.
+- [`llms.txt`](llms.txt) — the machine-friendly repo + feature map.
+- [`docs/`](docs/) — user, operator, and architecture documentation
+  ([`docs/getting-started.md`](docs/getting-started.md),
+  [`docs/architecture/overview.md`](docs/architecture/overview.md),
+  [`docs/development.md`](docs/development.md) are good next reads).

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,66 @@
+# Contributing to BAMF
+
+Contributions are very welcome — including AI-assisted ("vibe") contributions —
+as long as they follow the contracts in [`AGENTS.md`](AGENTS.md) and ship with
+tests. BAMF is MPL-2.0.
+
+## Setup
+
+Everything builds, lints, and tests in Docker via `make` — there is no local
+Go/Python/Node toolchain to install (Docker + a local Kubernetes for the dev
+stack is all you need).
+
+```sh
+make help          # list every target
+make lint          # lint Go + Python + Web
+make test          # test Go + Python
+make dev           # local Kubernetes dev stack (Tilt on Rancher Desktop)
+make dev-down      # stop it
+```
+
+First time working on the repo, install the git hooks (pre-commit lint/secret
+scan on staged files):
+
+```sh
+make hooks
+```
+
+See [`docs/development.md`](docs/development.md) for the full local-stack
+walkthrough and [`AGENTS.md`](AGENTS.md) for architecture, the API↔consumer and
+code↔tests contracts, and the conventions.
+
+## Workflow
+
+**Issue → branch → PR → squash-merge.**
+
+1. **Open a GitHub issue** for anything beyond a genuinely trivial tweak (typo,
+   one-line comment, formatting). The issue is where the change is scoped.
+2. **Branch off `main`** (`git checkout -b feat/short-description origin/main`).
+   Never push to `main`; never stack a PR on another open feature branch.
+3. **Make the change with its tests** at the right tier (see the Code↔Tests
+   contract in `AGENTS.md`). Update every consumer an API change touches
+   (`pkg/apiclient`, `web`, CLI). Keep `values.schema.json` in sync with
+   `values.yaml`. Keep `llms.txt` + the README/docs feature tables in sync when
+   you add or change a user-visible feature.
+4. **Verify locally** for the surface you changed (`make test-go` /
+   `make test-python` / `npm run build` in `web/` / `helm lint`).
+5. **Open a PR** that references the issue (`closes #N`) with a conventional-
+   commit title (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`,
+   `ci:`). CI (lint, test, build) must be green.
+
+## Content hygiene (please read)
+
+BAMF's history and source are public forever. Two hard rules:
+
+- **No internal references** — no company, internal hostname, internal
+  repo/cluster, or customer names in commits, PRs, comments, or docstrings.
+  Anonymise real-world motivation.
+- **Respect peer projects** — Teleport and other peers are respected fellow
+  projects. Factual, neutral comparison is fine; disparagement is not.
+
+Full detail: [`AGENTS.md` → Content hygiene](AGENTS.md#content-hygiene-hard-requirements).
+
+## Reporting security issues
+
+Please follow [`SECURITY.md`](SECURITY.md) — do not open a public issue for
+vulnerabilities.

--- a/LICENSE
+++ b/LICENSE
@@ -1,674 +1,373 @@
-                    GNU GENERAL PUBLIC LICENSE
-                       Version 3, 29 June 2007
-
- Copyright (C) 2007 Free Software Foundation, Inc. <https://fsf.org/>
- Everyone is permitted to copy and distribute verbatim copies
- of this license document, but changing it is not allowed.
-
-                            Preamble
-
-  The GNU General Public License is a free, copyleft license for
-software and other kinds of works.
-
-  The licenses for most software and other practical works are designed
-to take away your freedom to share and change the works.  By contrast,
-the GNU General Public License is intended to guarantee your freedom to
-share and change all versions of a program--to make sure it remains free
-software for all its users.  We, the Free Software Foundation, use the
-GNU General Public License for most of our software; it applies also to
-any other work released this way by its authors.  You can apply it to
-your programs, too.
-
-  When we speak of free software, we are referring to freedom, not
-price.  Our General Public Licenses are designed to make sure that you
-have the freedom to distribute copies of free software (and charge for
-them if you wish), that you receive source code or can get it if you
-want it, that you can change the software or use pieces of it in new
-free programs, and that you know you can do these things.
-
-  To protect your rights, we need to prevent others from denying you
-these rights or asking you to surrender the rights.  Therefore, you have
-certain responsibilities if you distribute copies of the software, or if
-you modify it: responsibilities to respect the freedom of others.
-
-  For example, if you distribute copies of such a program, whether
-gratis or for a fee, you must pass on to the recipients the same
-freedoms that you received.  You must make sure that they, too, receive
-or can get the source code.  And you must show them these terms so they
-know their rights.
-
-  Developers that use the GNU GPL protect your rights with two steps:
-(1) assert copyright on the software, and (2) offer you this License
-giving you legal permission to copy, distribute and/or modify it.
-
-  For the developers' and authors' protection, the GPL clearly explains
-that there is no warranty for this free software.  For both users' and
-authors' sake, the GPL requires that modified versions be marked as
-changed, so that their problems will not be attributed erroneously to
-authors of previous versions.
-
-  Some devices are designed to deny users access to install or run
-modified versions of the software inside them, although the manufacturer
-can do so.  This is fundamentally incompatible with the aim of
-protecting users' freedom to change the software.  The systematic
-pattern of such abuse occurs in the area of products for individuals to
-use, which is precisely where it is most unacceptable.  Therefore, we
-have designed this version of the GPL to prohibit the practice for those
-products.  If such problems arise substantially in other domains, we
-stand ready to extend this provision to those domains in future versions
-of the GPL, as needed to protect the freedom of users.
-
-  Finally, every program is threatened constantly by software patents.
-States should not allow patents to restrict development and use of
-software on general-purpose computers, but in those that do, we wish to
-avoid the special danger that patents applied to a free program could
-make it effectively proprietary.  To prevent this, the GPL assures that
-patents cannot be used to render the program non-free.
-
-  The precise terms and conditions for copying, distribution and
-modification follow.
-
-                       TERMS AND CONDITIONS
-
-  0. Definitions.
-
-  "This License" refers to version 3 of the GNU General Public License.
-
-  "Copyright" also means copyright-like laws that apply to other kinds of
-works, such as semiconductor masks.
-
-  "The Program" refers to any copyrightable work licensed under this
-License.  Each licensee is addressed as "you".  "Licensees" and
-"recipients" may be individuals or organizations.
-
-  To "modify" a work means to copy from or adapt all or part of the work
-in a fashion requiring copyright permission, other than the making of an
-exact copy.  The resulting work is called a "modified version" of the
-earlier work or a work "based on" the earlier work.
-
-  A "covered work" means either the unmodified Program or a work based
-on the Program.
-
-  To "propagate" a work means to do anything with it that, without
-permission, would make you directly or secondarily liable for
-infringement under applicable copyright law, except executing it on a
-computer or modifying a private copy.  Propagation includes copying,
-distribution (with or without modification), making available to the
-public, and in some countries other activities as well.
-
-  To "convey" a work means any kind of propagation that enables other
-parties to make or receive copies.  Mere interaction with a user through
-a computer network, with no transfer of a copy, is not conveying.
-
-  An interactive user interface displays "Appropriate Legal Notices"
-to the extent that it includes a convenient and prominently visible
-feature that (1) displays an appropriate copyright notice, and (2)
-tells the user that there is no warranty for the work (except to the
-extent that warranties are provided), that licensees may convey the
-work under this License, and how to view a copy of this License.  If
-the interface presents a list of user commands or options, such as a
-menu, a prominent item in the list meets this criterion.
-
-  1. Source Code.
-
-  The "source code" for a work means the preferred form of the work
-for making modifications to it.  "Object code" means any non-source
-form of a work.
-
-  A "Standard Interface" means an interface that either is an official
-standard defined by a recognized standards body, or, in the case of
-interfaces specified for a particular programming language, one that
-is widely used among developers working in that language.
-
-  The "System Libraries" of an executable work include anything, other
-than the work as a whole, that (a) is included in the normal form of
-packaging a Major Component, but which is not part of that Major
-Component, and (b) serves only to enable use of the work with that
-Major Component, or to implement a Standard Interface for which an
-implementation is available to the public in source code form.  A
-"Major Component", in this context, means a major essential component
-(kernel, window system, and so on) of the specific operating system
-(if any) on which the executable work runs, or a compiler used to
-produce the work, or an object code interpreter used to run it.
-
-  The "Corresponding Source" for a work in object code form means all
-the source code needed to generate, install, and (for an executable
-work) run the object code and to modify the work, including scripts to
-control those activities.  However, it does not include the work's
-System Libraries, or general-purpose tools or generally available free
-programs which are used unmodified in performing those activities but
-which are not part of the work.  For example, Corresponding Source
-includes interface definition files associated with source files for
-the work, and the source code for shared libraries and dynamically
-linked subprograms that the work is specifically designed to require,
-such as by intimate data communication or control flow between those
-subprograms and other parts of the work.
-
-  The Corresponding Source need not include anything that users
-can regenerate automatically from other parts of the Corresponding
-Source.
-
-  The Corresponding Source for a work in source code form is that
-same work.
-
-  2. Basic Permissions.
-
-  All rights granted under this License are granted for the term of
-copyright on the Program, and are irrevocable provided the stated
-conditions are met.  This License explicitly affirms your unlimited
-permission to run the unmodified Program.  The output from running a
-covered work is covered by this License only if the output, given its
-content, constitutes a covered work.  This License acknowledges your
-rights of fair use or other equivalent, as provided by copyright law.
-
-  You may make, run and propagate covered works that you do not
-convey, without conditions so long as your license otherwise remains
-in force.  You may convey covered works to others for the sole purpose
-of having them make modifications exclusively for you, or provide you
-with facilities for running those works, provided that you comply with
-the terms of this License in conveying all material for which you do
-not control copyright.  Those thus making or running the covered works
-for you must do so exclusively on your behalf, under your direction
-and control, on terms that prohibit them from making any copies of
-your copyrighted material outside their relationship with you.
-
-  Conveying under any other circumstances is permitted solely under
-the conditions stated below.  Sublicensing is not allowed; section 10
-makes it unnecessary.
-
-  3. Protecting Users' Legal Rights From Anti-Circumvention Law.
-
-  No covered work shall be deemed part of an effective technological
-measure under any applicable law fulfilling obligations under article
-11 of the WIPO copyright treaty adopted on 20 December 1996, or
-similar laws prohibiting or restricting circumvention of such
-measures.
-
-  When you convey a covered work, you waive any legal power to forbid
-circumvention of technological measures to the extent such circumvention
-is effected by exercising rights under this License with respect to
-the covered work, and you disclaim any intention to limit operation or
-modification of the work as a means of enforcing, against the work's
-users, your or third parties' legal rights to forbid circumvention of
-technological measures.
-
-  4. Conveying Verbatim Copies.
-
-  You may convey verbatim copies of the Program's source code as you
-receive it, in any medium, provided that you conspicuously and
-appropriately publish on each copy an appropriate copyright notice;
-keep intact all notices stating that this License and any
-non-permissive terms added in accord with section 7 apply to the code;
-keep intact all notices of the absence of any warranty; and give all
-recipients a copy of this License along with the Program.
-
-  You may charge any price or no price for each copy that you convey,
-and you may offer support or warranty protection for a fee.
-
-  5. Conveying Modified Source Versions.
-
-  You may convey a work based on the Program, or the modifications to
-produce it from the Program, in the form of source code under the
-terms of section 4, provided that you also meet all of these conditions:
-
-    a) The work must carry prominent notices stating that you modified
-    it, and giving a relevant date.
-
-    b) The work must carry prominent notices stating that it is
-    released under this License and any conditions added under section
-    7.  This requirement modifies the requirement in section 4 to
-    "keep intact all notices".
-
-    c) You must license the entire work, as a whole, under this
-    License to anyone who comes into possession of a copy.  This
-    License will therefore apply, along with any applicable section 7
-    additional terms, to the whole of the work, and all its parts,
-    regardless of how they are packaged.  This License gives no
-    permission to license the work in any other way, but it does not
-    invalidate such permission if you have separately received it.
-
-    d) If the work has interactive user interfaces, each must display
-    Appropriate Legal Notices; however, if the Program has interactive
-    interfaces that do not display Appropriate Legal Notices, your
-    work need not make them do so.
-
-  A compilation of a covered work with other separate and independent
-works, which are not by their nature extensions of the covered work,
-and which are not combined with it such as to form a larger program,
-in or on a volume of a storage or distribution medium, is called an
-"aggregate" if the compilation and its resulting copyright are not
-used to limit the access or legal rights of the compilation's users
-beyond what the individual works permit.  Inclusion of a covered work
-in an aggregate does not cause this License to apply to the other
-parts of the aggregate.
-
-  6. Conveying Non-Source Forms.
-
-  You may convey a covered work in object code form under the terms
-of sections 4 and 5, provided that you also convey the
-machine-readable Corresponding Source under the terms of this License,
-in one of these ways:
-
-    a) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by the
-    Corresponding Source fixed on a durable physical medium
-    customarily used for software interchange.
-
-    b) Convey the object code in, or embodied in, a physical product
-    (including a physical distribution medium), accompanied by a
-    written offer, valid for at least three years and valid for as
-    long as you offer spare parts or customer support for that product
-    model, to give anyone who possesses the object code either (1) a
-    copy of the Corresponding Source for all the software in the
-    product that is covered by this License, on a durable physical
-    medium customarily used for software interchange, for a price no
-    more than your reasonable cost of physically performing this
-    conveying of source, or (2) access to copy the
-    Corresponding Source from a network server at no charge.
-
-    c) Convey individual copies of the object code with a copy of the
-    written offer to provide the Corresponding Source.  This
-    alternative is allowed only occasionally and noncommercially, and
-    only if you received the object code with such an offer, in accord
-    with subsection 6b.
-
-    d) Convey the object code by offering access from a designated
-    place (gratis or for a charge), and offer equivalent access to the
-    Corresponding Source in the same way through the same place at no
-    further charge.  You need not require recipients to copy the
-    Corresponding Source along with the object code.  If the place to
-    copy the object code is a network server, the Corresponding Source
-    may be on a different server (operated by you or a third party)
-    that supports equivalent copying facilities, provided you maintain
-    clear directions next to the object code saying where to find the
-    Corresponding Source.  Regardless of what server hosts the
-    Corresponding Source, you remain obligated to ensure that it is
-    available for as long as needed to satisfy these requirements.
-
-    e) Convey the object code using peer-to-peer transmission, provided
-    you inform other peers where the object code and Corresponding
-    Source of the work are being offered to the general public at no
-    charge under subsection 6d.
-
-  A separable portion of the object code, whose source code is excluded
-from the Corresponding Source as a System Library, need not be
-included in conveying the object code work.
-
-  A "User Product" is either (1) a "consumer product", which means any
-tangible personal property which is normally used for personal, family,
-or household purposes, or (2) anything designed or sold for incorporation
-into a dwelling.  In determining whether a product is a consumer product,
-doubtful cases shall be resolved in favor of coverage.  For a particular
-product received by a particular user, "normally used" refers to a
-typical or common use of that class of product, regardless of the status
-of the particular user or of the way in which the particular user
-actually uses, or expects or is expected to use, the product.  A product
-is a consumer product regardless of whether the product has substantial
-commercial, industrial or non-consumer uses, unless such uses represent
-the only significant mode of use of the product.
-
-  "Installation Information" for a User Product means any methods,
-procedures, authorization keys, or other information required to install
-and execute modified versions of a covered work in that User Product from
-a modified version of its Corresponding Source.  The information must
-suffice to ensure that the continued functioning of the modified object
-code is in no case prevented or interfered with solely because
-modification has been made.
-
-  If you convey an object code work under this section in, or with, or
-specifically for use in, a User Product, and the conveying occurs as
-part of a transaction in which the right of possession and use of the
-User Product is transferred to the recipient in perpetuity or for a
-fixed term (regardless of how the transaction is characterized), the
-Corresponding Source conveyed under this section must be accompanied
-by the Installation Information.  But this requirement does not apply
-if neither you nor any third party retains the ability to install
-modified object code on the User Product (for example, the work has
-been installed in ROM).
-
-  The requirement to provide Installation Information does not include a
-requirement to continue to provide support service, warranty, or updates
-for a work that has been modified or installed by the recipient, or for
-the User Product in which it has been modified or installed.  Access to a
-network may be denied when the modification itself materially and
-adversely affects the operation of the network or violates the rules and
-protocols for communication across the network.
-
-  Corresponding Source conveyed, and Installation Information provided,
-in accord with this section must be in a format that is publicly
-documented (and with an implementation available to the public in
-source code form), and must require no special password or key for
-unpacking, reading or copying.
-
-  7. Additional Terms.
-
-  "Additional permissions" are terms that supplement the terms of this
-License by making exceptions from one or more of its conditions.
-Additional permissions that are applicable to the entire Program shall
-be treated as though they were included in this License, to the extent
-that they are valid under applicable law.  If additional permissions
-apply only to part of the Program, that part may be used separately
-under those permissions, but the entire Program remains governed by
-this License without regard to the additional permissions.
-
-  When you convey a copy of a covered work, you may at your option
-remove any additional permissions from that copy, or from any part of
-it.  (Additional permissions may be written to require their own
-removal in certain cases when you modify the work.)  You may place
-additional permissions on material, added by you to a covered work,
-for which you have or can give appropriate copyright permission.
-
-  Notwithstanding any other provision of this License, for material you
-add to a covered work, you may (if authorized by the copyright holders of
-that material) supplement the terms of this License with terms:
-
-    a) Disclaiming warranty or limiting liability differently from the
-    terms of sections 15 and 16 of this License; or
-
-    b) Requiring preservation of specified reasonable legal notices or
-    author attributions in that material or in the Appropriate Legal
-    Notices displayed by works containing it; or
-
-    c) Prohibiting misrepresentation of the origin of that material, or
-    requiring that modified versions of such material be marked in
-    reasonable ways as different from the original version; or
-
-    d) Limiting the use for publicity purposes of names of licensors or
-    authors of the material; or
-
-    e) Declining to grant rights under trademark law for use of some
-    trade names, trademarks, or service marks; or
-
-    f) Requiring indemnification of licensors and authors of that
-    material by anyone who conveys the material (or modified versions of
-    it) with contractual assumptions of liability to the recipient, for
-    any liability that these contractual assumptions directly impose on
-    those licensors and authors.
-
-  All other non-permissive additional terms are considered "further
-restrictions" within the meaning of section 10.  If the Program as you
-received it, or any part of it, contains a notice stating that it is
-governed by this License along with a term that is a further
-restriction, you may remove that term.  If a license document contains
-a further restriction but permits relicensing or conveying under this
-License, you may add to a covered work material governed by the terms
-of that license document, provided that the further restriction does
-not survive such relicensing or conveying.
-
-  If you add terms to a covered work in accord with this section, you
-must place, in the relevant source files, a statement of the
-additional terms that apply to those files, or a notice indicating
-where to find the applicable terms.
-
-  Additional terms, permissive or non-permissive, may be stated in the
-form of a separately written license, or stated as exceptions;
-the above requirements apply either way.
-
-  8. Termination.
-
-  You may not propagate or modify a covered work except as expressly
-provided under this License.  Any attempt otherwise to propagate or
-modify it is void, and will automatically terminate your rights under
-this License (including any patent licenses granted under the third
-paragraph of section 11).
-
-  However, if you cease all violation of this License, then your
-license from a particular copyright holder is reinstated (a)
-provisionally, unless and until the copyright holder explicitly and
-finally terminates your license, and (b) permanently, if the copyright
-holder fails to notify you of the violation by some reasonable means
-prior to 60 days after the cessation.
-
-  Moreover, your license from a particular copyright holder is
-reinstated permanently if the copyright holder notifies you of the
-violation by some reasonable means, this is the first time you have
-received notice of violation of this License (for any work) from that
-copyright holder, and you cure the violation prior to 30 days after
-your receipt of the notice.
-
-  Termination of your rights under this section does not terminate the
-licenses of parties who have received copies or rights from you under
-this License.  If your rights have been terminated and not permanently
-reinstated, you do not qualify to receive new licenses for the same
-material under section 10.
-
-  9. Acceptance Not Required for Having Copies.
-
-  You are not required to accept this License in order to receive or
-run a copy of the Program.  Ancillary propagation of a covered work
-occurring solely as a consequence of using peer-to-peer transmission
-to receive a copy likewise does not require acceptance.  However,
-nothing other than this License grants you permission to propagate or
-modify any covered work.  These actions infringe copyright if you do
-not accept this License.  Therefore, by modifying or propagating a
-covered work, you indicate your acceptance of this License to do so.
-
-  10. Automatic Licensing of Downstream Recipients.
-
-  Each time you convey a covered work, the recipient automatically
-receives a license from the original licensors, to run, modify and
-propagate that work, subject to this License.  You are not responsible
-for enforcing compliance by third parties with this License.
-
-  An "entity transaction" is a transaction transferring control of an
-organization, or substantially all assets of one, or subdividing an
-organization, or merging organizations.  If propagation of a covered
-work results from an entity transaction, each party to that
-transaction who receives a copy of the work also receives whatever
-licenses to the work the party's predecessor in interest had or could
-give under the previous paragraph, plus a right to possession of the
-Corresponding Source of the work from the predecessor in interest, if
-the predecessor has it or can get it with reasonable efforts.
-
-  You may not impose any further restrictions on the exercise of the
-rights granted or affirmed under this License.  For example, you may
-not impose a license fee, royalty, or other charge for exercise of
-rights granted under this License, and you may not initiate litigation
-(including a cross-claim or counterclaim in a lawsuit) alleging that
-any patent claim is infringed by making, using, selling, offering for
-sale, or importing the Program or any portion of it.
-
-  11. Patents.
-
-  A "contributor" is a copyright holder who authorizes use under this
-License of the Program or a work on which the Program is based.  The
-work thus licensed is called the contributor's "contributor version".
-
-  A contributor's "essential patent claims" are all patent claims
-owned or controlled by the contributor, whether already acquired or
-hereafter acquired, that would be infringed by some manner, permitted
-by this License, of making, using, or selling its contributor version,
-but do not include claims that would be infringed only as a
-consequence of further modification of the contributor version.  For
-purposes of this definition, "control" includes the right to grant
-patent sublicenses in a manner consistent with the requirements of
-this License.
-
-  Each contributor grants you a non-exclusive, worldwide, royalty-free
-patent license under the contributor's essential patent claims, to
-make, use, sell, offer for sale, import and otherwise run, modify and
-propagate the contents of its contributor version.
-
-  In the following three paragraphs, a "patent license" is any express
-agreement or commitment, however denominated, not to enforce a patent
-(such as an express permission to practice a patent or covenant not to
-sue for patent infringement).  To "grant" such a patent license to a
-party means to make such an agreement or commitment not to enforce a
-patent against the party.
-
-  If you convey a covered work, knowingly relying on a patent license,
-and the Corresponding Source of the work is not available for anyone
-to copy, free of charge and under the terms of this License, through a
-publicly available network server or other readily accessible means,
-then you must either (1) cause the Corresponding Source to be so
-available, or (2) arrange to deprive yourself of the benefit of the
-patent license for this particular work, or (3) arrange, in a manner
-consistent with the requirements of this License, to extend the patent
-license to downstream recipients.  "Knowingly relying" means you have
-actual knowledge that, but for the patent license, your conveying the
-covered work in a country, or your recipient's use of the covered work
-in a country, would infringe one or more identifiable patents in that
-country that you have reason to believe are valid.
-
-  If, pursuant to or in connection with a single transaction or
-arrangement, you convey, or propagate by procuring conveyance of, a
-covered work, and grant a patent license to some of the parties
-receiving the covered work authorizing them to use, propagate, modify
-or convey a specific copy of the covered work, then the patent license
-you grant is automatically extended to all recipients of the covered
-work and works based on it.
-
-  A patent license is "discriminatory" if it does not include within
-the scope of its coverage, prohibits the exercise of, or is
-conditioned on the non-exercise of one or more of the rights that are
-specifically granted under this License.  You may not convey a covered
-work if you are a party to an arrangement with a third party that is
-in the business of distributing software, under which you make payment
-to the third party based on the extent of your activity of conveying
-the work, and under which the third party grants, to any of the
-parties who would receive the covered work from you, a discriminatory
-patent license (a) in connection with copies of the covered work
-conveyed by you (or copies made from those copies), or (b) primarily
-for and in connection with specific products or compilations that
-contain the covered work, unless you entered into that arrangement,
-or that patent license was granted, prior to 28 March 2007.
-
-  Nothing in this License shall be construed as excluding or limiting
-any implied license or other defenses to infringement that may
-otherwise be available to you under applicable patent law.
-
-  12. No Surrender of Others' Freedom.
-
-  If conditions are imposed on you (whether by court order, agreement or
-otherwise) that contradict the conditions of this License, they do not
-excuse you from the conditions of this License.  If you cannot convey a
-covered work so as to satisfy simultaneously your obligations under this
-License and any other pertinent obligations, then as a consequence you may
-not convey it at all.  For example, if you agree to terms that obligate you
-to collect a royalty for further conveying from those to whom you convey
-the Program, the only way you could satisfy both those terms and this
-License would be to refrain entirely from conveying the Program.
-
-  13. Use with the GNU Affero General Public License.
-
-  Notwithstanding any other provision of this License, you have
-permission to link or combine any covered work with a work licensed
-under version 3 of the GNU Affero General Public License into a single
-combined work, and to convey the resulting work.  The terms of this
-License will continue to apply to the part which is the covered work,
-but the special requirements of the GNU Affero General Public License,
-section 13, concerning interaction through a network will apply to the
-combination as such.
-
-  14. Revised Versions of this License.
-
-  The Free Software Foundation may publish revised and/or new versions of
-the GNU General Public License from time to time.  Such new versions will
-be similar in spirit to the present version, but may differ in detail to
-address new problems or concerns.
-
-  Each version is given a distinguishing version number.  If the
-Program specifies that a certain numbered version of the GNU General
-Public License "or any later version" applies to it, you have the
-option of following the terms and conditions either of that numbered
-version or of any later version published by the Free Software
-Foundation.  If the Program does not specify a version number of the
-GNU General Public License, you may choose any version ever published
-by the Free Software Foundation.
-
-  If the Program specifies that a proxy can decide which future
-versions of the GNU General Public License can be used, that proxy's
-public statement of acceptance of a version permanently authorizes you
-to choose that version for the Program.
-
-  Later license versions may give you additional or different
-permissions.  However, no additional obligations are imposed on any
-author or copyright holder as a result of your choosing to follow a
-later version.
-
-  15. Disclaimer of Warranty.
-
-  THERE IS NO WARRANTY FOR THE PROGRAM, TO THE EXTENT PERMITTED BY
-APPLICABLE LAW.  EXCEPT WHEN OTHERWISE STATED IN WRITING THE COPYRIGHT
-HOLDERS AND/OR OTHER PARTIES PROVIDE THE PROGRAM "AS IS" WITHOUT WARRANTY
-OF ANY KIND, EITHER EXPRESSED OR IMPLIED, INCLUDING, BUT NOT LIMITED TO,
-THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
-PURPOSE.  THE ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE PROGRAM
-IS WITH YOU.  SHOULD THE PROGRAM PROVE DEFECTIVE, YOU ASSUME THE COST OF
-ALL NECESSARY SERVICING, REPAIR OR CORRECTION.
-
-  16. Limitation of Liability.
-
-  IN NO EVENT UNLESS REQUIRED BY APPLICABLE LAW OR AGREED TO IN WRITING
-WILL ANY COPYRIGHT HOLDER, OR ANY OTHER PARTY WHO MODIFIES AND/OR CONVEYS
-THE PROGRAM AS PERMITTED ABOVE, BE LIABLE TO YOU FOR DAMAGES, INCLUDING ANY
-GENERAL, SPECIAL, INCIDENTAL OR CONSEQUENTIAL DAMAGES ARISING OUT OF THE
-USE OR INABILITY TO USE THE PROGRAM (INCLUDING BUT NOT LIMITED TO LOSS OF
-DATA OR DATA BEING RENDERED INACCURATE OR LOSSES SUSTAINED BY YOU OR THIRD
-PARTIES OR A FAILURE OF THE PROGRAM TO OPERATE WITH ANY OTHER PROGRAMS),
-EVEN IF SUCH HOLDER OR OTHER PARTY HAS BEEN ADVISED OF THE POSSIBILITY OF
-SUCH DAMAGES.
-
-  17. Interpretation of Sections 15 and 16.
-
-  If the disclaimer of warranty and limitation of liability provided
-above cannot be given local legal effect according to their terms,
-reviewing courts shall apply local law that most closely approximates
-an absolute waiver of all civil liability in connection with the
-Program, unless a warranty or assumption of liability accompanies a
-copy of the Program in return for a fee.
-
-                     END OF TERMS AND CONDITIONS
-
-            How to Apply These Terms to Your New Programs
-
-  If you develop a new program, and you want it to be of the greatest
-possible use to the public, the best way to achieve this is to make it
-free software which everyone can redistribute and change under these terms.
-
-  To do so, attach the following notices to the program.  It is safest
-to attach them to the start of each source file to most effectively
-state the exclusion of warranty; and each file should have at least
-the "copyright" line and a pointer to where the full notice is found.
-
-    <one line to give the program's name and a brief idea of what it does.>
-    Copyright (C) <year>  <name of author>
-
-    This program is free software: you can redistribute it and/or modify
-    it under the terms of the GNU General Public License as published by
-    the Free Software Foundation, either version 3 of the License, or
-    (at your option) any later version.
-
-    This program is distributed in the hope that it will be useful,
-    but WITHOUT ANY WARRANTY; without even the implied warranty of
-    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-    GNU General Public License for more details.
-
-    You should have received a copy of the GNU General Public License
-    along with this program.  If not, see <https://www.gnu.org/licenses/>.
-
-Also add information on how to contact you by electronic and paper mail.
-
-  If the program does terminal interaction, make it output a short
-notice like this when it starts in an interactive mode:
-
-    <program>  Copyright (C) <year>  <name of author>
-    This program comes with ABSOLUTELY NO WARRANTY; for details type `show w'.
-    This is free software, and you are welcome to redistribute it
-    under certain conditions; type `show c' for details.
-
-The hypothetical commands `show w' and `show c' should show the appropriate
-parts of the General Public License.  Of course, your program's commands
-might be different; for a GUI interface, you would use an "about box".
-
-  You should also get your employer (if you work as a programmer) or school,
-if any, to sign a "copyright disclaimer" for the program, if necessary.
-For more information on this, and how to apply and follow the GNU GPL, see
-<https://www.gnu.org/licenses/>.
-
-  The GNU General Public License does not permit incorporating your program
-into proprietary programs.  If your program is a subroutine library, you
-may consider it more useful to permit linking proprietary applications with
-the library.  If this is what you want to do, use the GNU Lesser General
-Public License instead of this License.  But first, please read
-<https://www.gnu.org/licenses/why-not-lgpl.html>.
+Mozilla Public License Version 2.0
+==================================
+
+1. Definitions
+--------------
+
+1.1. "Contributor"
+    means each individual or legal entity that creates, contributes to
+    the creation of, or owns Covered Software.
+
+1.2. "Contributor Version"
+    means the combination of the Contributions of others (if any) used
+    by a Contributor and that particular Contributor's Contribution.
+
+1.3. "Contribution"
+    means Covered Software of a particular Contributor.
+
+1.4. "Covered Software"
+    means Source Code Form to which the initial Contributor has attached
+    the notice in Exhibit A, the Executable Form of such Source Code
+    Form, and Modifications of such Source Code Form, in each case
+    including portions thereof.
+
+1.5. "Incompatible With Secondary Licenses"
+    means
+
+    (a) that the initial Contributor has attached the notice described
+        in Exhibit B to the Covered Software; or
+
+    (b) that the Covered Software was made available under the terms of
+        version 1.1 or earlier of the License, but not also under the
+        terms of a Secondary License.
+
+1.6. "Executable Form"
+    means any form of the work other than Source Code Form.
+
+1.7. "Larger Work"
+    means a work that combines Covered Software with other material, in
+    a separate file or files, that is not Covered Software.
+
+1.8. "License"
+    means this document.
+
+1.9. "Licensable"
+    means having the right to grant, to the maximum extent possible,
+    whether at the time of the initial grant or subsequently, any and
+    all of the rights conveyed by this License.
+
+1.10. "Modifications"
+    means any of the following:
+
+    (a) any file in Source Code Form that results from an addition to,
+        deletion from, or modification of the contents of Covered
+        Software; or
+
+    (b) any new file in Source Code Form that contains any Covered
+        Software.
+
+1.11. "Patent Claims" of a Contributor
+    means any patent claim(s), including without limitation, method,
+    process, and apparatus claims, in any patent Licensable by such
+    Contributor that would be infringed, but for the grant of the
+    License, by the making, using, selling, offering for sale, having
+    made, import, or transfer of either its Contributions or its
+    Contributor Version.
+
+1.12. "Secondary License"
+    means either the GNU General Public License, Version 2.0, the GNU
+    Lesser General Public License, Version 2.1, the GNU Affero General
+    Public License, Version 3.0, or any later versions of those
+    licenses.
+
+1.13. "Source Code Form"
+    means the form of the work preferred for making modifications.
+
+1.14. "You" (or "Your")
+    means an individual or a legal entity exercising rights under this
+    License. For legal entities, "You" includes any entity that
+    controls, is controlled by, or is under common control with You. For
+    purposes of this definition, "control" means (a) the power, direct
+    or indirect, to cause the direction or management of such entity,
+    whether by contract or otherwise, or (b) ownership of more than
+    fifty percent (50%) of the outstanding shares or beneficial
+    ownership of such entity.
+
+2. License Grants and Conditions
+--------------------------------
+
+2.1. Grants
+
+Each Contributor hereby grants You a world-wide, royalty-free,
+non-exclusive license:
+
+(a) under intellectual property rights (other than patent or trademark)
+    Licensable by such Contributor to use, reproduce, make available,
+    modify, display, perform, distribute, and otherwise exploit its
+    Contributions, either on an unmodified basis, with Modifications, or
+    as part of a Larger Work; and
+
+(b) under Patent Claims of such Contributor to make, use, sell, offer
+    for sale, have made, import, and otherwise transfer either its
+    Contributions or its Contributor Version.
+
+2.2. Effective Date
+
+The licenses granted in Section 2.1 with respect to any Contribution
+become effective for each Contribution on the date the Contributor first
+distributes such Contribution.
+
+2.3. Limitations on Grant Scope
+
+The licenses granted in this Section 2 are the only rights granted under
+this License. No additional rights or licenses will be implied from the
+distribution or licensing of Covered Software under this License.
+Notwithstanding Section 2.1(b) above, no patent license is granted by a
+Contributor:
+
+(a) for any code that a Contributor has removed from Covered Software;
+    or
+
+(b) for infringements caused by: (i) Your and any other third party's
+    modifications of Covered Software, or (ii) the combination of its
+    Contributions with other software (except as part of its Contributor
+    Version); or
+
+(c) under Patent Claims infringed by Covered Software in the absence of
+    its Contributions.
+
+This License does not grant any rights in the trademarks, service marks,
+or logos of any Contributor (except as may be necessary to comply with
+the notice requirements in Section 3.4).
+
+2.4. Subsequent Licenses
+
+No Contributor makes additional grants as a result of Your choice to
+distribute the Covered Software under a subsequent version of this
+License (see Section 10.2) or under the terms of a Secondary License (if
+permitted under the terms of Section 3.3).
+
+2.5. Representation
+
+Each Contributor represents that the Contributor believes its
+Contributions are its original creation(s) or it has sufficient rights
+to grant the rights to its Contributions conveyed by this License.
+
+2.6. Fair Use
+
+This License is not intended to limit any rights You have under
+applicable copyright doctrines of fair use, fair dealing, or other
+equivalents.
+
+2.7. Conditions
+
+Sections 3.1, 3.2, 3.3, and 3.4 are conditions of the licenses granted
+in Section 2.1.
+
+3. Responsibilities
+-------------------
+
+3.1. Distribution of Source Form
+
+All distribution of Covered Software in Source Code Form, including any
+Modifications that You create or to which You contribute, must be under
+the terms of this License. You must inform recipients that the Source
+Code Form of the Covered Software is governed by the terms of this
+License, and how they can obtain a copy of this License. You may not
+attempt to alter or restrict the recipients' rights in the Source Code
+Form.
+
+3.2. Distribution of Executable Form
+
+If You distribute Covered Software in Executable Form then:
+
+(a) such Covered Software must also be made available in Source Code
+    Form, as described in Section 3.1, and You must inform recipients of
+    the Executable Form how they can obtain a copy of such Source Code
+    Form by reasonable means in a timely manner, at a charge no more
+    than the cost of distribution to the recipient; and
+
+(b) You may distribute such Executable Form under the terms of this
+    License, or sublicense it under different terms, provided that the
+    license for the Executable Form does not attempt to limit or alter
+    the recipients' rights in the Source Code Form under this License.
+
+3.3. Distribution of a Larger Work
+
+You may create and distribute a Larger Work under terms of Your choice,
+provided that You also comply with the requirements of this License for
+the Covered Software. If the Larger Work is a combination of Covered
+Software with a work governed by one or more Secondary Licenses, and the
+Covered Software is not Incompatible With Secondary Licenses, this
+License permits You to additionally distribute such Covered Software
+under the terms of such Secondary License(s), so that the recipient of
+the Larger Work may, at their option, further distribute the Covered
+Software under the terms of either this License or such Secondary
+License(s).
+
+3.4. Notices
+
+You may not remove or alter the substance of any license notices
+(including copyright notices, patent notices, disclaimers of warranty,
+or limitations of liability) contained within the Source Code Form of
+the Covered Software, except that You may alter any license notices to
+the extent required to remedy known factual inaccuracies.
+
+3.5. Application of Additional Terms
+
+You may choose to offer, and to charge a fee for, warranty, support,
+indemnity or liability obligations to one or more recipients of Covered
+Software. However, You may do so only on Your own behalf, and not on
+behalf of any Contributor. You must make it absolutely clear that any
+such warranty, support, indemnity, or liability obligation is offered by
+You alone, and You hereby agree to indemnify every Contributor for any
+liability incurred by such Contributor as a result of warranty, support,
+indemnity or liability terms You offer. You may include additional
+disclaimers of warranty and limitations of liability specific to any
+jurisdiction.
+
+4. Inability to Comply Due to Statute or Regulation
+---------------------------------------------------
+
+If it is impossible for You to comply with any of the terms of this
+License with respect to some or all of the Covered Software due to
+statute, judicial order, or regulation then You must: (a) comply with
+the terms of this License to the maximum extent possible; and (b)
+describe the limitations and the code they affect. Such description must
+be placed in a text file included with all distributions of the Covered
+Software under this License. Except to the extent prohibited by statute
+or regulation, such description must be sufficiently detailed for a
+recipient of ordinary skill to be able to understand it.
+
+5. Termination
+--------------
+
+5.1. The rights granted under this License will terminate automatically
+if You fail to comply with any of its terms. However, if You become
+compliant, then the rights granted under this License from a particular
+Contributor are reinstated (a) provisionally, unless and until such
+Contributor explicitly and finally terminates Your grants, and (b) on an
+ongoing basis, if such Contributor fails to notify You of the
+non-compliance by some reasonable means prior to 60 days after You have
+come back into compliance. Moreover, Your grants from a particular
+Contributor are reinstated on an ongoing basis if such Contributor
+notifies You of the non-compliance by some reasonable means, this is the
+first time You have received notice of non-compliance with this License
+from such Contributor, and You become compliant prior to 30 days after
+Your receipt of the notice.
+
+5.2. If You initiate litigation against any entity by asserting a patent
+infringement claim (excluding declaratory judgment actions,
+counter-claims, and cross-claims) alleging that a Contributor Version
+directly or indirectly infringes any patent, then the rights granted to
+You by any and all Contributors for the Covered Software under Section
+2.1 of this License shall terminate.
+
+5.3. In the event of termination under Sections 5.1 or 5.2 above, all
+end user license agreements (excluding distributors and resellers) which
+have been validly granted by You or Your distributors under this License
+prior to termination shall survive termination.
+
+************************************************************************
+*                                                                      *
+*  6. Disclaimer of Warranty                                           *
+*  -------------------------                                           *
+*                                                                      *
+*  Covered Software is provided under this License on an "as is"       *
+*  basis, without warranty of any kind, either expressed, implied, or  *
+*  statutory, including, without limitation, warranties that the       *
+*  Covered Software is free of defects, merchantable, fit for a        *
+*  particular purpose or non-infringing. The entire risk as to the     *
+*  quality and performance of the Covered Software is with You.        *
+*  Should any Covered Software prove defective in any respect, You     *
+*  (not any Contributor) assume the cost of any necessary servicing,   *
+*  repair, or correction. This disclaimer of warranty constitutes an   *
+*  essential part of this License. No use of any Covered Software is   *
+*  authorized under this License except under this disclaimer.         *
+*                                                                      *
+************************************************************************
+
+************************************************************************
+*                                                                      *
+*  7. Limitation of Liability                                          *
+*  --------------------------                                          *
+*                                                                      *
+*  Under no circumstances and under no legal theory, whether tort      *
+*  (including negligence), contract, or otherwise, shall any           *
+*  Contributor, or anyone who distributes Covered Software as          *
+*  permitted above, be liable to You for any direct, indirect,         *
+*  special, incidental, or consequential damages of any character      *
+*  including, without limitation, damages for lost profits, loss of    *
+*  goodwill, work stoppage, computer failure or malfunction, or any    *
+*  and all other commercial damages or losses, even if such party      *
+*  shall have been informed of the possibility of such damages. This   *
+*  limitation of liability shall not apply to liability for death or   *
+*  personal injury resulting from such party's negligence to the       *
+*  extent applicable law prohibits such limitation. Some               *
+*  jurisdictions do not allow the exclusion or limitation of           *
+*  incidental or consequential damages, so this exclusion and          *
+*  limitation may not apply to You.                                    *
+*                                                                      *
+************************************************************************
+
+8. Litigation
+-------------
+
+Any litigation relating to this License may be brought only in the
+courts of a jurisdiction where the defendant maintains its principal
+place of business and such litigation shall be governed by laws of that
+jurisdiction, without reference to its conflict-of-law provisions.
+Nothing in this Section shall prevent a party's ability to bring
+cross-claims or counter-claims.
+
+9. Miscellaneous
+----------------
+
+This License represents the complete agreement concerning the subject
+matter hereof. If any provision of this License is held to be
+unenforceable, such provision shall be reformed only to the extent
+necessary to make it enforceable. Any law or regulation which provides
+that the language of a contract shall be construed against the drafter
+shall not be used to construe this License against a Contributor.
+
+10. Versions of the License
+---------------------------
+
+10.1. New Versions
+
+Mozilla Foundation is the license steward. Except as provided in Section
+10.3, no one other than the license steward has the right to modify or
+publish new versions of this License. Each version will be given a
+distinguishing version number.
+
+10.2. Effect of New Versions
+
+You may distribute the Covered Software under the terms of the version
+of the License under which You originally received the Covered Software,
+or under the terms of any subsequent version published by the license
+steward.
+
+10.3. Modified Versions
+
+If you create software not governed by this License, and you want to
+create a new license for such software, you may create and use a
+modified version of this License if you rename the license and remove
+any references to the name of the license steward (except to note that
+such modified license differs from this License).
+
+10.4. Distributing Source Code Form that is Incompatible With Secondary
+Licenses
+
+If You choose to distribute Source Code Form that is Incompatible With
+Secondary Licenses under the terms of this version of the License, the
+notice described in Exhibit B of this License must be attached.
+
+Exhibit A - Source Code Form License Notice
+-------------------------------------------
+
+  This Source Code Form is subject to the terms of the Mozilla Public
+  License, v. 2.0. If a copy of the MPL was not distributed with this
+  file, You can obtain one at https://mozilla.org/MPL/2.0/.
+
+If it is not possible or desirable to put the notice in a particular
+file, then You may include the notice in a location (such as a LICENSE
+file in a relevant directory) where a recipient would be likely to look
+for such a notice.
+
+You may add additional accurate notices of copyright ownership.
+
+Exhibit B - "Incompatible With Secondary Licenses" Notice
+---------------------------------------------------------
+
+  This Source Code Form is "Incompatible With Secondary Licenses", as
+  defined by the Mozilla Public License, v. 2.0.

--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@
 	test test-go test-python \
 	build build-local images packages \
 	publish publish-images publish-chart publish-release \
-	release dev dev-down \
+	release hooks dev dev-down \
 	security-scan security-scan-go security-scan-python \
 	pentest pentest-dast pentest-images pentest-sast \
 	clean clean-cache test-down \
@@ -108,6 +108,10 @@ pentest-sast:       ## Run SAST static analysis (Semgrep)
 	scripts/pentest.sh sast
 
 # ── Development ──────────────────────────────────────────
+hooks:              ## Install git hooks (pre-commit lint + secret scan)
+	git config core.hooksPath .githooks
+	@echo "git hooks installed (core.hooksPath=.githooks). Pre-commit runs on staged files."
+
 dev:                ## Start Tilt development environment
 	tilt up
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # BAMF — Bridge Access Management Fabric
 
 [![CI](https://github.com/mattrobinsonsre/bamf/actions/workflows/ci.yml/badge.svg)](https://github.com/mattrobinsonsre/bamf/actions/workflows/ci.yml)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](LICENSE)
+[![License: MPL 2.0](https://img.shields.io/badge/License-MPL_2.0-brightgreen.svg)](LICENSE)
 
 Secure infrastructure access with short-lived certificates, centralized audit,
 and zero-trust tunnels. An open-source alternative to Teleport that builds in
@@ -20,16 +20,16 @@ starting with v16 (June 2024). Companies with >100 employees or >$10M revenue
 cannot legally use it. And even within those limits, SSO is locked to GitHub
 only — Okta, Azure AD, Google, SAML, and generic OIDC all require Enterprise.
 
-BAMF is **GPLv3** — no usage restrictions, no feature gating:
+BAMF is **MPL-2.0** — no usage restrictions, no feature gating:
 
-| | BAMF (GPLv3) | Teleport Community |
+| | BAMF (MPL-2.0) | Teleport Community |
 |---|---|---|
 | **SSO (OIDC/SAML)** | All providers included | GitHub only (Okta, Azure AD, SAML: Enterprise) |
 | **Session recording** | SSH + DB query + HTTP audit | SSH only (enhanced recording: Enterprise) |
 | **Web app access** | Included | Enterprise only |
 | **Commercial use** | Unrestricted | <100 employees **and** <$10M revenue |
 | **Build from source** | Go + Python, minutes | Go + Rust + C + libfido2, hours |
-| **License** | GPLv3 | Commercial (since v16, June 2024) |
+| **License** | MPL-2.0 | Commercial (since v16, June 2024) |
 
 [Detailed comparison](docs/comparison.md)
 
@@ -334,4 +334,6 @@ See [Development Guide](docs/development.md) for the full setup.
 
 ## License
 
-BAMF is licensed under the [GNU General Public License v3.0](LICENSE).
+BAMF is licensed under the [Mozilla Public License 2.0](LICENSE) — file-level
+copyleft (BAMF's own source stays open) with no usage, size, or revenue
+restrictions and unrestricted commercial use.

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -16,18 +16,18 @@ or resell Teleport Community in their products or services.
 Prior to v16, Teleport Community was AGPLv3. The source remains available but
 the license is no longer open-source by any standard definition.
 
-BAMF is licensed under the **GNU General Public License v3.0** with no usage
+BAMF is licensed under the **Mozilla Public License 2.0** with no usage
 restrictions. Any organization can use, modify, and distribute BAMF regardless
 of size or revenue. There is no CLA.
 
 | | BAMF | Teleport Community |
 |---|---|---|
-| License | GPLv3 | Commercial (employee + revenue caps) |
+| License | MPL-2.0 | Commercial (employee + revenue caps) |
 | Source available | Yes | Yes |
 | Free for individuals | Yes | Yes |
 | Free for companies >100 employees | Yes | No |
 | Free for companies >$10M revenue | Yes | No |
-| Embedding / reselling | Permitted (GPLv3 terms) | Prohibited |
+| Embedding / reselling | Permitted (MPL-2.0, file-level copyleft) | Prohibited |
 
 ## SSO — The Biggest Gap
 
@@ -39,7 +39,7 @@ Teleport Enterprise.
 
 BAMF includes full SSO support in the open-source release:
 
-| SSO Provider | BAMF (GPLv3) | Teleport Community | Teleport Enterprise |
+| SSO Provider | BAMF (MPL-2.0) | Teleport Community | Teleport Enterprise |
 |---|---|---|---|
 | GitHub | Planned | Yes | Yes |
 | Auth0 | Yes | No | Yes |
@@ -197,7 +197,7 @@ BAMF is a younger project. Features that Teleport has and BAMF does not:
 
 - Your team uses an identity provider (Okta, Azure AD, Auth0, Google, Keycloak)
   and needs SSO without paying for an enterprise license
-- You want a truly open-source solution (GPLv3) with no usage restrictions
+- You want a truly open-source solution (MPL-2.0) with no usage restrictions
 - You value build simplicity — standard Go + Python toolchains, no C/Rust deps
 - You don't need Windows/RDP desktop access
 - You prefer a lighter-weight deployment (separate Go data path + Python control plane)

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,6 +13,7 @@ New to the project? Read the [README](../README.md) first, then
 - [Getting started](getting-started.md) — install and first access.
 - [Comparison with Teleport](comparison.md) — features and licensing.
 - [Development guide](development.md) — the local Tilt stack.
+- [Releasing](releasing.md) — how to cut a release + the pre-release gates.
 
 ## Architecture
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,0 +1,48 @@
+# BAMF Documentation
+
+BAMF (Bridge Access Management Fabric) — secure, audited infrastructure access
+with short-lived certificates, session recording, and zero-trust tunnels. An
+open-source (MPL-2.0) alternative to Teleport.
+
+New to the project? Read the [README](../README.md) first, then
+[Getting started](getting-started.md). Building or contributing? See
+[AGENTS.md](../AGENTS.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Getting started
+
+- [Getting started](getting-started.md) — install and first access.
+- [Comparison with Teleport](comparison.md) — features and licensing.
+- [Development guide](development.md) — the local Tilt stack.
+
+## Architecture
+
+- [Overview](architecture/overview.md)
+- [Authentication](architecture/authentication.md)
+- [Tunnels](architecture/tunnels.md)
+- [Outpost deployments](architecture/outpost-deployments.md)
+- [Security](architecture/security.md)
+
+## Administration
+
+- [Deployment](admin/deployment.md)
+- [SSO](admin/sso.md)
+- [RBAC](admin/rbac.md)
+- [Users](admin/users.md)
+- [Certificates](admin/certificates.md)
+
+## Access guides
+
+- [SSH](guides/ssh.md)
+- [Databases](guides/databases.md)
+- [Kubernetes](guides/kubernetes.md)
+- [Web apps](guides/web-apps.md)
+- [Web terminal](guides/web-terminal.md)
+- [File shares](guides/file-shares.md)
+- [Agents](guides/agents.md)
+
+## Operations
+
+- [Upgrading](operations/upgrading.md)
+- [Backup & restore](operations/backup-restore.md)
+- [Scaling](operations/scaling.md)
+- [Monitoring](operations/monitoring.md)

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -1,0 +1,121 @@
+# Releasing BAMF
+
+Releases are **fully automated via GitHub Actions**: pushing a semver tag
+(`vX.Y.Z`) retags the images built for that commit, publishes the Helm chart,
+attaches the Go binaries + SBOMs, and creates the GitHub Release. This page is
+the mechanical how-to; the **quality gates** that must pass *before* you tag —
+the pre-release audit and the independent third-party review — live in
+[`AGENTS.md` → Release discipline](../AGENTS.md#release-discipline). Do those
+first; then follow the steps here.
+
+## Before tagging
+
+1. **All intended PRs are merged with green CI.** Don't tag a release with
+   unmerged work that was meant for it.
+2. **Run the pre-release audit (A–H) and the third-party review** described in
+   [`AGENTS.md`](../AGENTS.md#release-discipline), and land any fixes as a
+   dedicated `docs:`/`chore:` PR. Minor/major releases require the full audit;
+   patch releases still run the content-hygiene (D) and live-smoke (F) gates and
+   the third-party review (which scales with the diff).
+3. **`main` CI is green** on the commit you're about to tag. **Never tag a red
+   main.** (`gh run watch` the main-branch run to exit 0 first — "it'll probably
+   pass" is not sufficient.)
+
+## Cutting the release
+
+```sh
+git tag vX.Y.Z && git push origin vX.Y.Z
+```
+
+Then **watch the tag pipeline** (test → build → scan → manifest → release) in
+GitHub Actions. If any stage fails, the tag is **auto-deleted** by the
+`cleanup.yml` workflow — fix the issue and re-tag the same version (it's back to
+"never released", so reuse is safe).
+
+## Verify the published artifacts
+
+```sh
+docker manifest inspect ghcr.io/mattrobinsonsre/bamf-api:vX.Y.Z
+helm pull oci://ghcr.io/mattrobinsonsre/bamf --version X.Y.Z
+```
+
+## How the CI release flow works
+
+- Every push to `main` builds **SHA-tagged** images (`sha-<commit>`).
+- Pushing a semver tag **retags** those SHA images with the version + `:latest`,
+  publishes the Helm chart, and creates the GitHub Release. If the images for
+  that commit already exist (tag pushed on a commit `main` already built), tests
+  and builds are skipped and the release runs immediately.
+- A failed tag pipeline auto-cleans the tag (no partial release is left behind).
+- SHA-tagged images are garbage-collected after 30 days; **semver-tagged images
+  are kept indefinitely**.
+
+**Never move an existing (successfully published) release tag** to a different
+commit. If a version is broken after it published, abandon it and cut the next
+patch (`vX.Y.Z+1`). The criterion is "did the pipeline succeed and publish?" —
+if `cleanup.yml` deleted the tag, the version is free to reuse; otherwise it is
+frozen.
+
+All release logic is in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml);
+GHCR retention cleanup is in
+[`.github/workflows/cleanup.yml`](../.github/workflows/cleanup.yml).
+
+## Published artifacts
+
+| Artifact | Registry |
+|---|---|
+| `bamf-api` | `ghcr.io/mattrobinsonsre/bamf-api` |
+| `bamf-bridge` | `ghcr.io/mattrobinsonsre/bamf-bridge` |
+| `bamf-agent` | `ghcr.io/mattrobinsonsre/bamf-agent` |
+| `bamf-web` | `ghcr.io/mattrobinsonsre/bamf-web` |
+| `bamf-proxy` | `ghcr.io/mattrobinsonsre/bamf-proxy` |
+| Helm chart | `oci://ghcr.io/mattrobinsonsre/bamf` |
+| Go binaries | GitHub Release assets (linux/macOS/windows, amd64/arm64) |
+| SBOMs | GitHub Release assets (SPDX JSON per image) |
+
+All images are `linux/amd64` + `linux/arm64`; semver tags also get `:latest`.
+The Helm chart version strips the `v` prefix (`v0.1.0` → chart `0.1.0`);
+`Chart.yaml` stays at `0.0.0` in source and CI injects the real version at
+publish time via `helm package --version`.
+
+## Version flow
+
+```
+git tag v0.2.0
+    ↓  CI: VERSION="v0.2.0" (from GITHUB_REF)
+Go binaries:    -ldflags "-X ...Version=v0.2.0"
+Docker images:  bamf-api:v0.2.0, bamf-bridge:v0.2.0, ...  (+ :latest)
+Helm chart:     version: 0.2.0, appVersion: "v0.2.0"
+GitHub Release: "v0.2.0" with binaries + SBOMs + checksums
+```
+
+## Release notes
+
+The git tag, release tag, and release title are the bare semver: `vX.Y.Z`. CI
+auto-generates categorized notes from conventional commits between the previous
+and current tag. When editing manually:
+
+```markdown
+<One-sentence summary of what this release represents.>
+
+## Highlights
+- **Feature name** — concise, value-oriented description.
+
+## Bug Fixes
+- ... (only if any)
+
+## Breaking Changes
+- ... and migration path (only if any)
+
+## Security
+- ... (only if any)
+
+## Status
+<Alpha|Beta|Stable> — <one-line status note>.
+
+**Full Changelog**: https://github.com/mattrobinsonsre/bamf/compare/vPREV...vCURR
+```
+
+Conventions: lead with a one-line context sentence; bold feature names in
+Highlights; omit empty sections; end with the `**Full Changelog**` compare link;
+**no co-author lines or AI attribution**.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,98 @@
+# BAMF
+
+> BAMF (Bridge Access Management Fabric) is a free, open-source (MPL-2.0)
+> infrastructure access platform — an alternative to Teleport. It gives teams
+> secure, audited access to SSH servers, databases, Kubernetes clusters, and
+> internal web applications via short-lived certificates, centralized audit,
+> session recording, and zero-trust tunnels, with SSO and role-based access
+> control. Control plane in Python/FastAPI; data plane (bridge, agent, CLI) in
+> Go; Next.js web UI; deployed via a Helm chart. Repo:
+> `github.com/mattrobinsonsre/bamf`.
+
+This file is the machine-friendly map. Entries resolve to real files/commands in
+the repo — no hallucinated endpoints, Helm values, or config keys.
+
+## Start here (entry-point hierarchy)
+
+- [README.md](README.md): what BAMF is, feature overview, quickstart.
+- [AGENTS.md](AGENTS.md): contributor + AI-assistant guide — architecture,
+  contracts (API↔consumer, code↔tests), test tiers, conventions, content
+  hygiene, release discipline. **Read this before changing code.**
+- [CONTRIBUTING.md](CONTRIBUTING.md): setup + issue→branch→PR workflow.
+- [docs/index.md](docs/index.md): documentation entry point / table of contents.
+- `CLAUDE.md`: local-only (gitignored) operational + deep-architecture notes;
+  imports AGENTS.md. Not part of the public repo.
+
+## Build, test, run (all via Docker `make`; run `make help` for the full list)
+
+- `make lint` — lint Go + Python + Web.
+- `make test` — test Go + Python (`make test-go` / `make test-python` to scope).
+- `make build` — cross-compile the Go binaries; `make build-local` for the host.
+- `make dev` / `make dev-down` — local Kubernetes dev stack (Tilt on Rancher
+  Desktop); see [docs/development.md](docs/development.md).
+- `make db-migrate` — Alembic migrations. `make proto` — regenerate protobuf.
+- `make security-scan` — govulncheck + pip-audit. `make pentest` — SAST + Trivy + DAST.
+- Deploy: Helm chart at `helm/bamf/` — see [docs/admin/deployment.md](docs/admin/deployment.md).
+
+## Codebase map
+
+- `services/` — Python API server (FastAPI) + HTTP reverse proxy. Routers in
+  `services/bamf/api/routers/`; auth/CA/RBAC/SSO in `services/bamf/auth/`;
+  business logic in `services/bamf/services/`; models in `services/bamf/db/`.
+- `cmd/` — Go binaries: `bamf` (CLI), `bamf-bridge` (tunnel gateway),
+  `bamf-agent` (target-side agent).
+- `pkg/` — shared Go: `bridge`, `agent`, `ssh`, `dbproxy`, `tunnel`, `certs`,
+  `apiclient` (typed HTTP client for the Python API — the Go-side API contract),
+  `config`.
+- `web/` — Next.js 16 + React 19 + TypeScript frontend.
+- `proto/` → `pkg/pb/` — gRPC/protobuf.
+- `alembic/` — DB migrations. `helm/bamf/` — Helm chart. `docker/` — Dockerfiles.
+- `docs/` — documentation. `pentest/` — SAST/Trivy/DAST config.
+
+## Feature catalogue (each entry → what it does + where to learn more)
+
+- **SSO / identity** — OIDC + SAML connectors (Auth0, Okta, Google, Azure AD,
+  Keycloak, generic OIDC/SAML); MFA delegated to the IdP. Every provider is a
+  `Connector`. [docs/admin/sso.md](docs/admin/sso.md),
+  [docs/architecture/authentication.md](docs/architecture/authentication.md).
+- **RBAC** — role-based access control; built-in + custom roles; SSO claim
+  mapping via the `bamf:` claim prefix. [docs/admin/rbac.md](docs/admin/rbac.md).
+- **SSH access** — certificate-based SSH with session recording.
+  [docs/guides/ssh.md](docs/guides/ssh.md).
+- **Database access** — protocol-aware DB proxying (Postgres/MySQL) with query
+  audit. [docs/guides/databases.md](docs/guides/databases.md).
+- **Kubernetes access** — kube access via the HTTP proxy + exec credential
+  plugin. [docs/guides/kubernetes.md](docs/guides/kubernetes.md).
+- **Web app access** — authenticated HTTP reverse proxy to internal web apps.
+  [docs/guides/web-apps.md](docs/guides/web-apps.md).
+- **Web terminal** — browser-based SSH + DB access.
+  [docs/guides/web-terminal.md](docs/guides/web-terminal.md).
+- **Generic TCP tunnels** — short-lived local-forward tunnels (`bamf tcp ...`).
+  [docs/architecture/tunnels.md](docs/architecture/tunnels.md).
+- **Agents** — target-side agents (registration, heartbeat, join tokens).
+  [docs/guides/agents.md](docs/guides/agents.md).
+- **Audit & session recording** — immutable audit log; SSH/DB/HTTP recording
+  with redaction. [docs/architecture/security.md](docs/architecture/security.md).
+- **Certificates / internal CA** — BAMF-CA-issued short-lived certs (users 12h,
+  services 24h). [docs/admin/certificates.md](docs/admin/certificates.md).
+- **Outpost deployments** — data-plane components deployed close to targets.
+  [docs/architecture/outpost-deployments.md](docs/architecture/outpost-deployments.md).
+
+## Operations
+
+- [docs/operations/upgrading.md](docs/operations/upgrading.md),
+  [docs/operations/backup-restore.md](docs/operations/backup-restore.md),
+  [docs/operations/scaling.md](docs/operations/scaling.md),
+  [docs/operations/monitoring.md](docs/operations/monitoring.md).
+
+## Conventions that constrain changes (see AGENTS.md for the full text)
+
+- API is `/api/v1/`, flat responses (no envelope), FastAPI `{"detail": ...}`
+  errors, timezone-aware UTC ISO8601 timestamps, Pydantic request/response
+  models (no raw dicts).
+- Every API change updates its consumers: `pkg/apiclient` (Go), `web`, CLI.
+- Every code change ships tests at the right tier (Go unit / Python
+  services-API / integration / web E2E).
+- Helm: `values.yaml` ↔ `values.schema.json` must stay in sync
+  (`additionalProperties: false`); secrets via `secretKeyRef`, never ConfigMaps.
+- Content hygiene: no internal references; never disparage peer OSS (Teleport).

--- a/llms.txt
+++ b/llms.txt
@@ -33,6 +33,9 @@ the repo — no hallucinated endpoints, Helm values, or config keys.
 - `make db-migrate` — Alembic migrations. `make proto` — regenerate protobuf.
 - `make security-scan` — govulncheck + pip-audit. `make pentest` — SAST + Trivy + DAST.
 - Deploy: Helm chart at `helm/bamf/` — see [docs/admin/deployment.md](docs/admin/deployment.md).
+- Release: tag `vX.Y.Z` → automated GitHub Actions pipeline (images + Helm chart
+  + binaries + SBOMs). Process + pre-release gates:
+  [docs/releasing.md](docs/releasing.md) + [AGENTS.md](AGENTS.md#release-discipline).
 
 ## Codebase map
 

--- a/packaging/bamf-agent.yaml
+++ b/packaging/bamf-agent.yaml
@@ -12,7 +12,7 @@ maintainer: "Matt Robinson <mattrobinsonsre@gmail.com>"
 description: "BAMF Agent - secure infrastructure access agent"
 vendor: "BAMF"
 homepage: "https://github.com/mattrobinsonsre/bamf"
-license: "GPL-3.0"
+license: "MPL-2.0"
 
 contents:
   - src: dist/bamf-agent-linux-${ARCH}

--- a/services/bamf/proxy/pyproject.toml
+++ b/services/bamf/proxy/pyproject.toml
@@ -3,7 +3,7 @@ name = "bamf-proxy"
 description = "BAMF standalone HTTP proxy service"
 version = "0.0.0"
 authors = ["Matt Robinson <mattrobinsonsre@gmail.com>"]
-license = "GPL-3.0"
+license = "MPL-2.0"
 readme = "README.md"
 packages = [{include = "bamf", from = "../../services"}]
 

--- a/services/pyproject.toml
+++ b/services/pyproject.toml
@@ -3,7 +3,7 @@ name = "bamf"
 version = "0.1.0"
 description = "Beyond Access Management Framework - API Server"
 authors = ["Matt Robinson"]
-license = "Apache-2.0"
+license = "MPL-2.0"
 readme = "README.md"
 packages = [{include = "bamf"}]
 


### PR DESCRIPTION
Reactivation prep for BAMF — relicense to MPL-2.0 and port the development-process scaffolding we matured on Terrapod so future work is robust and convenient from day one. Two commits, reviewable independently.

## 1. Relicense GPLv3 → MPL-2.0
Sole-contributor relicense (no consent gate). `LICENSE` is now the canonical MPL-2.0 text; the README badge + comparison table/section, `docs/comparison.md`, and the per-package license fields (`services/pyproject.toml`, `services/bamf/proxy/pyproject.toml`, `packaging/bamf-agent.yaml`) all updated. MPL-2.0 keeps **file-level copyleft** (BAMF's own source stays open) while clearing the corporate GPL bans that screen the project out of evaluations, and it strengthens the "unrestricted commercial use" positioning. (Remaining `AGPLv3` mentions are factual references to Teleport — left as-is.)

## 2. Dev-process scaffolding (from Terrapod)
- **`AGENTS.md`** (committed) — the public contributor guide + **single source of truth** for shared conventions: architecture orientation, the **API↔consumer** (Python API ↔ `pkg/apiclient` ↔ web ↔ CLI) and **code↔tests** contracts, the test tiers, the Helm values-schema contract, release discipline (pre-release audit A–H + independent adversarial review), and **content hygiene** (no internal references + respect peer OSS / Teleport). The gitignored `CLAUDE.md` now imports it via `@AGENTS.md`, so a fresh AI session loads the directions automatically and nothing is duplicated.
- **`llms.txt`** (committed) — machine-friendly repo map + feature catalogue; every entry resolves to something real.
- **`CONTRIBUTING.md`** + **`docs/index.md`** — setup/issue→branch→PR workflow + a docs entry point.
- **Pre-commit hook** — `.githooks/pre-commit` (gitleaks + gofmt + ruff on staged files) installed via **`make hooks`**.
- **CI hardening** — every GitHub Action in `ci.yml`/`cleanup.yml` is now **pinned to a commit SHA** (`# vN` comments retained so Dependabot, which already tracks `github-actions`, keeps them current). CodeQL, Trivy, and dependency-review already run in `ci.yml`.

## Notes
- `CLAUDE.md` is gitignored (unchanged policy); its `@AGENTS.md` import + a short "reactivation handoff" section live only in the working tree.
- Verified: workflow YAML parses; changeset scoped. CI on this PR will run the full lint/test/build with the pinned actions.