### PR TITLE
fix(helm): gate bridge-bootstrap secret on outpost.enabled + auto-generate token

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -187,6 +187,18 @@ jobs:
             alpine/helm:3.17.2 \
             lint helm/bamf --values helm/bamf/values.yaml
 
+      # Every documented topology must render — guards against gating regressions
+      # like a Secret that requires input in a topology where its component is off.
+      - name: Helm template — all 4 topologies must render
+        run: |
+          docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 sh -euc '
+            helm template helm/bamf --set core.enabled=true,outpost.enabled=true,agent.enabled=false >/dev/null
+            helm template helm/bamf --set core.enabled=false,outpost.enabled=true,agent.enabled=false >/dev/null
+            helm template helm/bamf --set core.enabled=false,outpost.enabled=false,agent.enabled=true,agent.joinToken=dummy,agent.config.name=ci-agent >/dev/null
+            helm template helm/bamf --set core.enabled=true,outpost.enabled=true,agent.enabled=true,agent.joinToken=dummy,agent.config.name=ci-agent >/dev/null
+            echo "all 4 topologies rendered"
+          '
+
   # ── Security ────────────────────────────────────────────
   sast:
     name: SAST (Semgrep)

--- a/helm/bamf/templates/deployment-api.yaml
+++ b/helm/bamf/templates/deployment-api.yaml
@@ -84,7 +84,11 @@ spec:
             {{- end }}
             - name: BAMF_REDIS_URL
               value: {{ include "bamf.redisUrl" . | quote }}
-            {{- if .Values.outpost.bridge.bootstrap.enabled }}
+            {{- if and .Values.outpost.enabled .Values.outpost.bridge.bootstrap.enabled }}
+            {{- /* Only for the co-located bridge; remote-outpost bridges auth via
+                   DB-hashed bootstrap tokens, not this env var. Gate on
+                   outpost.enabled so a core-only install doesn't reference a
+                   Secret that isn't rendered. */}}
             - name: BAMF_BRIDGE_BOOTSTRAP_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/helm/bamf/templates/secret-bridge-bootstrap.yaml
+++ b/helm/bamf/templates/secret-bridge-bootstrap.yaml
@@ -1,14 +1,29 @@
-{{- if .Values.outpost.bridge.bootstrap.enabled }}
+{{- if and .Values.outpost.enabled .Values.outpost.bridge.bootstrap.enabled }}
 {{- if not .Values.outpost.bridge.bootstrap.tokenSecret }}
+{{- $name := printf "%s-bridge-bootstrap" (include "bamf.fullname" .) }}
+{{- $token := .Values.outpost.bridge.bootstrap.token }}
+{{- if not $token }}
+{{- /* Preserve an existing token across upgrades; otherwise generate one.
+       Safe to auto-generate: it is a shared secret the co-located API and
+       bridge both read from THIS Secret (config.py validates it as-is). Remote
+       outposts set outpost.bridge.bootstrap.token from their join flow so it
+       matches the central API. */}}
+{{- $existing := lookup "v1" "Secret" .Release.Namespace $name }}
+{{- if $existing }}
+{{- $token = index $existing.data "token" | b64dec }}
+{{- else }}
+{{- $token = randAlphaNum 40 }}
+{{- end }}
+{{- end }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ include "bamf.fullname" . }}-bridge-bootstrap
+  name: {{ $name }}
   labels:
     {{- include "bamf.labels" . | nindent 4 }}
     app.kubernetes.io/component: bridge
 type: Opaque
 stringData:
-  token: {{ required "outpost.bridge.bootstrap.token is required when bootstrap.enabled=true and no tokenSecret is specified" .Values.outpost.bridge.bootstrap.token | quote }}
+  token: {{ $token | quote }}
 {{- end }}
 {{- end }}


### PR DESCRIPTION
Closes #121.

`secret-bridge-bootstrap.yaml` gated only on `bootstrap.enabled` (default `true`) and hard-`required` a token, so it rendered — and failed — even in topologies with no bridge. This broke the default `helm template` and 2 of the 4 documented topologies (agent-only, outpost-disabled).

## Fix
- Gate the Secret on `outpost.enabled AND bootstrap.enabled`. Same gate applied to the API's `BAMF_BRIDGE_BOOTSTRAP_TOKEN` env (it's only for the *co-located* bridge — remote-outpost bridges auth via DB-hashed tokens — so it must not dangle in a core-only install).
- Auto-generate the token when not provided, preserved across upgrades via `lookup` (safe: the co-located API and bridge both read it from this Secret and the API validates it as-is; remote outposts still supply it from their join flow). Removes the render-time `required` failure.
- CI: new **helm-template matrix** step in the Helm Lint job asserts all 4 topologies render, so this class of gating regression fails CI.

## Verification
All 4 topologies render with their minimal legitimate inputs (agent installs still require `agent.joinToken` + `agent.config.name`, which are genuinely operator-provided):
```
OK central · OK remote-outpost · OK agent-only · OK central+agent
```
`helm lint` clean. Agent-only no longer renders the bootstrap secret (0 refs).