### PR TITLE
fix(proxy): strip client-supplied trust headers before injecting identity

### DIFF
--- a/services/bamf/proxy/kube.py
+++ b/services/bamf/proxy/kube.py
@@ -136,10 +136,17 @@ async def kube_proxy(
     target_host = resource.hostname or "kubernetes.default.svc"
     target_port = resource.port or 6443
 
-    # Build headers for the bridge relay
-    headers = dict(request.headers)
-    for h in ("host", "connection", "transfer-encoding", "upgrade"):
-        headers.pop(h, None)
+    # Build headers for the bridge relay. Drop hop-by-hop headers AND any
+    # client-supplied trust headers (X-Forwarded-* / X-Bamf-* / Impersonate-*)
+    # so the client can't spoof identity, Kubernetes groups, or the target —
+    # that would be privilege escalation to impersonated groups + SSRF via
+    # X-Bamf-Target. The authoritative values are set below.
+    headers = {
+        k: v
+        for k, v in request.headers.items()
+        if k.lower() not in ("host", "connection", "transfer-encoding", "upgrade")
+        and not k.lower().startswith(("x-forwarded-", "x-bamf-", "impersonate-"))
+    }
 
     headers["X-Bamf-Target"] = f"{target_protocol}://{target_host}:{target_port}"
     headers["X-Forwarded-Email"] = session.email

--- a/services/bamf/proxy/rewrite.py
+++ b/services/bamf/proxy/rewrite.py
@@ -83,6 +83,12 @@ def rewrite_request_headers(
         # Strip BAMF Bearer token — the target shouldn't see it
         if lower_k == "authorization":
             continue
+        # Strip any client-supplied trust headers — the proxy injects the
+        # authoritative X-Forwarded-* / X-Bamf-* / Impersonate-* values below.
+        # Leaving inbound copies lets a client spoof identity, Kubernetes
+        # groups, or the proxy target (privilege escalation + SSRF).
+        if lower_k.startswith(("x-forwarded-", "x-bamf-", "impersonate-")):
+            continue
         # Strip bamf_session cookie but keep other cookies
         if lower_k == "cookie":
             v = _strip_bamf_cookie(v)

--- a/services/tests/test_api/test_rewrite.py
+++ b/services/tests/test_api/test_rewrite.py
@@ -98,6 +98,38 @@ class TestRewriteRequestHeaders:
         assert result["X-Forwarded-For"] == "10.0.0.1"
         assert result["X-Forwarded-Roles"] == "developer"
 
+    def test_client_supplied_trust_headers_stripped(self):
+        """Inbound X-Forwarded-* / X-Bamf-* / Impersonate-* from the client are
+        stripped so they cannot spoof identity, k8s groups, or the target."""
+        headers = {
+            "accept": "*/*",
+            "x-forwarded-email": "attacker@evil.example",
+            "x-forwarded-user": "attacker@evil.example",
+            "x-forwarded-roles": "admin",
+            "x-forwarded-groups": "system:masters",
+            "x-bamf-target": "http://169.254.169.254/",
+            "impersonate-user": "system:admin",
+            "impersonate-group": "system:masters",
+        }
+        result = rewrite_request_headers(headers=headers, **self._base_kwargs())
+        # None of the spoofed inbound (lowercase) keys survive.
+        for k in (
+            "x-forwarded-email",
+            "x-forwarded-user",
+            "x-forwarded-roles",
+            "x-forwarded-groups",
+            "x-bamf-target",
+            "impersonate-user",
+            "impersonate-group",
+        ):
+            assert k not in result, k
+        # The authoritative values are the proxy's own.
+        assert result["X-Forwarded-Email"] == "alice@example.com"
+        assert result["X-Forwarded-User"] == "alice@example.com"
+        assert result["X-Forwarded-Roles"] == "developer"
+        assert result["X-Bamf-Target"] == "http://grafana.internal:3000"
+        assert "accept" in result
+
     def test_authorization_stripped(self):
         """Authorization header (BAMF Bearer) is stripped from proxied requests."""
         headers = {"authorization": "Bearer bamf-session-token"}


### PR DESCRIPTION
The HTTP proxy (`rewrite_request_headers`) and the kube proxy copied inbound request headers wholesale, then injected the authoritative `X-Forwarded-*` / `X-Bamf-*` values. Because ASGI lowercases inbound header names, a client-supplied lowercase copy and the proxy's Title-Case copy could **both** reach the agent (which reads the first value) — letting a client spoof identity, Kubernetes groups, or the relay target.

Fix: strip all inbound `x-forwarded-*` / `x-bamf-*` / `impersonate-*` headers in both paths before injecting, so the proxy's values are authoritative.

Test: asserts spoofed inbound trust headers are stripped and the proxy's own values win. Full suite 1007 pass; lint clean.