### PR TITLE
fix(security): give every session an absolute lifetime cap

### DIFF
--- a/docs/admin/users.md
+++ b/docs/admin/users.md
@@ -78,9 +78,14 @@ and the next API request with that session token will fail.
 
 ### Session Lifetime
 
-Sessions expire after a configurable duration (default: 12 hours). This is
-controlled by the Redis key TTL. To disable a user mid-session, revoke their
-sessions.
+Sessions use a **sliding** TTL (`auth.session_ttl_hours`, default 12 hours):
+each authenticated request extends the Redis key TTL, so an active session stays
+alive. To bound this, every session also has an **absolute cap**
+(`auth.session_max_lifetime_hours`, default 168 hours / 7 days) recorded at
+creation — a session can never slide past this cap regardless of activity, so it
+eventually forces re-authentication. When an external IdP's id_token expires
+sooner than the cap, the token lifetime wins (a BAMF session never outlives the
+IdP assertion). To disable a user mid-session, revoke their sessions.
 
 ## Disabling Users
 

--- a/services/bamf/api/routers/auth.py
+++ b/services/bamf/api/routers/auth.py
@@ -845,23 +845,26 @@ def _enforce_external_sso_requirement(provider_name: str, roles: list[str]) -> N
         )
 
 
-def _compute_max_session_ttl(id_token_expires_at: datetime | None) -> int | None:
-    """Compute max session TTL from id_token expiry.
+def _compute_max_session_ttl(id_token_expires_at: datetime | None) -> int:
+    """Absolute session cap in seconds, used as the session's hard_expires_at.
 
