### PR TITLE
fix(auth): cap session refresh at the login-time hard expiry

### DIFF
--- a/services/bamf/auth/sessions.py
+++ b/services/bamf/auth/sessions.py
@@ -42,6 +42,10 @@ class Session:
     # Kubernetes groups resolved from roles at login (union of all matching roles)
     kubernetes_groups: list[str] = field(default_factory=list)
 
+    # Absolute hard expiry (e.g. the IDP id_token lifetime) — a sliding refresh
+    # must never extend the session past this. None means no hard cap.
+    hard_expires_at: str | None = None
+
     # Token is not stored in Redis — it's the key, not the value.
     token: str = field(default="", repr=False)
 
@@ -73,6 +77,13 @@ async def create_session(
         ttl = max_ttl
     now = utc_now()
     expires_at = now + timedelta(seconds=ttl)
+    # Record the absolute hard cap so a later sliding refresh cannot extend the
+    # session past the IDP token lifetime.
+    hard_expires_at = (
+        (now + timedelta(seconds=max_ttl)).isoformat()
+        if max_ttl is not None and max_ttl > 0
+        else None
+    )
 
     session = Session(
         email=email,
@@ -83,6 +94,7 @@ async def create_session(
         expires_at=expires_at.isoformat(),
         last_active_at=now.isoformat(),
         kubernetes_groups=kubernetes_groups or [],
+        hard_expires_at=hard_expires_at,
         token=token,
     )
 
@@ -137,10 +149,24 @@ async def refresh_session(token: str, session: Session) -> None:
         return  # Session vanished between check and refresh — harmless
 
     data = json.loads(raw)
+    user_key = USER_SESSIONS_PREFIX + session.email
+
+    # Honor the hard cap (e.g. the IDP id_token lifetime) set at login — a
+    # sliding refresh must never extend the session past it.
+    hard = data.get("hard_expires_at")
+    if hard:
+        remaining = int((datetime.fromisoformat(hard) - now).total_seconds())
+        if remaining <= 0:
+            # Reached the hard cap — expire the session now instead of extending.
+            async with redis.pipeline(transaction=True) as pipe:
+                pipe.delete(session_key)
+                pipe.srem(user_key, token)
+                await pipe.execute()
+            return
+        ttl = min(ttl, remaining)
+
     data["last_active_at"] = now.isoformat()
     data["expires_at"] = (now + timedelta(seconds=ttl)).isoformat()
-
-    user_key = USER_SESSIONS_PREFIX + session.email
 
     async with redis.pipeline(transaction=True) as pipe:
         pipe.set(session_key, json.dumps(data), ex=ttl)

--- a/services/tests/test_sessions.py
+++ b/services/tests/test_sessions.py
@@ -8,6 +8,7 @@ import pytest
 
 from bamf.auth.sessions import (
     SESSION_REFRESH_INTERVAL,
+    Session,
     _should_refresh_session,
     create_session,
     get_session,
@@ -506,4 +507,57 @@ class TestRefreshSession:
             await refresh_session("test-token", session)
 
         # Pipeline should NOT have been used since session was gone
+        pipeline.set.assert_not_called()
+
+
+class TestRefreshSessionHardCap:
+    """refresh_session must never extend a session past its hard cap (e.g. the
+    IDP id_token lifetime recorded at login)."""
+
+    @pytest.fixture
+    def mock_redis(self):
+        redis = AsyncMock()
+        pipeline = AsyncMock()
+        pipeline.__aenter__ = AsyncMock(return_value=pipeline)
+        pipeline.__aexit__ = AsyncMock(return_value=None)
+        redis.pipeline = lambda **kwargs: pipeline
+        return redis, pipeline
+
+    def _session_data(self, hard_expires_at):
+        now = utc_now()
+        return {
+            "email": "a@example.com",
+            "display_name": None,
+            "roles": [],
+            "provider_name": "auth0",
+            "created_at": now.isoformat(),
+            "expires_at": now.isoformat(),
+            "last_active_at": now.isoformat(),
+            "kubernetes_groups": [],
+            "hard_expires_at": hard_expires_at,
+        }
+
+    @pytest.mark.asyncio
+    async def test_refresh_clamps_to_hard_cap(self, mock_redis):
+        redis, pipeline = mock_redis
+        hard = (utc_now() + timedelta(seconds=60)).isoformat()
+        data = self._session_data(hard)
+        redis.get = AsyncMock(return_value=json.dumps(data))
+        session = Session(token="t", **data)
+        with patch("bamf.auth.sessions.get_redis_client", return_value=redis):
+            await refresh_session("t", session)
+        # ex is clamped to the ~60s remaining, not the multi-hour session TTL.
+        _, kwargs = pipeline.set.call_args
+        assert kwargs["ex"] <= 60
+
+    @pytest.mark.asyncio
+    async def test_refresh_expires_session_past_hard_cap(self, mock_redis):
+        redis, pipeline = mock_redis
+        hard = (utc_now() - timedelta(seconds=1)).isoformat()
+        data = self._session_data(hard)
+        redis.get = AsyncMock(return_value=json.dumps(data))
+        session = Session(token="t", **data)
+        with patch("bamf.auth.sessions.get_redis_client", return_value=redis):
+            await refresh_session("t", session)
+        pipeline.delete.assert_called_once()
         pipeline.set.assert_not_called()


### PR DESCRIPTION
A sliding session refresh recomputed the full configured TTL, ignoring the `max_ttl` cap set at login (e.g. the IDP id_token lifetime) — so an active session could outlive the IDP token indefinitely.

Fix: record the absolute hard expiry (`hard_expires_at`) on the session at creation, and in `refresh_session` clamp the new TTL to it; once the cap is reached the session is expired rather than extended. Backward-compatible (old sessions without the field just have no cap).

Tests: refresh clamps to the hard cap; refresh past the cap deletes the session. 1009 pass; lint clean.