### PR TITLE
fix(security): pre-release audit — webhook header spoofing, rate-limit XFF bypass, revocation durability

### DIFF
--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -625,7 +625,11 @@ token's assigned name. This is mitigated by:
 ## Hardening Checklist
 
 - [x] TLS 1.3 on ingress and internal mTLS (default since v0.4.0)
-- [x] Rate limiting on public HTTP endpoints (default since v0.4.0)
+- [x] Ingress-level rate limiting on public HTTP endpoints (`gateway.rateLimit`)
+- [x] Application-level rate limiting (Redis sliding window, per-IP, strict
+      `/auth/*` tier for login brute-force defence — `core.api.config.rate_limit`)
+- [x] Certificate revocation denylist for leaked agent/bridge certs
+      (`POST /certificates/revoke`)
 - [x] SAST (Semgrep) and container image scanning (Trivy) in CI
 - [x] DAST (Nuclei) with custom templates validating auth, CORS, header injection
 - [ ] Use external SSO (not local auth) for production

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -137,6 +137,16 @@ CRUD API for resources — they are managed through agent configuration.
 | GET | `/certificates/ca` | No | Get CA public certificate |
 | POST | `/certificates/user` | Yes | Issue user identity certificate |
 | POST | `/certificates/service` | Yes | Issue service certificate |
+| POST | `/certificates/revoke` | Admin | Revoke a certificate by SHA-256 fingerprint |
+| GET | `/certificates/revoked` | Admin/Audit | List revoked certificates |
+
+Revocation is a kill-switch for leaked long-lived agent/bridge certificates.
+Revoked fingerprints are enforced at the API cert-auth layer (agent/bridge
+requests presenting `X-Bamf-Client-Cert` get `401` once revoked). The durable
+list lives in Postgres and is mirrored into a Redis set for O(1) checks;
+enforcement fails open if Redis is unavailable. User sessions are revoked
+separately via `/auth/sessions`, and tunnel session certs are 30-second TTL, so
+revocation targets the long-lived service certs.
 
 ## Audit Log
 

--- a/docs/reference/helm-values.md
+++ b/docs/reference/helm-values.md
@@ -69,7 +69,29 @@ core:
         bridge_ttl_hours: 24         # Bridge cert lifetime
       audit:
         retention_days: 90           # Audit log retention
