### PR TITLE
feat(security): certificate revocation denylist for agent/bridge certs

### DIFF
--- a/alembic/versions/a2b3c4d5_add_revoked_certificates.py
+++ b/alembic/versions/a2b3c4d5_add_revoked_certificates.py
@@ -1,0 +1,31 @@
+"""Add revoked_certificates table (certificate revocation denylist).
+
+Revision ID: a2b3c4d5
+Revises: f1a2b3c4
+"""
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "a2b3c4d5"
+down_revision: str | None = "f1a2b3c4"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "revoked_certificates",
+        sa.Column("fingerprint", sa.String(64), primary_key=True),
+        sa.Column("revoked_at", sa.DateTime(timezone=True), nullable=False),
+        sa.Column("reason", sa.Text(), nullable=True),
+        sa.Column("revoked_by", sa.String(255), nullable=True),
+        sa.Column("subject_cn", sa.String(255), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("revoked_certificates")

--- a/services/bamf/api/app.py
+++ b/services/bamf/api/app.py
@@ -63,6 +63,10 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     async with async_session_factory() as db_session:
         await init_ca(db_session)
+        # Load the certificate-revocation denylist into Redis for fast cert-auth checks.
+        from bamf.auth.revocation import load_revoked_into_redis
+
+        await load_revoked_into_redis(db_session)
     logger.info("Certificate Authority initialized")
 
     init_connectors()

--- a/services/bamf/api/dependencies.py
+++ b/services/bamf/api/dependencies.py
@@ -178,11 +178,24 @@ def _validate_client_cert(header_value: str | None, entity_type: str) -> x509.Ce
     return cert
 
 
+async def _reject_if_revoked(cert: x509.Certificate) -> None:
+    """Reject a certificate whose fingerprint is on the revocation denylist."""
+    from bamf.auth.ca import get_certificate_fingerprint
+    from bamf.auth.revocation import is_certificate_revoked
+
+    if await is_certificate_revoked(get_certificate_fingerprint(cert)):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="Certificate has been revoked",
+        )
+
+
 async def get_agent_identity(
     x_bamf_client_cert: str | None = Header(default=None, alias="X-Bamf-Client-Cert"),
 ) -> AgentIdentity:
     """Dependency to validate agent certificate from X-Bamf-Client-Cert header."""
     cert = _validate_client_cert(x_bamf_client_cert, "agent")
+    await _reject_if_revoked(cert)
     cn = cert.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[0].value
     return AgentIdentity(name=cn, certificate=cert, expires_at=cert.not_valid_after_utc)
 
@@ -192,5 +205,6 @@ async def get_bridge_identity(
 ) -> BridgeIdentity:
     """Dependency to validate bridge certificate from X-Bamf-Client-Cert header."""
     cert = _validate_client_cert(x_bamf_client_cert, "bridge")
+    await _reject_if_revoked(cert)
     cn = cert.subject.get_attributes_for_oid(x509.oid.NameOID.COMMON_NAME)[0].value
     return BridgeIdentity(bridge_id=cn, certificate=cert, expires_at=cert.not_valid_after_utc)

--- a/services/bamf/api/models/certificates.py
+++ b/services/bamf/api/models/certificates.py
@@ -38,3 +38,20 @@ class CACertificateResponse(BAMFBaseModel):
     """Response containing the public CA certificate."""
 
     ca_certificate: str = Field(description="PEM-encoded CA certificate")
+
+
+class RevokeCertificateRequest(BAMFBaseModel):
+    """Request to revoke a certificate by fingerprint."""
+
+    fingerprint: str = Field(description="SHA256 hex fingerprint of the certificate to revoke")
+    reason: str | None = Field(default=None, description="Optional revocation reason")
+
+
+class RevokedCertificateResponse(BAMFBaseModel):
+    """A revoked certificate entry."""
+
+    fingerprint: str
+    revoked_at: datetime
+    reason: str | None = None
+    revoked_by: str | None = None
+    subject_cn: str | None = None

--- a/services/bamf/api/routers/certificates.py
+++ b/services/bamf/api/routers/certificates.py
@@ -1,17 +1,28 @@
 """Certificates router for CA operations."""
 
-from fastapi import APIRouter, Depends
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.ext.asyncio import AsyncSession
 
-from bamf.api.dependencies import get_current_session, require_admin
+from bamf.api.dependencies import (
+    get_current_session,
+    require_admin,
+    require_admin_or_audit,
+)
 from bamf.api.models.certificates import (
     CACertificateResponse,
+    RevokeCertificateRequest,
+    RevokedCertificateResponse,
     ServiceCertificateRequest,
     ServiceCertificateResponse,
     UserCertificateResponse,
 )
 from bamf.auth.ca import get_ca, serialize_certificate, serialize_private_key
+from bamf.auth.revocation import list_revoked_certificates, revoke_certificate
 from bamf.auth.sessions import Session
+from bamf.db.models import utc_now
+from bamf.db.session import get_db
 from bamf.logging_config import get_logger
+from bamf.services.audit_service import log_audit_event
 
 router = APIRouter(prefix="/certificates", tags=["certificates"])
 logger = get_logger(__name__)
