### PR TITLE
fix(webhook): warn on unrestricted (no source_cidrs) webhook passthrough

### DIFF
--- a/services/bamf/api/routers/internal_proxy.py
+++ b/services/bamf/api/routers/internal_proxy.py
@@ -434,16 +434,25 @@ def _match_webhook(resource, method: str, path: str, client_ip: str | None) -> d
 
         # Source CIDR check
         source_cidrs = wh.get("source_cidrs", [])
-        if source_cidrs and client_ip:
+        if source_cidrs:
+            if not client_ip:
+                # CIDRs configured but no client IP available — deny (fail closed).
+                continue
             try:
                 addr = ipaddress.ip_address(client_ip)
                 if not any(addr in ipaddress.ip_network(cidr) for cidr in source_cidrs):
                     continue
             except ValueError:
                 continue
-        elif source_cidrs and not client_ip:
-            # CIDRs configured but no client IP available — deny
-            continue
+        else:
+            # No IP allowlist — the webhook is unrestricted by source and relies
+            # entirely on the target application's own auth (HMAC, etc.). Warn so
+            # an unintentionally-open webhook is visible in the logs.
+            logger.warning(
+                "webhook passthrough matched with no source_cidrs — unrestricted by IP",
+                path=wh_path,
+                method=method,
+            )
 
         return wh
 


### PR DESCRIPTION
Webhook passthrough bypasses BAMF auth **by design** (the target app authenticates). An empty `source_cidrs` is a valid 'no IP restriction' config, so this doesn't block it — but an unintentionally-open webhook was silent.

- Refactor the CIDR check (still **fail-closed** when CIDRs are configured but the client IP is unknown).
- Log a warning when a webhook matches with no `source_cidrs`, for visibility.

Behavior-preserving for the IP-restricted cases. 1010 pass; lint clean.