### PR TITLE
docs(security): route vulnerability reports to private advisories (closes #136)

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,10 +11,14 @@ We recommend always running the latest release.
 
 ## Reporting a Vulnerability
 
-To report a security vulnerability, please
-[open a GitHub issue](https://github.com/mattrobinsonsre/bamf/issues/new).
-Include a description of the vulnerability, steps to reproduce, and affected
-versions if known.
+**Please do not open a public issue for security vulnerabilities** — a public
+issue discloses the flaw before a fix is available.
+
+Report privately through GitHub's private vulnerability reporting:
+[**Report a vulnerability**](https://github.com/mattrobinsonsre/bamf/security/advisories/new).
+Include a description, steps to reproduce, affected versions, and any
+proof-of-concept. We aim to acknowledge reports within a few working days and
+will coordinate a fix and a disclosure timeline with you.
 
 ## Security Design
 


### PR DESCRIPTION
`SECURITY.md` instructed reporters to **open a public GitHub issue** for vulnerabilities — a disclosure hazard on a public repo, and inconsistent with `CONTRIBUTING.md` and the private Security Advisory flow now in use. Routes reporters to GitHub private vulnerability reporting (`/security/advisories/new`) instead.

Closes #136