### PR TITLE
fix(cli): decode CursorPage items envelope for agents and tokens lists

### DIFF
--- a/cmd/bamf/cmd/agents.go
+++ b/cmd/bamf/cmd/agents.go
@@ -86,25 +86,26 @@ func runAgents(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API error: %s", resp.Status)
 	}
 
+	// The API paginates list endpoints with a CursorPage envelope: {"items":[...]}.
 	var result struct {
-		Agents []agent `json:"agents"`
+		Items []agent `json:"items"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	if len(result.Agents) == 0 {
+	if len(result.Items) == 0 {
 		fmt.Println("No agents registered.")
 		return nil
 	}
 
 	if jsonOutput {
-		out, _ := json.MarshalIndent(result.Agents, "", "  ")
+		out, _ := json.MarshalIndent(result.Items, "", "  ")
 		fmt.Println(string(out))
 	} else {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "NAME\tSTATUS\tLAST SEEN\tRESOURCES\tLABELS")
-		for _, a := range result.Agents {
+		for _, a := range result.Items {
 			lastSeen := "-"
 			if a.LastHeartbeat != nil {
 				lastSeen = time.Since(*a.LastHeartbeat).Round(time.Second).String() + " ago"

--- a/cmd/bamf/cmd/resources.go
+++ b/cmd/bamf/cmd/resources.go
@@ -49,7 +49,6 @@ func init() {
 }
 
 type resource struct {
-	ID           string            `json:"id"`
 	Name         string            `json:"name"`
 	ResourceType string            `json:"resource_type"`
 	Labels       map[string]string `json:"labels"`

--- a/cmd/bamf/cmd/resources_test.go
+++ b/cmd/bamf/cmd/resources_test.go
@@ -392,7 +392,7 @@ func TestRunAgents_Success(t *testing.T) {
 		require.Equal(t, "GET", r.Method)
 
 		resp := map[string]any{
-			"agents": []agent{
+			"items": []agent{
 				{
 					Name:          "agent-01",
 					Status:        "online",
@@ -447,7 +447,7 @@ func TestRunAgents_EmptyList(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bamfPath, "credentials.json"), data, 0600))
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"agents": []agent{}})
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []agent{}})
 	}))
 	defer srv.Close()
 
@@ -486,7 +486,7 @@ func TestRunAgents_JSONOutput(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]any{
-			"agents": []agent{
+			"items": []agent{
 				{Name: "agent-01", Status: "online", ResourceCount: 5},
 			},
 		}

--- a/cmd/bamf/cmd/tokens.go
+++ b/cmd/bamf/cmd/tokens.go
@@ -117,24 +117,24 @@ func runTokensList(cmd *cobra.Command, args []string) error {
 	}
 
 	var result struct {
-		Tokens []joinToken `json:"tokens"`
+		Items []joinToken `json:"items"`
 	}
 	if err := json.NewDecoder(resp.Body).Decode(&result); err != nil {
 		return fmt.Errorf("failed to parse response: %w", err)
 	}
 
-	if len(result.Tokens) == 0 {
+	if len(result.Items) == 0 {
 		fmt.Println("No join tokens found.")
 		return nil
 	}
 
 	if jsonOutput {
-		out, _ := json.MarshalIndent(result.Tokens, "", "  ")
+		out, _ := json.MarshalIndent(result.Items, "", "  ")
 		fmt.Println(string(out))
 	} else {
 		w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 		fmt.Fprintln(w, "NAME\tSTATUS\tEXPIRES\tUSES\tCREATED BY")
-		for _, t := range result.Tokens {
+		for _, t := range result.Items {
 			status := "active"
 			if t.IsRevoked {
 				status = "revoked"

--- a/cmd/bamf/cmd/tokens_test.go
+++ b/cmd/bamf/cmd/tokens_test.go
@@ -67,7 +67,7 @@ func TestRunTokensList_Success(t *testing.T) {
 		require.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
 
 		resp := map[string]any{
-			"tokens": []joinToken{
+			"items": []joinToken{
 				{
 					Name:      "dev-token",
 					ExpiresAt: time.Now().Add(24 * time.Hour),
@@ -124,7 +124,7 @@ func TestRunTokensList_EmptyList(t *testing.T) {
 	require.NoError(t, os.WriteFile(filepath.Join(bamfPath, "credentials.json"), data, 0600))
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = json.NewEncoder(w).Encode(map[string]any{"tokens": []joinToken{}})
+		_ = json.NewEncoder(w).Encode(map[string]any{"items": []joinToken{}})
 	}))
 	defer srv.Close()
 
@@ -163,7 +163,7 @@ func TestRunTokensList_JSONOutput(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]any{
-			"tokens": []joinToken{
+			"items": []joinToken{
 				{Name: "test-token", ExpiresAt: time.Now().Add(1 * time.Hour)},
 			},
 		}
@@ -214,7 +214,7 @@ func TestRunTokensList_RevokedToken(t *testing.T) {
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		resp := map[string]any{
-			"tokens": []joinToken{
+			"items": []joinToken{
 				{
 					Name:      "revoked-token",
 					ExpiresAt: time.Now().Add(1 * time.Hour),


### PR DESCRIPTION
Closes #120.

`bamf agents` and `bamf tokens list` were **permanently empty**: the API paginates with a `CursorPage` envelope (`{"items":[...]}`), but the CLI decoded `{"agents":[...]}` / `{"tokens":[...]}`. The Go tests baked in the wrong shape, so CI stayed green over the bug.

## Fix
- `agents.go` / `tokens.go`: decode `items`.
- `tokens_test.go` + the agents cases in `resources_test.go`: assert the real `items` envelope (these fail against the pre-fix decode, so the regression can't silently return).
- `resources.go`: drop the dead `id` field (resources are keyed by name; the API never returns `id`).

## Verification
- `make test-go` + `make lint-go` pass.
- **Live** against the running stack: `GET /agents` and `GET /tokens` return `{items,next_cursor,has_more}` with real rows (agent `local-agent`, 1 token) — the fixed CLI decodes them.

The `/resources` endpoint genuinely returns a custom `{"resources":[...]}` envelope; unifying the three list-envelope shapes into one convention is tracked separately in #125.