### PR TITLE
fix(ca): rename ca_key_encrypted -> ca_key_pem (it was never encrypted)

### DIFF
--- a/alembic/versions/f1a2b3c4_rename_ca_key_column.py
+++ b/alembic/versions/f1a2b3c4_rename_ca_key_column.py
@@ -1,0 +1,28 @@
+"""Rename certificate_authority.ca_key_encrypted to ca_key_pem.
+
+The column was named "_encrypted", but the CA private key is stored as plain
+PEM with no encryption at rest — by design: the database is the trust root and
+a PostgreSQL backup is the DR artifact, protected by DB access controls (and,
+optionally, an external CA provider that keeps the key in Vault/cert-manager).
+Rename the column so the schema no longer implies encryption that isn't there.
+
+Revision ID: f1a2b3c4
+Revises: e7f0a5b4
+"""
+
+from collections.abc import Sequence
+
+from alembic import op
+
+revision: str = "f1a2b3c4"
+down_revision: str | None = "e7f0a5b4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.alter_column("certificate_authority", "ca_key_encrypted", new_column_name="ca_key_pem")
+
+
+def downgrade() -> None:
+    op.alter_column("certificate_authority", "ca_key_pem", new_column_name="ca_key_encrypted")

--- a/services/bamf/auth/ca.py
+++ b/services/bamf/auth/ca.py
@@ -526,7 +526,7 @@ async def init_ca(db: AsyncSession) -> CertificateAuthority:
         # Load existing CA from database
         ca = CertificateAuthority.load(
             ca_record.ca_cert.encode(),
-            ca_record.ca_key_encrypted.encode(),
+            ca_record.ca_key_pem.encode(),
         )
         logger.info(
             "Loaded CA from database",
@@ -542,7 +542,7 @@ async def init_ca(db: AsyncSession) -> CertificateAuthority:
 
         ca_record = CertificateAuthorityModel(
             ca_cert=cert_pem,
-            ca_key_encrypted=key_pem,
+            ca_key_pem=key_pem,
         )
         db.add(ca_record)
         await db.commit()

--- a/services/bamf/db/models.py
+++ b/services/bamf/db/models.py
@@ -359,7 +359,10 @@ class CertificateAuthority(Base):
 
     id: Mapped[int] = mapped_column(Integer, primary_key=True, autoincrement=True)
     ca_cert: Mapped[str] = mapped_column(Text, nullable=False)
-    ca_key_encrypted: Mapped[str] = mapped_column(Text, nullable=False)  # Encrypted private key
+    # PEM CA private key. Stored unencrypted at rest by design (the DB is the
+    # trust root; a PG backup is the DR artifact). Protect via DB access
+    # controls / encryption-at-rest, or an external CA provider (Vault/cert-manager).
+    ca_key_pem: Mapped[str] = mapped_column(Text, nullable=False)
     ssh_host_key: Mapped[str | None] = mapped_column(
         Text, nullable=True
     )  # PEM Ed25519 for ssh-audit


### PR DESCRIPTION
The `certificate_authority.ca_key_encrypted` column stored the CA private key as **plain PEM** (`NoEncryption()`), but the name and comment implied encryption at rest that wasn't there — a false-confidence hazard.

Rename to `ca_key_pem` with an honest comment: the key is stored unencrypted **by design** (the DB is the trust root and a PG backup is the DR artifact), protected by DB access controls / encryption-at-rest — or, for operators who want the key out of the DB, an external CA provider (Vault/cert-manager, tracked as opt-in in #126). Reversible `alter_column` migration; 1011 tests pass, lint clean.

Context: this is the *real* part of the CA-key advisory. Keeping the key where the API can sign with it (DB + K8s Secret) is normal secret storage, not an exploitable hole — so the advisory is being downgraded to hardening + this naming fix.