@@ -84,3 +95,60 @@ async def issue_service_certificate(
         ca_certificate=ca.ca_cert_pem,
         expires_at=cert.not_valid_after_utc,
     )
+
+
+@router.post("/revoke", response_model=RevokedCertificateResponse)
+async def revoke_certificate_endpoint(
+    body: RevokeCertificateRequest,
+    db: AsyncSession = Depends(get_db),
+    current_user: Session = Depends(require_admin),
+) -> RevokedCertificateResponse:
+    """Revoke a certificate by fingerprint (admin).
+
+    Durable (Postgres) + enforced at the API cert-auth layer for agent/bridge
+    certs. Tunnel session certs are 30s TTL and won't be re-minted for a revoked
+    identity, so the bridge keeps its zero-runtime-dependency design.
+    """
+    if not body.fingerprint:
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST, detail="fingerprint is required"
+        )
+    await revoke_certificate(
+        db, body.fingerprint, reason=body.reason, revoked_by=current_user.email
+    )
+    await log_audit_event(
+        db,
+        event_type="admin",
+        action="certificate_revoked",
+        actor_type="user",
+        actor_id=current_user.email,
+        target_type="certificate",
+        target_id=body.fingerprint,
+        success=True,
+        details={"reason": body.reason},
+    )
+    return RevokedCertificateResponse(
+        fingerprint=body.fingerprint,
+        revoked_at=utc_now(),
+        reason=body.reason,
+        revoked_by=current_user.email,
+    )
+
+
+@router.get("/revoked", response_model=list[RevokedCertificateResponse])
+async def list_revoked_certs(
+    db: AsyncSession = Depends(get_db),
+    _admin: Session = Depends(require_admin_or_audit),
+) -> list[RevokedCertificateResponse]:
+    """List revoked certificates (admin/audit)."""
+    revoked = await list_revoked_certificates(db)
+    return [
+        RevokedCertificateResponse(
+            fingerprint=r.fingerprint,
+            revoked_at=r.revoked_at,
+            reason=r.reason,
+            revoked_by=r.revoked_by,
+            subject_cn=r.subject_cn,
+        )
+        for r in revoked
+    ]

--- a/services/bamf/auth/revocation.py
+++ b/services/bamf/auth/revocation.py
@@ -1,0 +1,79 @@
+"""Certificate revocation denylist.
+
+Durable source of truth in Postgres (``revoked_certificates``); a working copy
+in a Redis set for O(1) cert-auth checks. The set is loaded from Postgres at
+startup and updated on each revoke, so it survives an API restart and is shared
+across replicas.
+
+Revocation is enforced at the API's cert-auth layer (agent/bridge certs, which
+are long-lived). The bridge keeps its zero-runtime-dependency design; tunnel
+session certs are 30s TTL and the API won't mint a new one for a revoked
+identity, so the tunnel path needs no bridge-side check.
+"""
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bamf.db.models import RevokedCertificate, utc_now
+from bamf.logging_config import get_logger
+from bamf.redis.client import get_redis_client
+
+logger = get_logger(__name__)
+
+_REVOKED_SET = "bamf:revoked_certs"
+
+
+async def is_certificate_revoked(fingerprint: str) -> bool:
+    """Return True if the fingerprint is on the denylist (Redis set)."""
+    try:
+        redis = get_redis_client()
+        return bool(await redis.sismember(_REVOKED_SET, fingerprint))
+    except Exception:
+        # Fail open on Redis error (consistent with the rate limiter): the
+        # durable DB reloads into Redis at startup, so the exposure window is
+        # small, and failing closed would break all agent/bridge auth.
+        logger.warning("revocation check Redis error, failing open", exc_info=True)
+        return False
+
+
+async def revoke_certificate(
+    db: AsyncSession,
+    fingerprint: str,
+    reason: str | None = None,
+    revoked_by: str | None = None,
+    subject_cn: str | None = None,
+) -> None:
+    """Add a certificate fingerprint to the durable denylist and the Redis set."""
+    if await db.get(RevokedCertificate, fingerprint) is None:
+        db.add(
+            RevokedCertificate(
+                fingerprint=fingerprint,
+                revoked_at=utc_now(),
+                reason=reason,
+                revoked_by=revoked_by,
+                subject_cn=subject_cn,
+            )
+        )
+        await db.flush()
+    redis = get_redis_client()
+    await redis.sadd(_REVOKED_SET, fingerprint)
+    logger.info("certificate revoked", fingerprint=fingerprint[:16], revoked_by=revoked_by)
+
+
+async def list_revoked_certificates(db: AsyncSession) -> list[RevokedCertificate]:
+    """List all revoked certificates, newest first."""
+    result = await db.execute(
+        select(RevokedCertificate).order_by(RevokedCertificate.revoked_at.desc())
+    )
+    return list(result.scalars().all())
+
+
+async def load_revoked_into_redis(db: AsyncSession) -> int:
+    """Populate the Redis denylist set from Postgres. Called at startup."""
+    result = await db.execute(select(RevokedCertificate.fingerprint))
+    fingerprints = [row[0] for row in result.all()]
+    if fingerprints:
+        redis = get_redis_client()
+        await redis.sadd(_REVOKED_SET, *fingerprints)
+    logger.info("loaded revoked certificates into Redis", count=len(fingerprints))
+    return len(fingerprints)