+      rate_limit:                    # Application-level rate limiting (see below)
+        enabled: true
+        requests_per_minute: 100     # Per-IP limit for unauthenticated requests
+        authenticated_requests_per_minute: 1000  # Per-IP limit once authenticated
+        auth_requests_per_minute: 10 # Per-IP limit for /auth/* (login brute-force defence)
+        trusted_proxy_hops: 1        # Trusted reverse-proxy hops for client-IP resolution
 ```
+
+### Application-level rate limiting
+
+Separate from the ingress-level `gateway.rateLimit` above, the API runs its own
+Redis-backed sliding-window limiter (`core.api.config.rate_limit`) — defence in
+depth, and the only tier that can distinguish authenticated from anonymous
+traffic and apply a strict per-IP limit to `/auth/*` for login brute-force
+defence. A per-tier value of `0` means unlimited; the limiter fails open if
+Redis is unavailable.
+
+The client IP for keying is read from `X-Forwarded-For`, counting
+`trusted_proxy_hops` entries in from the right (the entries your own trusted
+proxies appended). The leftmost entries are client-supplied and spoofable, so
+they are never used. Set `trusted_proxy_hops` to the number of trusted reverse
+proxies in front of the API — `1` for a single ingress; raise it if a CDN or
+load balancer sits in front of the ingress.
 
 ## Bridge
 

--- a/helm/bamf/templates/configmap-api.yaml
+++ b/helm/bamf/templates/configmap-api.yaml
@@ -30,6 +30,7 @@ data:
       requests_per_minute: {{ .Values.core.api.config.rate_limit.requests_per_minute }}
       authenticated_requests_per_minute: {{ .Values.core.api.config.rate_limit.authenticated_requests_per_minute }}
       auth_requests_per_minute: {{ .Values.core.api.config.rate_limit.auth_requests_per_minute }}
+      trusted_proxy_hops: {{ .Values.core.api.config.rate_limit.trusted_proxy_hops | default 1 }}
 
     # Redis URL (password injected via environment)
     redis_url: {{ include "bamf.redisUrl" . | quote }}

--- a/helm/bamf/values.schema.json
+++ b/helm/bamf/values.schema.json
@@ -158,7 +158,8 @@
                     "enabled": { "type": "boolean" },
                     "requests_per_minute": { "type": "integer", "minimum": 0 },
                     "authenticated_requests_per_minute": { "type": "integer", "minimum": 0 },
-                    "auth_requests_per_minute": { "type": "integer", "minimum": 0 }
+                    "auth_requests_per_minute": { "type": "integer", "minimum": 0 },
+                    "trusted_proxy_hops": { "type": "integer", "minimum": 1 }
                   }
                 }
               }

--- a/helm/bamf/values.yaml
+++ b/helm/bamf/values.yaml
@@ -60,6 +60,10 @@ core:
         requests_per_minute: 100
         authenticated_requests_per_minute: 1000
         auth_requests_per_minute: 10
+        # Trusted reverse-proxy hops in front of the API. The rate-limit client
+        # IP is read this many entries in from the right of X-Forwarded-For
+        # (leftmost entries are client-supplied/spoofable). 1 = a single ingress.
+        trusted_proxy_hops: 1
       # CORS — only origins listed here can make cross-origin requests.
       # Empty list (default) means CORS middleware is disabled (same-origin only).
       # Set to your BAMF hostname for production.

--- a/llms.txt
+++ b/llms.txt
@@ -77,7 +77,13 @@ the repo — no hallucinated endpoints, Helm values, or config keys.
 - **Audit & session recording** — immutable audit log; SSH/DB/HTTP recording
   with redaction. [docs/architecture/security.md](docs/architecture/security.md).
 - **Certificates / internal CA** — BAMF-CA-issued short-lived certs (users 12h,
-  services 24h). [docs/admin/certificates.md](docs/admin/certificates.md).
+  services 24h). Revocation denylist for leaked agent/bridge certs
+  (`POST /certificates/revoke`, enforced at API cert-auth).
+  [docs/admin/certificates.md](docs/admin/certificates.md).
+- **Rate limiting** — ingress-level (`gateway.rateLimit`) plus an application
+  Redis sliding-window limiter (`core.api.config.rate_limit`) with a strict
+  `/auth/*` tier for login brute-force defence.
+  [docs/reference/helm-values.md](docs/reference/helm-values.md).
 - **Outpost deployments** — data-plane components deployed close to targets.
   [docs/architecture/outpost-deployments.md](docs/architecture/outpost-deployments.md).
 

--- a/pkg/bridge/server.go
+++ b/pkg/bridge/server.go
@@ -44,19 +44,19 @@ type Server struct {
 	// TLS configuration — protected by certMu for hot-swap during renewal.
 	// The tls.Config uses GetCertificate callbacks that read currentCert
 	// under certMu, so renewed certs are used for new TLS handshakes.
-	tlsConfig  *tls.Config
-	mtlsConfig *tls.Config // For tunnel connections (mTLS with session certs)
-	certMu     sync.RWMutex
+	tlsConfig     *tls.Config
+	mtlsConfig    *tls.Config // For tunnel connections (mTLS with session certs)
+	certMu        sync.RWMutex
 	currentCert   *tls.Certificate // Hot-swappable via certMu
 	certNotBefore time.Time
 	certExpiry    time.Time
 
 	// Session management
-	tunnels      *TunnelManager
-	relays       *RelayPool
-	apiClient    *APIClient
-	sshProxy     *sshproxy.Proxy
-	metrics      *metricsProvider
+	tunnels   *TunnelManager
+	relays    *RelayPool
+	apiClient *APIClient
+	sshProxy  *sshproxy.Proxy
+	metrics   *metricsProvider
 
 	// Pending connections waiting for match (keyed by session ID)
 	pendingConns   map[string]*pendingConnection
@@ -80,7 +80,7 @@ type Server struct {
 type pendingConnection struct {
 	conn         net.Conn
 	sessionID    string
-	isClient     bool   // true = CLI client, false = agent
+	isClient     bool // true = CLI client, false = agent
 	resource     string
 	resourceType string // e.g., "ssh", "ssh-audit", "tunnel"
 	receivedAt   time.Time
@@ -707,6 +707,26 @@ func shortID(id string) string {
 	return id[:16] + "..."
 }
 
+// resolveResourceType returns the authoritative resource type for routing.
+// The CA-signed session cert (certType) wins over the client-supplied wire-line
+// type — a client must not be able to force an unrecorded splice by lying on the
+// wire. A legacy cert without the type SAN (certType == "") falls back to the
+// wire line. Invariant guarded by tests: cert always wins when present.
+func resolveResourceType(wireType, certType string) string {
+	if certType != "" {
+		return certType
+	}
+	return wireType
+}
+
+// bridgePinMatches reports whether a session cert's bridge pin authorizes this
+// bridge. Fails closed: an empty pin (no bamf://bridge/ SAN) never matches, even
+// against an empty bridge ID — the CA always sets the pin, so an absent one is
+// an attempted replay against the wrong bridge.
+func bridgePinMatches(certBridgeID, ownBridgeID string) bool {
+	return certBridgeID != "" && certBridgeID == ownBridgeID
+}
+
 // handleTunnelConnection handles an mTLS tunnel connection.
 // It validates the session cert, matches client with agent, and splices the tunnel.
 // The bridge is protocol-agnostic — it never interprets the tunneled bytes.
@@ -797,17 +817,15 @@ func (s *Server) handleTunnelConnection(ctx context.Context, conn net.Conn) {
 	// The CA-signed session cert is authoritative for the resource type — it
 	// decides recording/audit routing. A client can't spoof it via the wire-line
 	// type=. (Legacy certs without the type SAN fall back to the wire line.)
-	if info.ResourceType != "" {
-		if resourceType != info.ResourceType {
-			s.logger.Warn("wire-line type disagrees with session cert; using cert",
-				"wire", resourceType, "cert", info.ResourceType, "session_id", shortID(sessionID))
-		}
-		resourceType = info.ResourceType
+	if info.ResourceType != "" && resourceType != info.ResourceType {
+		s.logger.Warn("wire-line type disagrees with session cert; using cert",
+			"wire", resourceType, "cert", info.ResourceType, "session_id", shortID(sessionID))
 	}
+	resourceType = resolveResourceType(resourceType, info.ResourceType)
 
 	// Verify this connection is for this bridge. Fail closed: a session cert
 	// with no bridge pin (empty SAN) is also rejected — the CA always sets it.
-	if info.BridgeID != s.cfg.BridgeID {
+	if !bridgePinMatches(info.BridgeID, s.cfg.BridgeID) {
 		s.logger.Error("session cert is for different bridge",
 			"protocol", protocol,
 			"expected", s.cfg.BridgeID,
@@ -1427,7 +1445,7 @@ func (s *Server) handleWebTerminalDB(ctx context.Context, clientConn, agentConn 
 	username := params["user"]
 	database := params["database"]
 	password := params["password"]
-	dbType := params["db_type"]           // "postgres" or "mysql"
+	dbType := params["db_type"]               // "postgres" or "mysql"
 	auditSession := params["audit"] == "true" // capture queries for -audit resources
 
 	if dbType == "" {
@@ -1835,4 +1853,3 @@ func extractSessionInfo(cert *x509.Certificate) (sessionInfo, error) {
 	}
 	return info, nil
 }
-

--- a/pkg/bridge/server_test.go
+++ b/pkg/bridge/server_test.go
@@ -62,3 +62,49 @@ func TestShortID(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveResourceType guards the #157 invariant: the CA-signed session cert
+// is authoritative for recording/audit routing — a client cannot force an
+// unrecorded splice via the wire line. Only a legacy cert with no type SAN
+// falls back to the wire line.
+func TestResolveResourceType(t *testing.T) {
+	tests := []struct {
+		name     string
+		wireType string
+		certType string
+		want     string
+	}{
+		{"cert wins over wire", "ssh", "ssh-audit", "ssh-audit"},
+		{"client cannot downgrade audit", "ssh", "postgres-audit", "postgres-audit"},
+		{"client cannot strip audit to plain", "ssh-audit", "ssh-audit", "ssh-audit"},
+		{"legacy no-type falls back to wire", "ssh-audit", "", "ssh-audit"},
+		{"legacy no-type default tunnel", "tunnel", "", "tunnel"},
+		{"cert wins even if wire is empty-ish", "tunnel", "web-ssh", "web-ssh"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, resolveResourceType(tt.wireType, tt.certType))
+		})
+	}
+}
+
+// TestBridgePinMatches guards the #151 invariant: the session-cert bridge pin
+// must match this bridge, and an empty pin fails closed (never matches).
+func TestBridgePinMatches(t *testing.T) {
+	tests := []struct {
+		name         string
+		certBridgeID string
+		ownBridgeID  string
+		want         bool
+	}{
+		{"matching pin", "bridge-0", "bridge-0", true},
+		{"different bridge rejected", "bridge-1", "bridge-0", false},
+		{"empty pin fails closed", "", "bridge-0", false},
+		{"empty pin fails closed even vs empty own", "", "", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, bridgePinMatches(tt.certBridgeID, tt.ownBridgeID))
+		})
+	}
+}

--- a/services/bamf/api/app.py
+++ b/services/bamf/api/app.py
@@ -69,6 +69,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
         await load_revoked_into_redis(db_session)
     logger.info("Certificate Authority initialized")
 
+    # Periodically re-seed the revocation denylist from Postgres so it survives a
+    # Redis restart/flush (enforcement reads only Redis on the hot path).
+    from bamf.auth.revocation import reconcile_revoked_loop
+
+    revocation_reconcile_task = asyncio.create_task(reconcile_revoked_loop())
+
     init_connectors()
     logger.info("SSO connectors initialized")
 
@@ -76,6 +82,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     # Shutdown — signal SSE generators to close before tearing down connections
     logger.info("Shutting down BAMF API server")
+    revocation_reconcile_task.cancel()
     shutdown_event.set()
     # Brief pause so SSE generators see the event and close cleanly
     await asyncio.sleep(0.5)
@@ -127,6 +134,7 @@ def create_application() -> FastAPI:
             requests_per_minute=settings.rate_limit.requests_per_minute,
             authenticated_requests_per_minute=settings.rate_limit.authenticated_requests_per_minute,
             auth_requests_per_minute=settings.rate_limit.auth_requests_per_minute,
+            trusted_proxy_hops=settings.rate_limit.trusted_proxy_hops,
         )
 
     # Request ID middleware — propagate existing or generate new

--- a/services/bamf/api/rate_limit.py
+++ b/services/bamf/api/rate_limit.py
@@ -33,11 +33,24 @@ def _is_auth_path(path: str) -> bool:
     return any(path.startswith(p) for p in _AUTH_PREFIXES)
 
 
-def _get_client_ip(request: Request) -> str:
-    """Client IP, respecting X-Forwarded-For behind the ingress."""
+def _get_client_ip(request: Request, trusted_proxy_hops: int = 1) -> str:
+    """Client IP for rate-limit keying, resolved from X-Forwarded-For.
+
+    XFF is ``client, proxy1, ..., proxyN`` where each proxy appends the address
+    it received the request from — so the entries appended by our own trusted
+    proxies are the RIGHTMOST ones, and anything a client sends arrives on the
+    LEFT. Taking ``[0]`` (leftmost) is attacker-controlled: rotating a spoofed
+    XFF value lands every request in a fresh bucket and defeats the limiter
+    (including the auth-tier brute-force defence). Instead we count
+    ``trusted_proxy_hops`` in from the right — the IP our outermost trusted proxy
+    observed. Default 1 = a single ingress in front of the API.
+    """
     forwarded = request.headers.get("x-forwarded-for")
     if forwarded:
-        return forwarded.split(",")[0].strip()
+        parts = [p.strip() for p in forwarded.split(",") if p.strip()]
+        if parts:
+            idx = min(max(trusted_proxy_hops, 1), len(parts))
+            return parts[-idx]
     if request.client:
         return request.client.host
     return "unknown"
@@ -52,12 +65,14 @@ class RateLimitMiddleware:
         requests_per_minute: int = 100,
         authenticated_requests_per_minute: int = 1000,
         auth_requests_per_minute: int = 10,
+        trusted_proxy_hops: int = 1,
         get_redis: Callable | None = None,
     ) -> None:
         self.app = app
         self.requests_per_minute = requests_per_minute
         self.authenticated_requests_per_minute = authenticated_requests_per_minute
         self.auth_requests_per_minute = auth_requests_per_minute
+        self.trusted_proxy_hops = trusted_proxy_hops
         self._get_redis = get_redis
 
     def _resolve_redis(self):  # type: ignore[no-untyped-def]
@@ -101,7 +116,7 @@ class RateLimitMiddleware:
             await self.app(scope, receive, send)  # Redis not initialized — fail open
             return
 
-        client_ip = _get_client_ip(request)
+        client_ip = _get_client_ip(request, self.trusted_proxy_hops)
         window_id = int(time.time()) // 60  # 60-second buckets
         key = f"bamf:ratelimit:{prefix}:{client_ip}:{window_id}"
 

--- a/services/bamf/auth/revocation.py
+++ b/services/bamf/auth/revocation.py
@@ -11,6 +11,8 @@ session certs are 30s TTL and the API won't mint a new one for a revoked
 identity, so the tunnel path needs no bridge-side check.
 """
 
+import asyncio
+
 from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -23,11 +25,23 @@ logger = get_logger(__name__)
 _REVOKED_SET = "bamf:revoked_certs"
 
 
+def _normalize_fingerprint(fingerprint: str) -> str:
+    """Normalize a fingerprint to the form enforcement compares against.
+
+    Enforcement checks against ``cert.fingerprint(SHA256).hex()`` — lowercase
+    hex, no separators. An admin may paste an uppercase or colon-delimited
+    fingerprint; without normalization the stored/denied value would never match
+    ``sismember`` and the revocation would silently no-op while appearing revoked
+    in the audit log and ``/revoked`` listing.
+    """
+    return fingerprint.strip().replace(":", "").replace(" ", "").lower()
+
+
 async def is_certificate_revoked(fingerprint: str) -> bool:
     """Return True if the fingerprint is on the denylist (Redis set)."""
     try:
         redis = get_redis_client()
-        return bool(await redis.sismember(_REVOKED_SET, fingerprint))
+        return bool(await redis.sismember(_REVOKED_SET, _normalize_fingerprint(fingerprint)))
     except Exception:
         # Fail open on Redis error (consistent with the rate limiter): the
         # durable DB reloads into Redis at startup, so the exposure window is
@@ -44,6 +58,7 @@ async def revoke_certificate(
     subject_cn: str | None = None,
 ) -> None:
     """Add a certificate fingerprint to the durable denylist and the Redis set."""
+    fingerprint = _normalize_fingerprint(fingerprint)
     if await db.get(RevokedCertificate, fingerprint) is None:
         db.add(
             RevokedCertificate(
@@ -77,3 +92,28 @@ async def load_revoked_into_redis(db: AsyncSession) -> int:
         await redis.sadd(_REVOKED_SET, *fingerprints)
     logger.info("loaded revoked certificates into Redis", count=len(fingerprints))
     return len(fingerprints)
+
+
+# Enforcement reads only the Redis set (the hot cert-auth path must not hit
+# Postgres per request). But Redis is volatile: a restart / failover / flush
+# would drop the denylist and silently re-admit every revoked cert until the
+# next API process restart. Postgres is the source of truth, so we periodically
+# re-seed the set from it — bounding the post-flush exposure window to one
+# interval without adding a per-request DB round-trip.
+_RECONCILE_INTERVAL_SECONDS = 60
+
+
+async def reconcile_revoked_loop(interval_seconds: int = _RECONCILE_INTERVAL_SECONDS) -> None:
+    """Background task: periodically re-seed the Redis denylist from Postgres."""
+    from bamf.db.session import async_session_factory
+
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            async with async_session_factory() as db:
+                await load_revoked_into_redis(db)
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Never let a transient DB/Redis error kill the reconciler.
+            logger.warning("revocation reconcile iteration failed", exc_info=True)

--- a/services/bamf/config.py
+++ b/services/bamf/config.py
@@ -169,6 +169,15 @@ class RateLimitConfig(BaseModel):
         default=10,
         description="Per-IP limit for /auth/* endpoints — login brute-force defence",
     )
+    trusted_proxy_hops: int = Field(
+        default=1,
+        description=(
+            "Number of trusted reverse proxies in front of the API. The client IP "
+            "for rate-limit keying is taken this many hops in from the right of "
+            "X-Forwarded-For (the leftmost entries are client-supplied and spoofable). "
+            "1 = a single ingress; raise it if a CDN/LB sits in front of the ingress."
+        ),
+    )
 
 
 class AuditConfig(BaseSettings):

--- a/services/bamf/proxy/rewrite.py
+++ b/services/bamf/proxy/rewrite.py
@@ -172,7 +172,15 @@ def rewrite_webhook_request_headers(
             continue
         if lower_k in ("host", "origin"):
             continue
-        # Keep Authorization — it belongs to the webhook provider, not BAMF
+        # Strip client-supplied trust headers on the UNAUTHENTICATED webhook
+        # path. Webhook passthrough bypasses BAMF session auth, so an inbound
+        # X-Forwarded-Email / X-Forwarded-K8s-Groups / Impersonate-* would let an
+        # anonymous caller spoof identity to the backend (and, for K8s-reachable
+        # agents, escalate to impersonation). BAMF injects no identity here; these
+        # must never survive from the client. Authorization is kept intentionally
+        # — it belongs to the webhook provider (HMAC/bearer), not BAMF.
+        if lower_k.startswith(("x-forwarded-", "x-bamf-", "impersonate-")):
+            continue
         # Strip bamf_session cookie but keep other cookies
         if lower_k == "cookie":
             v = _strip_bamf_cookie(v)

--- a/services/tests/test_api/test_certificates_router.py
+++ b/services/tests/test_api/test_certificates_router.py
@@ -177,3 +177,122 @@ class TestIssueServiceCertificate:
                 },
             )
         assert resp.status_code == 422  # Pydantic validation
+
+
+# ── Certificate revocation endpoints (RBAC + errors) ──────────────────────
+
+
+def _revoke_app(session: Session) -> FastAPI:
+    """Build an app that runs the REAL require_admin/require_admin_or_audit
+    gates against the given session, with a fake DB and no real Redis/PG."""
+    from bamf.api.dependencies import get_current_session as real_get_current_session
+    from bamf.db.session import get_db
+
+    app = FastAPI()
+    app.include_router(router, prefix="/api/v1")
+
+    async def override_session() -> Session:
+        return session
+
+    async def override_db():
+        from unittest.mock import AsyncMock
+
+        yield AsyncMock()
+
+    app.dependency_overrides[real_get_current_session] = override_session
+    app.dependency_overrides[get_db] = override_db
+    return app
+
+
+async def _revoke_client(app: FastAPI) -> AsyncClient:
+    return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+
+
+class TestRevokeCertificate:
+    @pytest.mark.asyncio
+    async def test_admin_can_revoke(self):
+        from unittest.mock import AsyncMock
+
+        app = _revoke_app(ADMIN_SESSION)
+        async with await _revoke_client(app) as client:
+            with (
+                patch(
+                    "bamf.api.routers.certificates.revoke_certificate",
+                    new_callable=AsyncMock,
+                ) as mock_revoke,
+                patch(
+                    "bamf.api.routers.certificates.log_audit_event",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                resp = await client.post(
+                    "/api/v1/certificates/revoke",
+                    json={"fingerprint": "aa:bb:cc", "reason": "leaked"},
+                )
+        assert resp.status_code == 200
+        mock_revoke.assert_awaited_once()
+
+    @pytest.mark.asyncio
+    async def test_non_admin_forbidden(self):
+        app = _revoke_app(USER_SESSION)
+        async with await _revoke_client(app) as client:
+            resp = await client.post(
+                "/api/v1/certificates/revoke",
+                json={"fingerprint": "aa:bb:cc"},
+            )
+        assert resp.status_code == 403
+
+    @pytest.mark.asyncio
+    async def test_empty_fingerprint_rejected(self):
+        from unittest.mock import AsyncMock
+
+        app = _revoke_app(ADMIN_SESSION)
+        async with await _revoke_client(app) as client:
+            with (
+                patch(
+                    "bamf.api.routers.certificates.revoke_certificate",
+                    new_callable=AsyncMock,
+                ),
+                patch(
+                    "bamf.api.routers.certificates.log_audit_event",
+                    new_callable=AsyncMock,
+                ),
+            ):
+                resp = await client.post(
+                    "/api/v1/certificates/revoke",
+                    json={"fingerprint": ""},
+                )
+        assert resp.status_code == 400
+
+
+class TestListRevokedCertificates:
+    @pytest.mark.asyncio
+    async def test_audit_can_list(self):
+        from unittest.mock import AsyncMock
+
+        audit_session = Session(
+            email="audit@example.com",
+            display_name="Auditor",
+            roles=["audit"],
+            provider_name="local",
+            created_at=_NOW,
+            expires_at=_NOW,
+            last_active_at=_NOW,
+        )
+        app = _revoke_app(audit_session)
+        async with await _revoke_client(app) as client:
+            with patch(
+                "bamf.api.routers.certificates.list_revoked_certificates",
+                new_callable=AsyncMock,
+                return_value=[],
+            ):
+                resp = await client.get("/api/v1/certificates/revoked")
+        assert resp.status_code == 200
+        assert resp.json() == []
+
+    @pytest.mark.asyncio
+    async def test_plain_user_forbidden(self):
+        app = _revoke_app(USER_SESSION)
+        async with await _revoke_client(app) as client:
+            resp = await client.get("/api/v1/certificates/revoked")
+        assert resp.status_code == 403

--- a/services/tests/test_api/test_dependencies.py
+++ b/services/tests/test_api/test_dependencies.py
@@ -19,6 +19,8 @@ from fastapi import HTTPException
 
 from bamf.api.dependencies import (
     _validate_client_cert,
+    get_agent_identity,
+    get_bridge_identity,
     get_current_session,
     require_admin,
     require_admin_or_audit,
@@ -278,3 +280,65 @@ class TestRequireAdminOrAudit:
         session = _make_session(roles=["audit"])
         result = await require_admin_or_audit(session)
         assert result is session
+
+
+# ── revocation enforcement (agent/bridge cert-auth) ──────────────────────
+
+
+class TestRevocationEnforcement:
+    """A revoked agent/bridge certificate must be rejected at cert-auth even
+    though it is otherwise valid and CA-signed. This is the whole invariant of
+    the revocation feature — enforcement lives in the dependency, not the helper.
+    """
+
+    def setup_method(self):
+        self.ca = CertificateAuthority.generate()
+
+    @pytest.mark.asyncio
+    async def test_revoked_agent_cert_returns_401(self):
+        cert, _ = self.ca.issue_service_certificate("agent-1", "agent")
+        header = _encode_cert(cert)
+        with (
+            patch("bamf.api.dependencies.get_ca", return_value=self.ca),
+            patch(
+                "bamf.auth.revocation.is_certificate_revoked",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_agent_identity(header)
+        assert exc_info.value.status_code == 401
+        assert "revoked" in exc_info.value.detail.lower()
+
+    @pytest.mark.asyncio
+    async def test_non_revoked_agent_cert_authenticates(self):
+        cert, _ = self.ca.issue_service_certificate("agent-1", "agent")
+        header = _encode_cert(cert)
+        with (
+            patch("bamf.api.dependencies.get_ca", return_value=self.ca),
+            patch(
+                "bamf.auth.revocation.is_certificate_revoked",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+        ):
+            identity = await get_agent_identity(header)
+        assert identity.name == "agent-1"
+
+    @pytest.mark.asyncio
+    async def test_revoked_bridge_cert_returns_401(self):
+        cert, _ = self.ca.issue_service_certificate("bridge-0", "bridge")
+        header = _encode_cert(cert)
+        with (
+            patch("bamf.api.dependencies.get_ca", return_value=self.ca),
+            patch(
+                "bamf.auth.revocation.is_certificate_revoked",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+        ):
+            with pytest.raises(HTTPException) as exc_info:
+                await get_bridge_identity(header)
+        assert exc_info.value.status_code == 401
+        assert "revoked" in exc_info.value.detail.lower()

--- a/services/tests/test_api/test_kube_proxy.py
+++ b/services/tests/test_api/test_kube_proxy.py
@@ -267,6 +267,52 @@ class TestKubeProxyHappyPath:
         assert "transfer-encoding" not in headers
         assert "upgrade" not in headers
 
+    @pytest.mark.asyncio
+    async def test_client_supplied_trust_headers_stripped(self):
+        """Inbound X-Forwarded-* / X-Bamf-* / Impersonate-* from the client are
+        stripped before forwarding — otherwise a caller could forge
+        X-Forwarded-K8s-Groups=system:masters and escalate to cluster-admin via
+        the agent's impersonation, or point X-Bamf-Target at an SSRF host."""
+        from starlette.requests import Request
+
+        auth_result = _make_auth_result(email="alice@example.com", k8s_groups=["view"])
+        forward_resp = _make_httpx_response(status_code=200, content=b"{}")
+
+        scope = _make_request_scope(
+            headers={
+                "authorization": "Bearer tok",
+                "x-forwarded-email": "attacker@evil.example",
+                "x-forwarded-k8s-groups": "system:masters",
+                "x-bamf-target": "http://169.254.169.254/",
+                "impersonate-user": "system:admin",
+                "impersonate-group": "system:masters",
+            },
+        )
+        request = Request(scope=scope)
+        request._body = b""
+
+        with (
+            patch("bamf.proxy.kube.api_client.authorize", new_callable=AsyncMock) as mock_auth,
+            patch("bamf.proxy.kube._get_kube_client"),
+            patch("bamf.proxy.kube._forward", new_callable=AsyncMock) as mock_forward,
+        ):
+            mock_auth.return_value = auth_result
+            mock_forward.return_value = forward_resp
+
+            await kube_mod.kube_proxy(
+                resource_name="prod-cluster",
+                path="api/v1/pods",
+                request=request,
+            )
+
+        headers = mock_forward.call_args[0][3]
+        # No Impersonate-* forwarded (agent sets those from the trusted values).
+        assert not any(k.lower().startswith("impersonate-") for k in headers)
+        # The authoritative identity/groups/target win — not the spoofed inbound.
+        assert headers["X-Forwarded-Email"] == "alice@example.com"
+        assert headers["X-Forwarded-K8s-Groups"] == "view"
+        assert headers["X-Bamf-Target"] == "https://kubernetes.default.svc:6443"
+
 
 class TestKubeProxyMissingToken:
     """Tests for missing/invalid Bearer token."""

--- a/services/tests/test_api/test_rate_limit.py
+++ b/services/tests/test_api/test_rate_limit.py
@@ -5,10 +5,16 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from httpx import ASGITransport, AsyncClient
 from starlette.applications import Starlette
+from starlette.requests import Request
 from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 
-from bamf.api.rate_limit import RateLimitMiddleware
+from bamf.api.rate_limit import RateLimitMiddleware, _get_client_ip
+
+
+def _request_with_xff(xff: str | None, peer: str = "10.0.0.254") -> Request:
+    headers = [(b"x-forwarded-for", xff.encode())] if xff is not None else []
+    return Request({"type": "http", "headers": headers, "client": (peer, 0)})
 
 
 def _make_redis(count: int):
@@ -38,6 +44,47 @@ def _app(redis, **limits) -> Starlette:
 async def _get(app, path, method="GET"):
     async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
         return await c.request(method, path)
+
+
+def test_client_ip_ignores_spoofed_leftmost_xff():
+    """A client-supplied leftmost X-Forwarded-For must NOT become the rate-limit
+    key — otherwise rotating it defeats the limiter (incl. auth brute-force)."""
+    # Ingress appends the real peer on the right; leftmost is attacker-controlled.
+    req = _request_with_xff("1.2.3.4, 203.0.113.7")
+    assert _get_client_ip(req, trusted_proxy_hops=1) == "203.0.113.7"
+    # Rotating the spoofed leftmost value does not change the resolved IP.
+    req2 = _request_with_xff("9.9.9.9, 203.0.113.7")
+    assert _get_client_ip(req2, trusted_proxy_hops=1) == "203.0.113.7"
+
+
+def test_client_ip_honours_trusted_hops():
+    """With two trusted proxies, count two in from the right."""
+    req = _request_with_xff("spoof, real-client, ingress")
+    assert _get_client_ip(req, trusted_proxy_hops=2) == "real-client"
+
+
+def test_client_ip_single_entry_and_fallback():
+    assert _get_client_ip(_request_with_xff("203.0.113.7")) == "203.0.113.7"
+    # No XFF → fall back to the socket peer.
+    assert _get_client_ip(_request_with_xff(None, peer="198.51.100.9")) == "198.51.100.9"
+    # More trusted hops than entries → clamp to the leftmost available.
+    assert _get_client_ip(_request_with_xff("only-one"), trusted_proxy_hops=5) == "only-one"
+
+
+@pytest.mark.asyncio
+async def test_spoofed_xff_shares_one_bucket():
+    """End-to-end: requests differing only in spoofed leftmost XFF hit the same
+    Redis bucket (same key), so the limiter counts them together."""
+    redis = _make_redis(1)
+    keys: list[str] = []
+    pipe = redis.pipeline.return_value
+    pipe.incr = MagicMock(side_effect=lambda k: keys.append(k))
+    app = _app(redis, requests_per_minute=5, trusted_proxy_hops=1)
+    async with AsyncClient(transport=ASGITransport(app=app), base_url="http://t") as c:
+        await c.get("/x", headers={"x-forwarded-for": "1.1.1.1, 203.0.113.7"})
+        await c.get("/x", headers={"x-forwarded-for": "2.2.2.2, 203.0.113.7"})
+    assert len(keys) == 2
+    assert keys[0] == keys[1], keys  # same client-IP component → same bucket
 
 
 @pytest.mark.asyncio

--- a/services/tests/test_api/test_rewrite.py
+++ b/services/tests/test_api/test_rewrite.py
@@ -414,3 +414,37 @@ class TestRewriteWebhookRequestHeaders:
         result = rewrite_webhook_request_headers(headers=headers, **self._base_kwargs())
         assert "bamf_session" not in result.get("cookie", "")
         assert "github_token=xyz" in result["cookie"]
+
+    def test_client_supplied_trust_headers_stripped(self):
+        """Inbound X-Forwarded-* / X-Bamf-* / Impersonate-* are stripped on the
+        UNAUTHENTICATED webhook path — an anonymous caller must not be able to
+        spoof identity or K8s impersonation groups to the backend."""
+        headers = {
+            "accept": "*/*",
+            "x-forwarded-email": "attacker@evil.example",
+            "x-forwarded-user": "attacker@evil.example",
+            "x-forwarded-roles": "admin",
+            "x-forwarded-k8s-groups": "system:masters",
+            "x-bamf-target": "http://169.254.169.254/",
+            "x-bamf-session-token": "forged",
+            "impersonate-user": "system:admin",
+            "impersonate-group": "system:masters",
+        }
+        result = rewrite_webhook_request_headers(headers=headers, **self._base_kwargs())
+        for k in (
+            "x-forwarded-email",
+            "x-forwarded-user",
+            "x-forwarded-roles",
+            "x-forwarded-k8s-groups",
+            "impersonate-user",
+            "impersonate-group",
+        ):
+            assert k not in result, k
+        # The proxy's own X-Forwarded-* / X-Bamf-Target win (set after the copy).
+        assert result["X-Forwarded-Host"] == "jenkins.tunnel.bamf.local"
+        assert result["X-Forwarded-For"] == "140.82.112.10"
+        assert result["X-Bamf-Target"] == "http://jenkins.internal:8080"
+        # A forged session token must not survive to the backend.
+        assert "x-bamf-session-token" not in result
+        assert "X-Bamf-Session-Token" not in result
+        assert "accept" in result