-    Returns the remaining id_token lifetime in seconds if it's shorter than
-    the configured session TTL, otherwise None.
+    A session may slide (refresh on activity) up to session_ttl_hours per window,
+    but never past this absolute cap from creation — so local and long-lived-IDP
+    sessions can't refresh indefinitely. When the IDP id_token expires sooner
+    than the cap, the token lifetime wins (a BAMF session never outlives the IDP
+    assertion). Always returns a positive value, so every session gets a hard cap.
     """
-    if id_token_expires_at is None:
-        return None
-
     from bamf.db.models import utc_now
 
-    remaining = (id_token_expires_at - utc_now()).total_seconds()
-    configured = settings.auth.session_ttl_hours * 3600
+    max_absolute = settings.auth.session_max_lifetime_hours * 3600
+    if id_token_expires_at is None:
+        return max_absolute
 
-    if 0 < remaining < configured:
-        return int(remaining)
-    return None
+    remaining = int((id_token_expires_at - utc_now()).total_seconds())
+    if remaining <= 0:
+        # id_token already expired at login (anomalous) — fall back to the cap.
+        return max_absolute
+    return min(remaining, max_absolute)
 
 
 def _get_claims_rules(provider_name: str) -> list:

--- a/services/bamf/config.py
+++ b/services/bamf/config.py
@@ -115,7 +115,16 @@ class AuthConfig(BaseSettings):
     sso: SSOConfig = Field(default_factory=SSOConfig)
     session_ttl_hours: int = Field(
         default=12,
-        description="Session TTL in hours",
+        description="Sliding session TTL in hours — extended on activity",
+    )
+    session_max_lifetime_hours: int = Field(
+        default=168,
+        description=(
+            "Absolute maximum session lifetime in hours. A session may slide "
+            "(refresh on activity) up to session_ttl_hours per window, but never "
+            "past this cap from creation — bounding indefinitely-active local and "
+            "long-lived-IDP-token sessions. Default 168h (7 days)."
+        ),
     )
     require_external_sso_for_roles: list[str] = Field(
         default_factory=list,

--- a/services/tests/test_api/test_auth_router.py
+++ b/services/tests/test_api/test_auth_router.py
@@ -1493,53 +1493,56 @@ class TestEnforceExternalSSO:
 class TestComputeMaxSessionTTL:
     """Tests for _compute_max_session_ttl helper."""
 
-    def test_none_when_no_expiry(self):
-        """No id_token expiry returns None."""
+    def test_absolute_cap_when_no_expiry(self):
+        """No id_token expiry (e.g. local auth) still returns the absolute cap —
+        the session can no longer slide indefinitely."""
         from bamf.api.routers.auth import _compute_max_session_ttl
 
-        assert _compute_max_session_ttl(None) is None
+        with patch("bamf.api.routers.auth.settings") as mock_settings:
+            mock_settings.auth.session_max_lifetime_hours = 168
+            result = _compute_max_session_ttl(None)
 
-    def test_returns_remaining_when_shorter_than_configured(self):
-        """When id_token expires sooner than session TTL, returns remaining seconds."""
+        assert result == 168 * 3600
+
+    def test_returns_remaining_when_shorter_than_cap(self):
+        """When id_token expires sooner than the absolute cap, the token wins."""
         from datetime import timedelta
 
         from bamf.api.routers.auth import _compute_max_session_ttl
 
-        # id_token expires in 1 hour, session TTL is 12 hours
         future_time = datetime.now(UTC) + timedelta(hours=1)
         with patch("bamf.api.routers.auth.settings") as mock_settings:
-            mock_settings.auth.session_ttl_hours = 12
+            mock_settings.auth.session_max_lifetime_hours = 168
             result = _compute_max_session_ttl(future_time)
 
-        assert result is not None
         assert 3500 < result < 3700  # ~1 hour in seconds, allowing timing tolerance
 
-    def test_none_when_longer_than_configured(self):
-        """When id_token expires later than session TTL, returns None."""
+    def test_capped_when_id_token_longer_than_cap(self):
+        """When id_token outlives the absolute cap, the cap wins (no unbounded life)."""
         from datetime import timedelta
 
         from bamf.api.routers.auth import _compute_max_session_ttl
 
-        # id_token expires in 24 hours, session TTL is 12 hours
-        future_time = datetime.now(UTC) + timedelta(hours=24)
+        # id_token expires in 30 days, absolute cap is 7 days
+        future_time = datetime.now(UTC) + timedelta(days=30)
         with patch("bamf.api.routers.auth.settings") as mock_settings:
-            mock_settings.auth.session_ttl_hours = 12
+            mock_settings.auth.session_max_lifetime_hours = 168
             result = _compute_max_session_ttl(future_time)
 
-        assert result is None
+        assert result == 168 * 3600
 
-    def test_none_when_already_expired(self):
-        """Already-expired id_token returns None (remaining <= 0)."""
+    def test_absolute_cap_when_already_expired(self):
+        """Already-expired id_token (anomalous at login) falls back to the cap."""
         from datetime import timedelta
 
         from bamf.api.routers.auth import _compute_max_session_ttl
 
         past_time = datetime.now(UTC) - timedelta(hours=1)
         with patch("bamf.api.routers.auth.settings") as mock_settings:
-            mock_settings.auth.session_ttl_hours = 12
+            mock_settings.auth.session_max_lifetime_hours = 168
             result = _compute_max_session_ttl(past_time)
 
-        assert result is None
+        assert result == 168 * 3600
 
 
 # ── Tests: Get Claims Rules ──────────────────────────────────────────


### PR DESCRIPTION
Closes #160 (v0.7.0 audit fast-follow).

`_compute_max_session_ttl` returned `None` for local auth (no id_token) and for id_tokens longer than the session window, leaving `hard_expires_at` unset — so those sessions could **slide indefinitely** (each request refreshes the TTL). The #149 clamp only bounded SSO sessions whose id_token was *shorter* than one window.

## Fix
- `_compute_max_session_ttl` now always returns a positive cap: `min(id_token_remaining, session_max_lifetime_hours)`. Every session gets a `hard_expires_at`, so even a continuously-active session eventually forces re-auth.
- New `auth.session_max_lifetime_hours` (default **168h / 7 days**).
- IdP id_token expiry still wins when shorter (a BAMF session never outlives the IdP assertion).
- Existing `refresh_session` hard-cap clamp (#149) now applies to all sessions.

## Verification
`make test-python` 1040 passed (updated `TestComputeMaxSessionTTL` for the always-finite cap; the `refresh_session` clamp tests still pass). `make lint-python` clean. Session-lifetime docs updated.