### PR TITLE
fix(auth): restrict OAuth redirect_uri to an allowlist

### DIFF
--- a/services/bamf/api/routers/auth.py
+++ b/services/bamf/api/routers/auth.py
@@ -30,6 +30,7 @@ Changes to response shapes must be coordinated with web UI auth code.
 import base64
 import hashlib
 from datetime import datetime
+from urllib.parse import urlparse
 
 from fastapi import APIRouter, Depends, Form, HTTPException, Query, Request, status
 from fastapi.responses import JSONResponse, RedirectResponse
@@ -72,6 +73,39 @@ router = APIRouter(prefix="/auth", tags=["auth"])
 logger = get_logger(__name__)
 
 
+# --- redirect_uri allowlist (prevents authorization-code injection) ---
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1"}
+
+
+def _origin(url: str) -> tuple[str, str, int] | None:
+    """Return (scheme, host, port) with the scheme's default port applied, or
+    None if the URL isn't an http(s) URL with a host."""
+    parsed = urlparse(url)
+    if parsed.scheme not in ("http", "https") or not parsed.hostname:
+        return None
+    port = parsed.port or (443 if parsed.scheme == "https" else 80)
+    return (parsed.scheme, parsed.hostname, port)
+
+
+def _redirect_uri_allowed(redirect_uri: str) -> bool:
+    """Allowlist the client redirect_uri to prevent open-redirect /
+    authorization-code injection: the attacker cannot start a flow and have the
+    one-time code delivered to a host they control.
+
+    Permitted targets:
+    - loopback callbacks (the CLI): http/https on 127.0.0.1 / localhost / ::1,
+      any port and path (RFC 8252 native-app pattern);
+    - the Web UI: the same origin as the configured callback_base_url.
+    """
+    origin = _origin(redirect_uri)
+    if origin is None:
+        return False
+    if origin[1] in _LOOPBACK_HOSTS:
+        return True
+    base = _origin(settings.auth.callback_base_url)
+    return base is not None and origin == base
+
+
 @router.get("/providers", response_model=ProvidersResponse)
 async def list_providers() -> ProvidersResponse:
     """List configured auth providers.
@@ -109,6 +143,13 @@ async def authorize(
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="Only S256 code_challenge_method is supported",
+        )
+
+    if not _redirect_uri_allowed(redirect_uri):
+        logger.warning("Authorize: rejected redirect_uri", redirect_uri=redirect_uri)
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail="redirect_uri is not allowed",
         )
 
     # Resolve provider

--- a/services/tests/test_api/test_auth_router.py
+++ b/services/tests/test_api/test_auth_router.py
@@ -19,7 +19,7 @@ from fastapi import FastAPI, HTTPException
 from httpx import ASGITransport, AsyncClient
 
 from bamf.api.dependencies import get_current_session, require_admin
-from bamf.api.routers.auth import _verify_pkce, router
+from bamf.api.routers.auth import _redirect_uri_allowed, _verify_pkce, router
 from bamf.auth.auth_state import AuthCode
 from bamf.auth.sessions import Session
 from bamf.db.session import get_db
@@ -163,6 +163,59 @@ class TestAuthorize:
             )
         assert resp.status_code == 400
         assert "Provider not found" in resp.json()["detail"]
+
+    @pytest.mark.asyncio
+    async def test_rejects_disallowed_redirect_uri(self, auth_client):
+        # A redirect_uri that is neither loopback nor the configured web origin
+        # is rejected before any provider work — blocks auth-code injection.
+        with patch("bamf.api.routers.auth.settings") as mock_settings:
+            mock_settings.auth.callback_base_url = "https://bamf.example.com"
+            resp = await auth_client.get(
+                "/api/v1/auth/authorize",
+                params={
+                    "redirect_uri": "https://evil.example/callback",
+                    "code_challenge": "test",
+                    "state": "test",
+                    "response_type": "code",
+                    "code_challenge_method": "S256",
+                    "provider": "local",
+                },
+            )
+        assert resp.status_code == 400
+        assert "redirect_uri" in resp.json()["detail"]
+
+
+class TestRedirectURIAllowlist:
+    def test_loopback_allowed(self):
+        for uri in (
+            "http://127.0.0.1:53123/callback",
+            "http://localhost:8888/callback",
+            "https://127.0.0.1/callback",
+            "http://[::1]:9000/callback",
+        ):
+            assert _redirect_uri_allowed(uri) is True, uri
+
+    def test_web_origin_allowed(self):
+        with patch("bamf.api.routers.auth.settings") as mock_settings:
+            mock_settings.auth.callback_base_url = "https://bamf.example.com"
+            assert _redirect_uri_allowed("https://bamf.example.com/auth/callback") is True
+            # default-port normalization (:443 == implicit https port)
+            assert _redirect_uri_allowed("https://bamf.example.com:443/auth/callback") is True
+
+    def test_rejects_external_and_malformed(self):
+        with patch("bamf.api.routers.auth.settings") as mock_settings:
+            mock_settings.auth.callback_base_url = "https://bamf.example.com"
+            for uri in (
+                "https://evil.example/callback",
+                "https://bamf.example.com.evil.example/callback",
+                "http://bamf.example.com/callback",  # scheme mismatch
+                "https://bamf.example.com:8443/callback",  # port mismatch
+                "javascript:alert(1)",
+                "//evil.example",
+                "not a url",
+                "",
+            ):
+                assert _redirect_uri_allowed(uri) is False, uri
 
 
 # ── Tests: CA Certificate ────────────────────────────────────────────────


### PR DESCRIPTION
Hardens the OAuth-style login flow: `GET /auth/authorize` now validates the client `redirect_uri` against an allowlist before storing auth state, and rejects anything else with 400.

**Allowed targets:**
- Loopback callbacks for the CLI — `127.0.0.1` / `localhost` / `::1`, any port/path (RFC 8252 native-app pattern).
- The Web UI — the same origin as the configured `callback_base_url` (with default-port normalization).

`/auth/authorize` is the single client-controlled entry point for the redirect target: `local_authorize` returns the code to the XHR caller (no redirect), and the `callback` / `local-login` / `saml_acs` paths reuse the stored (now validated) value — so validating once here closes the flow.

Tests: unit tests for the allowlist helper (loopback, web origin, external/malformed rejection) + a router-level 400 test. Full suite 1006 pass; lint clean.