--- a/services/tests/test_auth/test_revocation.py
+++ b/services/tests/test_auth/test_revocation.py
@@ -4,7 +4,43 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
-from bamf.auth.revocation import is_certificate_revoked, revoke_certificate
+from bamf.auth.revocation import (
+    _normalize_fingerprint,
+    is_certificate_revoked,
+    revoke_certificate,
+)
+
+
+def test_normalize_fingerprint():
+    # Uppercase, colon-delimited, and padded forms all collapse to lowercase hex.
+    assert _normalize_fingerprint("AB:CD:EF") == "abcdef"
+    assert _normalize_fingerprint("  ABcd  ") == "abcd"
+    assert _normalize_fingerprint("a1b2c3") == "a1b2c3"
+
+
+@pytest.mark.asyncio
+async def test_revoke_normalizes_before_store():
+    """An admin-pasted uppercase/colon fingerprint is normalized so it matches
+    the lowercase-hex form enforcement compares against (else silent no-op)."""
+    redis = MagicMock()
+    redis.sadd = AsyncMock()
+    db = AsyncMock()
+    db.get = AsyncMock(return_value=None)
+    db.add = MagicMock()
+    db.flush = AsyncMock()
+    with patch("bamf.auth.revocation.get_redis_client", return_value=redis):
+        await revoke_certificate(db, "AA:BB:CC")
+    assert db.add.call_args[0][0].fingerprint == "aabbcc"
+    redis.sadd.assert_awaited_once_with("bamf:revoked_certs", "aabbcc")
+
+
+@pytest.mark.asyncio
+async def test_is_revoked_normalizes_query():
+    redis = MagicMock()
+    redis.sismember = AsyncMock(return_value=1)
+    with patch("bamf.auth.revocation.get_redis_client", return_value=redis):
+        await is_certificate_revoked("AA:BB:CC")
+    redis.sismember.assert_awaited_once_with("bamf:revoked_certs", "aabbcc")
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Fixes surfaced by the **v0.7.0 pre-release adversarial audit** (parallel read-only reviewers across API/security correctness, consumer-contract drift, test coverage, and docs). Landing before the tag per AGENTS.md release discipline.

