### PR TITLE
fix(ci): override entrypoint for the helm-template topology matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -189,9 +189,11 @@ jobs:
 
       # Every documented topology must render — guards against gating regressions
       # like a Secret that requires input in a topology where its component is off.
+      # --entrypoint sh: the alpine/helm image's entrypoint is `helm`, so a bare
+      # `... alpine/helm sh -euc` would run `helm sh` ("unknown command").
       - name: Helm template — all 4 topologies must render
         run: |
-          docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 sh -euc '
+          docker run --rm --entrypoint sh -v "$PWD:/chart" -w /chart alpine/helm:3.17.2 -euc '
             helm template helm/bamf --set core.enabled=true,outpost.enabled=true,agent.enabled=false >/dev/null
             helm template helm/bamf --set core.enabled=false,outpost.enabled=true,agent.enabled=false >/dev/null
             helm template helm/bamf --set core.enabled=false,outpost.enabled=false,agent.enabled=true,agent.joinToken=dummy,agent.config.name=ci-agent >/dev/null


### PR DESCRIPTION
The `alpine/helm` image's entrypoint is `helm`, so the topology-matrix step added in #170 ran `helm sh -euc …` → "unknown command sh", failing the Helm Lint job on main. Pass `--entrypoint sh`. Verified locally with the exact command — all 4 topologies render, exit 0.