### PR TITLE
fix(audit): redact tokens and multipart bodies in audit recordings

### DIFF
--- a/services/bamf/proxy/redact.py
+++ b/services/bamf/proxy/redact.py
@@ -32,6 +32,12 @@ REDACT_BODY_FIELDS: frozenset[str] = frozenset(
         "code_verifier",
         "samlresponse",
         "session_token",
+        "access_token",
+        "refresh_token",
+        "id_token",
+        "token",
+        "api_key",
+        "authorization",
         "key",
         "private_key",
     }
@@ -124,6 +130,11 @@ def redact_body(body: str, content_type: str) -> str:
         return _redact_json(body)
     if ct == "application/x-www-form-urlencoded":
         return _redact_form(body)
+    if ct == "multipart/form-data":
+        # Multipart bodies (file uploads / form fields) aren't parsed here and
+        # may carry secrets — redact the whole body rather than risk leaking it
+        # into the audit store.
+        return _REDACTED
 
     return body
 

--- a/services/tests/test_api/test_redact.py
+++ b/services/tests/test_api/test_redact.py
@@ -177,36 +177,26 @@ class TestRedactBodyJson:
         assert data["users"][1]["password"] == "[REDACTED]"
 
     def test_all_redact_body_fields(self):
-        """All fields in REDACT_BODY_FIELDS are redacted."""
+        """Every field in REDACT_BODY_FIELDS is redacted. Iterates the set so
+        new entries (e.g. access_token / refresh_token / id_token) are covered
+        automatically."""
         import json
 
-        body = json.dumps(
-            {
-                "password": "pw",
-                "secret": "sec",
-                "client_secret": "cs",
-                "code_verifier": "cv",
-                "samlresponse": "sr",
-                "session_token": "st",
-                "key": "k",
-                "private_key": "pk",
-                "safe_field": "keep-me",
-            }
-        )
-        result = redact_body(body, "application/json")
+        from bamf.proxy.redact import REDACT_BODY_FIELDS
+
+        payload = dict.fromkeys(REDACT_BODY_FIELDS, "sensitive")
+        payload["safe_field"] = "keep-me"
+        result = redact_body(json.dumps(payload), "application/json")
         data = json.loads(result)
-        for field in [
-            "password",
-            "secret",
-            "client_secret",
-            "code_verifier",
-            "samlresponse",
-            "session_token",
-            "key",
-            "private_key",
-        ]:
+        for field in REDACT_BODY_FIELDS:
             assert data[field] == "[REDACTED]", f"Expected {field} to be redacted"
         assert data["safe_field"] == "keep-me"
+
+    def test_multipart_body_fully_redacted(self):
+        """multipart/form-data bodies are redacted wholesale — they may carry
+        file uploads or secret form fields and aren't parsed here."""
+        body = '--x\r\nContent-Disposition: form-data; name="password"\r\n\r\nhunter2\r\n--x--'
+        assert redact_body(body, "multipart/form-data; boundary=x") == "[REDACTED]"
 
     def test_case_insensitive_field_matching(self):
         """Field name matching is case-insensitive."""


### PR DESCRIPTION
Closes redaction gaps so secrets don't reach the audit store:
- Add `access_token` / `refresh_token` / `id_token` / `token` / `api_key` / `authorization` to `REDACT_BODY_FIELDS`.
- Redact `multipart/form-data` bodies wholesale (may carry uploads / secret form fields; not parsed here).

Tests: the field test now iterates `REDACT_BODY_FIELDS` (auto-covers new entries) + a multipart-redaction test. 1010 pass; lint clean.