## Security blockers fixed
- **Webhook trust-header spoofing** (`proxy/rewrite.py`) — the unauthenticated webhook passthrough copied inbound headers verbatim, so an anonymous caller could inject `X-Forwarded-Email` / `X-Forwarded-K8s-Groups: system:masters` / `Impersonate-*` and spoof identity to the backend (cluster-admin escalation for K8s-reachable agents). #148 fixed the web + kube paths but missed webhooks; now the same strip applies (Authorization intentionally kept).
- **Rate-limiter XFF bypass** (`api/rate_limit.py`) — keyed on the leftmost `X-Forwarded-For` (client-controlled; ingress appends the real IP on the right), so rotating it defeated every tier including the `/auth/*` brute-force defence. Now resolves the client IP `trusted_proxy_hops` in from the right (config `core.api.config.rate_limit.trusted_proxy_hops`, default 1).

## Revocation hardening
- Periodic reconcile of the Redis denylist from Postgres (60s) so it survives a Redis restart/flush — enforcement reads only Redis on the hot path, and previously the set was seeded once at startup.
- Fingerprint normalization (lowercase, strip `:`/spaces) so an admin-pasted uppercase/colon fingerprint can't silently no-op enforcement.

## Test coverage (the audit's NO-GO items)
- Revoked agent/bridge cert → **401 through `get_agent_identity`/`get_bridge_identity`** (the actual enforcement path, previously only helpers were tested).
- Kube-proxy **and** webhook inbound trust-header stripping.
- Rate-limiter XFF-spoof resistance (`_get_client_ip` + same-bucket assertion).
- Revoke-endpoint RBAC (admin-only revoke, admin/audit list) + empty-fingerprint 400.
- Bridge **fail-closed pin** and **cert-over-wire** invariants — extracted `resolveResourceType`/`bridgePinMatches` pure helpers with table tests.

## Docs
- `/certificates/revoke` + `/certificates/revoked` in the API reference.
- Application-level rate limiting in helm-values + security hardening checklist.
- `llms.txt` updated for revocation + rate limiting; `trusted_proxy_hops` value + schema.

## Verification
`gmake test-python` 1040→ (all pass), `gmake lint-python` clean, `gmake test-go` + `gmake lint-go` pass, `helm lint` clean, ConfigMap renders `trusted_proxy_hops`.

Fast-follows filed: #160 (absolute session cap), #161 (SSE revoke-push + write ordering), #162 (bridge panic pending-cleanup), #163 (deflake sshproxy exec test).

closes #164