### PR TITLE
fix(auth): offload blocking auth work off the event loop (PBKDF2, SAML)

### DIFF
--- a/services/bamf/api/routers/users.py
+++ b/services/bamf/api/routers/users.py
@@ -1,5 +1,7 @@
 """Users router."""
 
+import asyncio
+
 from fastapi import APIRouter, Depends, HTTPException, status
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -129,10 +131,14 @@ async def create_user(
             detail="User with this email already exists",
         )
 
-    # Create user
+    # Create user. Hash off the event loop — PBKDF2 (100k iterations) is
+    # CPU-heavy and would stall the worker on the async path.
+    password_hash = (
+        await asyncio.to_thread(hash_password, user_data.password) if user_data.password else None
+    )
     user = User(
         email=user_data.email,
-        password_hash=hash_password(user_data.password) if user_data.password else None,
+        password_hash=password_hash,
         is_active=user_data.is_active,
     )
     db.add(user)
@@ -217,7 +223,7 @@ async def update_user(
     if user_data.is_active is not None:
         user.is_active = user_data.is_active
     if user_data.password is not None:
-        user.password_hash = hash_password(user_data.password)
+        user.password_hash = await asyncio.to_thread(hash_password, user_data.password)
 
     # Update local role assignments if provided
     if user_data.roles is not None:

--- a/services/bamf/auth/connectors/local.py
+++ b/services/bamf/auth/connectors/local.py
@@ -9,6 +9,7 @@ Returns empty groups — role resolution (including internal role_assignments
 lookup) is handled by process_login() for all providers uniformly.
 """
 
+import asyncio
 from typing import Any
 
 from sqlalchemy import select
@@ -78,7 +79,7 @@ class LocalConnector(SSOConnector):
         if not user or not user.password_hash:
             raise ValueError("Invalid credentials")
 
-        if not verify_password(password, user.password_hash):
+        if not await asyncio.to_thread(verify_password, password, user.password_hash):
             raise ValueError("Invalid credentials")
 
         if not user.is_active:

--- a/services/bamf/auth/connectors/saml.py
+++ b/services/bamf/auth/connectors/saml.py
@@ -3,6 +3,7 @@
 Uses python3-saml for metadata parsing and assertion validation.
 """
 
+import asyncio
 from typing import Any
 
 from bamf.auth.sso import AuthenticatedIdentity, AuthorizationRequest, SSOConnector
@@ -66,8 +67,11 @@ class SAMLConnector(SSOConnector):
 
         # Parse IDP metadata
         if self._idp_metadata is None:
-            self._idp_metadata = OneLogin_Saml2_IdPMetadataParser.parse_remote(
-                self._config.metadata_url
+            # parse_remote does a blocking HTTP GET — offload it so a slow or
+            # unreachable IdP can't freeze the event loop.
+            self._idp_metadata = await asyncio.to_thread(
+                OneLogin_Saml2_IdPMetadataParser.parse_remote,
+                self._config.metadata_url,
             )
 
         saml_settings = self._get_saml_settings(callback_url)
@@ -107,8 +111,11 @@ class SAMLConnector(SSOConnector):
             raise RuntimeError("python3-saml is required for SAML providers.") from e
 
         if self._idp_metadata is None:
-            self._idp_metadata = OneLogin_Saml2_IdPMetadataParser.parse_remote(
-                self._config.metadata_url
+            # parse_remote does a blocking HTTP GET — offload it so a slow or
+            # unreachable IdP can't freeze the event loop.
+            self._idp_metadata = await asyncio.to_thread(
+                OneLogin_Saml2_IdPMetadataParser.parse_remote,
+                self._config.metadata_url,
             )
 
         saml_settings = self._get_saml_settings(callback_url)
@@ -123,7 +130,8 @@ class SAMLConnector(SSOConnector):
         }
 
         auth = OneLogin_Saml2_Auth(request_data, saml_settings)
-        auth.process_response()
+        # process_response runs xmlsec signature verification (CPU-bound).
+        await asyncio.to_thread(auth.process_response)
 
         errors = auth.get_errors()
         if errors:


### PR DESCRIPTION
Establishes the `asyncio.to_thread` pattern (previously unused) and wraps the blocking calls that ran directly on the uvicorn event loop:
- **PBKDF2** (100k iters) hash/verify on the **login** path (`local.py`) and user create/update (`users.py`) — highest impact; a partly-unauthenticated login was a DoS amplifier (each attempt pinned a worker for the full hash).
- **SAML** `parse_remote` (blocking HTTP — a slow IdP froze the loop) + `process_response` (xmlsec CPU) in the SAML callback.

1011 pass; lint clean. Closes #143.