### PR TITLE
fix(bridge): route recording/audit from the session cert, not the wire line

### DIFF
--- a/pkg/bridge/server.go
+++ b/pkg/bridge/server.go
@@ -794,6 +794,17 @@ func (s *Server) handleTunnelConnection(ctx context.Context, conn net.Conn) {
 	sessionID := info.SessionID
 	resource := info.Resource
 
+	// The CA-signed session cert is authoritative for the resource type — it
+	// decides recording/audit routing. A client can't spoof it via the wire-line
+	// type=. (Legacy certs without the type SAN fall back to the wire line.)
+	if info.ResourceType != "" {
+		if resourceType != info.ResourceType {
+			s.logger.Warn("wire-line type disagrees with session cert; using cert",
+				"wire", resourceType, "cert", info.ResourceType, "session_id", shortID(sessionID))
+		}
+		resourceType = info.ResourceType
+	}
+
 	// Verify this connection is for this bridge. Fail closed: a session cert
 	// with no bridge pin (empty SAN) is also rejected — the CA always sets it.
 	if info.BridgeID != s.cfg.BridgeID {
@@ -1784,10 +1795,11 @@ func (s *Server) cleanupPending(sessionID string) {
 
 // sessionInfo holds fields extracted from a session certificate's SAN URIs.
 type sessionInfo struct {
-	SessionID string
-	Resource  string
-	BridgeID  string
-	Role      string // "client" or "agent"
+	SessionID    string
+	Resource     string
+	BridgeID     string
+	Role         string // "client" or "agent"
+	ResourceType string // authoritative resource type (audit routing) — may be empty on legacy certs
 }
 
 // extractSessionInfo extracts session ID, resource name, bridge ID, and role from cert SAN URIs.
@@ -1814,6 +1826,8 @@ func extractSessionInfo(cert *x509.Certificate) (sessionInfo, error) {
 			info.BridgeID = value
 		case "role":
 			info.Role = value
+		case "type":
+			info.ResourceType = value
 		}
 	}
 	if info.SessionID == "" {

--- a/pkg/bridge/server_test.go
+++ b/pkg/bridge/server_test.go
@@ -1,10 +1,49 @@
 package bridge
 
 import (
+	"crypto/x509"
+	"net/url"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func mustURL(s string) *url.URL {
+	u, err := url.Parse(s)
+	if err != nil {
+		panic(err)
+	}
+	return u
+}
+
+func TestExtractSessionInfo(t *testing.T) {
+	cert := &x509.Certificate{URIs: []*url.URL{
+		mustURL("bamf://session/sess-1"),
+		mustURL("bamf://resource/web-01"),
+		mustURL("bamf://bridge/bridge-0"),
+		mustURL("bamf://role/client"),
+		mustURL("bamf://type/ssh-audit"),
+	}}
+	info, err := extractSessionInfo(cert)
+	require.NoError(t, err)
+	require.Equal(t, "sess-1", info.SessionID)
+	require.Equal(t, "web-01", info.Resource)
+	require.Equal(t, "bridge-0", info.BridgeID)
+	require.Equal(t, "client", info.Role)
+	require.Equal(t, "ssh-audit", info.ResourceType)
+}
+
+func TestExtractSessionInfo_LegacyNoType(t *testing.T) {
+	cert := &x509.Certificate{URIs: []*url.URL{mustURL("bamf://session/s")}}
+	info, err := extractSessionInfo(cert)
+	require.NoError(t, err)
+	require.Empty(t, info.ResourceType)
+}
+
+func TestExtractSessionInfo_MissingSession(t *testing.T) {
+	_, err := extractSessionInfo(&x509.Certificate{URIs: nil})
+	require.Error(t, err)
+}
 
 func TestShortID(t *testing.T) {
 	tests := []struct {

--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -433,6 +433,7 @@ async def _issue_session(
         bridge_id=bridge_id,
         subject_cn=current_user.email,
         role="client",
+        resource_type=resource_type,
         ttl_seconds=session_ttl,
     )
 
@@ -442,6 +443,7 @@ async def _issue_session(
         bridge_id=bridge_id,
         subject_cn=agent_id,
         role="agent",
+        resource_type=resource_type,
         ttl_seconds=session_ttl,
     )
 

--- a/services/bamf/auth/ca.py
+++ b/services/bamf/auth/ca.py
@@ -341,6 +341,7 @@ class CertificateAuthority:
         bridge_id: str,
         subject_cn: str,
         role: str = "client",
+        resource_type: str = "",
         ttl_seconds: int = 30,
     ) -> tuple[x509.Certificate, ed25519.Ed25519PrivateKey]:
         """Issue a per-tunnel session certificate.
@@ -411,6 +412,13 @@ class CertificateAuthority:
                         x509.UniformResourceIdentifier(f"bamf://resource/{resource_name}"),
                         x509.UniformResourceIdentifier(f"bamf://bridge/{bridge_id}"),
                         x509.UniformResourceIdentifier(f"bamf://role/{role}"),
+                        # Authoritative resource type — the bridge routes
+                        # recording/audit from this (CA-signed), not the client wire line.
+                        *(
+                            [x509.UniformResourceIdentifier(f"bamf://type/{resource_type}")]
+                            if resource_type
+                            else []
+                        ),
                     ]
                 ),
                 critical=False,

--- a/services/tests/test_auth/test_ca.py
+++ b/services/tests/test_auth/test_ca.py
@@ -143,7 +143,7 @@ class TestIssueSessionCertificate:
         assert cert is not None
         assert key is not None
 
-    def test_session_cert_has_4_san_uris(self):
+    def test_session_cert_binds_resource_type(self):
         ca = ca_module.CertificateAuthority.generate()
         cert, _ = ca.issue_session_certificate(
             session_id="sess-123",
@@ -151,14 +151,28 @@ class TestIssueSessionCertificate:
             bridge_id="bridge-0",
             subject_cn="alice@example.com",
             role="developer",
+            resource_type="ssh-audit",
         )
         # parse_san_uris returns a dict keyed by URI type
         uris = ca_module.parse_san_uris(cert)
-        assert len(uris) == 4
+        assert len(uris) == 5
         assert uris["session"] == "sess-123"
         assert uris["resource"] == "web-01"
         assert uris["bridge"] == "bridge-0"
         assert uris["role"] == "developer"
+        # The audit-critical resource type is bound into the (CA-signed) cert.
+        assert uris["type"] == "ssh-audit"
+
+    def test_session_cert_omits_type_when_unset(self):
+        ca = ca_module.CertificateAuthority.generate()
+        cert, _ = ca.issue_session_certificate(
+            session_id="s",
+            resource_name="r",
+            bridge_id="b",
+            subject_cn="alice@example.com",
+        )
+        uris = ca_module.parse_san_uris(cert)
+        assert "type" not in uris
 
     def test_session_cert_short_ttl(self):
         ca = ca_module.CertificateAuthority.generate()


### PR DESCRIPTION
The bridge chose record-vs-splice from a **client-supplied wire-line `type=`** (first-arriver-wins), so a modified client could request an audited resource (`ssh-audit`/`postgres-audit`/`mysql-audit`) and receive an **unrecorded byte-splice** — a session-recording / query-audit bypass. The session cert carried the resource *name* but not the audit *requirement*, and nothing cross-checked.

Fix: bind the authoritative resource type into the **CA-signed session cert** (`bamf://type/{type}` SAN — issued by the API, which knows the effective type). The bridge now routes recording/audit from the **cert** and only falls back to the wire line for legacy certs without the SAN (logs a warning on disagreement).

**Session-cert SAN URIs: 4 → 5** (session, resource, bridge, role, **type**) — the SAN contract; docs/AGENTS + #125 registry to be updated.

Tests: Python (cert binds/omits the type SAN), Go (`extractSessionInfo` parses type; legacy + missing-session cases). Go build + bridge tests + golangci-lint (0) + Python 1018 pass + lint clean.