### PR TITLE
fix(auth): validate the OIDC id_token nonce (replay protection)

### DIFF
--- a/services/bamf/api/routers/auth.py
+++ b/services/bamf/api/routers/auth.py
@@ -417,6 +417,7 @@ async def callback(
             callback_url=bamf_callback_url,
             code=code,
             state=state,
+            nonce=auth_state.nonce,
         )
     except ValueError as e:
         logger.error("SSO callback failed", provider=auth_state.provider_name, error=str(e))

--- a/services/bamf/auth/connectors/oidc.py
+++ b/services/bamf/auth/connectors/oidc.py
@@ -151,6 +151,13 @@ class OIDCConnector(SSOConnector):
         except JoseError as e:
             raise ValueError(f"ID token validation failed for {self.name}: {e}") from e
 
+        # Validate the nonce binds this id_token to our authorization request
+        # (replay protection). Per OIDC, if we sent a nonce the IDP must echo it
+        # in the id_token.
+        expected_nonce = kwargs.get("nonce")
+        if expected_nonce and claims.get("nonce") != expected_nonce:
+            raise ValueError(f"ID token nonce mismatch for {self.name}")
+
         # Merge additional claims from /userinfo endpoint (catches groups/roles
         # that providers put in userinfo but not in the ID token)
         userinfo_claims = await self._fetch_userinfo(access_token)

--- a/services/tests/test_auth/test_oidc_connector.py
+++ b/services/tests/test_auth/test_oidc_connector.py
@@ -176,6 +176,41 @@ class TestHandleCallback:
         assert identity.provider_name == "test-oidc"
 
     @pytest.mark.asyncio
+    async def test_nonce_mismatch_raises(self):
+        """An id_token whose nonce != the one we sent is rejected (replay)."""
+        connector = OIDCConnector(_make_config())
+        connector._discovery = DISCOVERY_DOC
+        connector._jwks = MagicMock()
+        claims = {"sub": "u", "email": "a@example.com", "nonce": "server-sent-nonce"}
+
+        with (
+            patch("bamf.auth.connectors.oidc.httpx.AsyncClient") as mock_http,
+            patch("bamf.auth.connectors.oidc.authlib_jwt") as mock_jwt,
+        ):
+            mock_resp = MagicMock()
+            mock_resp.json.return_value = {"id_token": "t", "access_token": "at"}
+            mock_resp.raise_for_status = MagicMock()
+            mock_client = AsyncMock()
+            mock_client.post.return_value = mock_resp
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock()
+            mock_http.return_value = mock_client
+
+            decoded = MagicMock()
+            decoded.get.side_effect = claims.get
+            decoded.__getitem__.side_effect = claims.__getitem__
+            decoded.__contains__.side_effect = claims.__contains__
+            decoded.validate.return_value = None
+            mock_jwt.decode.return_value = decoded
+
+            with pytest.raises(ValueError, match="nonce mismatch"):
+                await connector.handle_callback(
+                    callback_url="https://bamf.example.com/auth/callback",
+                    code="c",
+                    nonce="a-different-nonce",
+                )
+
+    @pytest.mark.asyncio
     async def test_no_id_token_raises(self):
         connector = OIDCConnector(_make_config())
         connector._discovery = DISCOVERY_DOC


### PR DESCRIPTION
The OIDC nonce was generated, stored in auth state, and sent to the IDP, but never validated against the returned id_token. Pass the stored nonce from the callback into `OIDCConnector.handle_callback` and reject the login if `id_token.nonce` != the value we sent — binding the token to our authorization request (replay protection).

Test: nonce-mismatch raises; the no-nonce path (existing success test) is unaffected. 1011 pass; lint clean.