### PR TITLE
fix(security): clear open security alerts (SBOM curl|sh + nested postcss)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -531,11 +531,16 @@ jobs:
 
           echo "$notes" > /tmp/release-notes.md
 
+      # Install syft via the SHA-pinned action instead of `curl … | sh`
+      # (removes the piped-shell supply-chain risk and pins the syft version).
+      - name: Install syft (SBOM tool)
+        uses: anchore/sbom-action/download-syft@e22c389904149dbc22b58101806040fa8d37a610 # v0.24.0
+        with:
+          syft-version: v1.46.0
+
       - name: Generate SBOMs
         run: |
           version="${{ needs.prepare.outputs.version }}"
-
-          curl -sSfL https://raw.githubusercontent.com/anchore/syft/main/install.sh | sh -s -- -b /usr/local/bin
 
           for image in bamf-api bamf-bridge bamf-agent bamf-web bamf-proxy; do
             echo "Generating SBOM for $image:$version"

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -34,7 +34,7 @@
         "@types/react-dom": "^19",
         "eslint": "^9",
         "eslint-config-next": "^16.2.10",
-        "postcss": "^8.4.49",
+        "postcss": "^8.5.10",
         "tailwindcss": "^4.2.2",
         "typescript": "^6.0.2"
       }
@@ -5982,34 +5982,6 @@
         }
       }
     },
-    "node_modules/next/node_modules/postcss": {
-      "version": "8.4.31",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.31.tgz",
-      "integrity": "sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==",
-      "funding": [
-        {
-          "type": "opencollective",
-          "url": "https://opencollective.com/postcss/"
-        },
-        {
-          "type": "tidelift",
-          "url": "https://tidelift.com/funding/github/npm/postcss"
-        },
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/ai"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "nanoid": "^3.3.6",
-        "picocolors": "^1.0.0",
-        "source-map-js": "^1.0.2"
-      },
-      "engines": {
-        "node": "^10 || ^12 || >=14"
-      }
-    },
     "node_modules/node-releases": {
       "version": "2.0.50",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
@@ -6284,7 +6256,6 @@
       "version": "8.5.16",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
       "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
-      "dev": true,
       "funding": [
         {
           "type": "opencollective",

--- a/web/package.json
+++ b/web/package.json
@@ -36,8 +36,11 @@
     "@types/react-dom": "^19",
     "eslint": "^9",
     "eslint-config-next": "^16.2.10",
-    "postcss": "^8.4.49",
+    "postcss": "^8.5.10",
     "tailwindcss": "^4.2.2",
     "typescript": "^6.0.2"
+  },
+  "overrides": {
+    "postcss": "^8.5.10"
   }
 }


### PR DESCRIPTION
Clears the two actionable open security alerts (the other 5 code-scanning alerts — `dependabot-missing-cooldown` — were dismissed as won't-fix: keeping Dependabot aligned with the reference setup / manual batching is a deliberate choice).

## Fixes
- **Code scanning `gha-curl-pipe-shell`** (ci.yml:535) — replaced `curl … syft/main/install.sh | sh` with the SHA-pinned `anchore/sbom-action/download-syft@e22c389 # v0.24.0` (`syft-version: v1.46.0`). Removes the piped-shell pattern and pins the tool, consistent with the repo's SHA-pinning convention.
- **Dependabot GHSA-qx2v-qp2m-jg93** (postcss `< 8.5.10`) — Next.js pinned a transitive `postcss@8.4.31`. Added an `overrides: { postcss: "^8.5.10" }` (and bumped the direct dev dep to align). postcss is now `8.5.16` throughout; `npm run build` passes.

## Verification
- `npm run build` in `web/` — all routes prerender.
- Lockfile scan: no `postcss < 8.5.10` remains.