--- a/services/bamf/db/models.py
+++ b/services/bamf/db/models.py
@@ -371,3 +371,20 @@ class CertificateAuthority(Base):
     )
 
     __table_args__ = (UniqueConstraint("id"),)  # Only one CA row
+
+
+class RevokedCertificate(Base):
+    """Denylisted certificate fingerprints (revocation). Durable source of
+    truth; cached in Redis for fast cert-auth checks. The bridge keeps its
+    zero-runtime-dependency design — revocation is enforced at the API's
+    cert-auth layer (agent/bridge certs), and tunnel session certs are 30s TTL."""
+
+    __tablename__ = "revoked_certificates"
+
+    fingerprint: Mapped[str] = mapped_column(String(64), primary_key=True)  # SHA256 hex
+    revoked_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True), default=utc_now, nullable=False
+    )
+    reason: Mapped[str | None] = mapped_column(Text, nullable=True)
+    revoked_by: Mapped[str | None] = mapped_column(String(255), nullable=True)  # admin email
+    subject_cn: Mapped[str | None] = mapped_column(String(255), nullable=True)  # for admin UX

--- a/services/tests/test_auth/test_revocation.py
+++ b/services/tests/test_auth/test_revocation.py
@@ -1,0 +1,56 @@
+"""Tests for certificate revocation."""
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from bamf.auth.revocation import is_certificate_revoked, revoke_certificate
+
+
+@pytest.mark.asyncio
+async def test_is_certificate_revoked_true():
+    redis = MagicMock()
+    redis.sismember = AsyncMock(return_value=1)
+    with patch("bamf.auth.revocation.get_redis_client", return_value=redis):
+        assert await is_certificate_revoked("abc") is True
+
+
+@pytest.mark.asyncio
+async def test_is_certificate_revoked_false():
+    redis = MagicMock()
+    redis.sismember = AsyncMock(return_value=0)
+    with patch("bamf.auth.revocation.get_redis_client", return_value=redis):
+        assert await is_certificate_revoked("abc") is False
+
+
+@pytest.mark.asyncio
+async def test_is_certificate_revoked_fails_open_on_redis_error():
+    with patch("bamf.auth.revocation.get_redis_client", side_effect=RuntimeError("down")):
+        assert await is_certificate_revoked("abc") is False
+
+
+@pytest.mark.asyncio
+async def test_revoke_adds_to_db_and_redis():
+    redis = MagicMock()
+    redis.sadd = AsyncMock()
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=None)  # not already revoked
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    with patch("bamf.auth.revocation.get_redis_client", return_value=redis):
+        await revoke_certificate(db, "abc123", reason="leaked", revoked_by="admin@example.com")
+    db.add.assert_called_once()
+    redis.sadd.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_revoke_idempotent_when_already_revoked():
+    redis = MagicMock()
+    redis.sadd = AsyncMock()
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=object())  # already in the table
+    db.add = MagicMock()
+    with patch("bamf.auth.revocation.get_redis_client", return_value=redis):
+        await revoke_certificate(db, "abc123")
+    db.add.assert_not_called()  # no duplicate row
+    redis.sadd.assert_awaited_once()  # but still ensures the Redis set has it


### PR DESCRIPTION
## What

Adds a certificate revocation denylist — a kill-switch for leaked long-lived agent/bridge service certificates.

## Design

Revocation is enforced at the **API cert-auth layer**, not the bridge, preserving the bridge's zero-runtime-dependency design:

- Users already authenticate via revocable Redis sessions (delete key → instant logout).
- Tunnel **session** certs are 30s TTL and the API won't mint a new one for a revoked identity, so the tunnel data path needs no bridge-side check.
- Only long-lived **agent/bridge** identity certs (sent on every API call via `X-Bamf-Client-Cert`) get a denylist check.

Mechanics:
- Durable: `revoked_certificates` table (fingerprint PK, revoked_at, reason, revoked_by, subject_cn) — migration `a2b3c4d5`.
- Fast path: Redis set `bamf:revoked_certs`, loaded from Postgres at startup (`load_revoked_into_redis` in lifespan), updated on each revoke; `SISMEMBER` on agent/bridge cert-auth. **Fails open** on Redis error (matches rate limiter) — durable table reloads at startup, so exposure window is small and failing closed would break all agent/bridge auth.
- Admin API: `POST /api/v1/certificates/revoke` (admin), `GET /api/v1/certificates/revoked` (admin/audit). Audited as `certificate_revoked`.

## Tests

`services/tests/test_auth/test_revocation.py` — revoke→is_revoked True, not-revoked False, fails-open on Redis error, DB+Redis write, idempotent double-revoke. Full suite: 1023 passed; `lint-python` clean.

## Fast-follows (tracked in #158)
- CLI `bamf certs revoke` / `bamf certs revoked`.
- Revoke-by-agent-name convenience.

closes #158