### PR TITLE
fix(agent): reliable API→agent command delivery + larger SSE scanner buffer

### DIFF
--- a/pkg/agent/sse.go
+++ b/pkg/agent/sse.go
@@ -130,6 +130,12 @@ func (c *SSEClient) Connect(ctx context.Context) (<-chan SSEEvent, error) {
 		defer close(eventCh)
 
 		scanner := bufio.NewScanner(resp.Body)
+		// A tunnel_request/relay_connect data line inlines three PEM blocks
+		// (session_cert + session_key + ca_certificate). The default 64KB token
+		// limit is comfortable today (~6KB) but a cert chain or larger key could
+		// exceed it and silently drop the event (bufio.ErrTooLong). Give ample
+		// headroom (1MB) so oversized-but-legitimate events still parse.
+		scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
 		var eventType string
 		var dataLines []string
 

--- a/services/bamf/api/agent_commands.py
+++ b/services/bamf/api/agent_commands.py
@@ -1,0 +1,44 @@
+"""Reliable API→agent command delivery.
+
+CONTRACT: this is the producer half of the API→agent command stream; the
+consumer is the SSE handler in ``routers/agents.py`` (which drains the same
+queue) and the Go agent in ``pkg/agent/sse.go`` / ``pkg/agent/agent.go``.
+
+Commands go to a short-lived per-instance Redis **list** (not fire-and-forget
+pub/sub). If a command is issued while the agent's SSE stream is momentarily down
+(exponential-backoff reconnect), it is not lost — it waits in the list, bounded
+by ``COMMAND_QUEUE_TTL_SECONDS``, and is delivered when the agent re-subscribes.
+The SSE handler drains via ``BLPOP``, giving exactly-once delivery to the single
+active consumer (no pub/sub duplicate-on-reconnect problem).
+
+Producers map ``command`` → SSE event type (``relay_connect``/``revoke``, else
+``tunnel_request``); the consumer switches on the event type and then the inner
+``command`` (``dial``/``redial``). Keep producer and consumer in sync.
+"""
+
+import json
+
+from redis import asyncio as aioredis
+
+# How long an undelivered command waits for a reconnecting agent. Sized above the
+# 30s tunnel-setup timeout with headroom: a command older than this is stale (the
+# client's connect attempt has already errored), so letting it expire is correct.
+COMMAND_QUEUE_TTL_SECONDS = 60
+
+
+def command_queue_key(agent_id: str, instance_id: str) -> str:
+    """Redis list key for an agent instance's command queue."""
+    return f"agent:{agent_id}:instance:{instance_id}:commands"
+
+
+async def enqueue_agent_command(
+    r: aioredis.Redis, agent_id: str, instance_id: str, payload: dict
+) -> None:
+    """Append a command to an agent instance's reliable delivery queue.
+
+    Refreshes the queue TTL on every push so an active tunnel-setup flow keeps
+    the queue alive; an idle queue expires and is garbage-collected.
+    """
+    key = command_queue_key(agent_id, instance_id)
+    await r.rpush(key, json.dumps(payload))
+    await r.expire(key, COMMAND_QUEUE_TTL_SECONDS)

--- a/services/bamf/api/bridge_relay.py
+++ b/services/bamf/api/bridge_relay.py
@@ -14,10 +14,10 @@ Relay connection lifecycle:
 from __future__ import annotations
 
 import asyncio
-import json
 
 import httpx
 
+from bamf.api.agent_commands import enqueue_agent_command
 from bamf.auth.ca import get_ca
 from bamf.config import settings
 from bamf.logging_config import get_logger
@@ -149,18 +149,17 @@ async def send_relay_connect(r, agent_id: str, bridge_id: str) -> None:
     # The agent may have joined with a previous CA — always send the current one.
     ca = get_ca()
 
-    # Route to the selected instance's channel
-    channel = f"agent:{agent_id}:instance:{instance_id}:commands"
-    await r.publish(
-        channel,
-        json.dumps(
-            {
-                "command": "relay_connect",
-                "bridge_host": bridge_host,
-                "bridge_port": bridge_port,
-                "ca_certificate": ca.ca_cert_pem,
-            }
-        ),
+    # Enqueue on the selected instance's reliable delivery queue.
+    await enqueue_agent_command(
+        r,
+        agent_id,
+        instance_id,
+        {
+            "command": "relay_connect",
+            "bridge_host": bridge_host,
+            "bridge_port": bridge_port,
+            "ca_certificate": ca.ca_cert_pem,
+        },
     )
 
     # Mark this instance as having a relay connection

--- a/services/bamf/api/routers/agents.py
+++ b/services/bamf/api/routers/agents.py
@@ -34,6 +34,7 @@ from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import StreamingResponse
 
+from bamf.api.agent_commands import command_queue_key, enqueue_agent_command
 from bamf.api.dependencies import (
     AgentIdentity,
     get_agent_identity,
@@ -588,14 +589,15 @@ async def delete_agent(
     agent_id_str = str(resolved_id)
     agent_name = agent.name
 
-    # Send revoke event to all instances via their instance-specific channels
-    revoke_payload = json.dumps({"command": "revoke", "reason": "Agent deleted by administrator"})
+    # Enqueue a revoke command on every instance's reliable delivery queue.
     instances = await r.hgetall(f"agent:{agent_id_str}:instances")
     if instances:
         for iid in instances:
-            await r.publish(
-                f"agent:{agent_id_str}:instance:{iid}:commands",
-                revoke_payload,
+            await enqueue_agent_command(
+                r,
+                agent_id_str,
+                iid,
+                {"command": "revoke", "reason": "Agent deleted by administrator"},
             )
 
     # Clear all Redis state for this agent
@@ -684,50 +686,43 @@ async def agent_events(
     """
     resolved_id, _ = await resolve_agent_id(agent_id, db)
     agent_id_str = str(resolved_id)
-    # Instance-specific channel for targeted command routing
-    channel = f"agent:{agent_id_str}:instance:{instance_id}:commands"
+    # Reliable per-instance command queue (drained via BLPOP). A command enqueued
+    # while this stream was down waits here (bounded by TTL) and is delivered on
+    # (re)connect — exactly-once, no fire-and-forget pub/sub loss.
+    queue_key = command_queue_key(agent_id_str, instance_id)
 
     async def event_generator() -> AsyncGenerator[str]:
         from bamf.api.app import shutdown_event
 
-        # Subscribe to the instance-specific command channel
-        pubsub = r.pubsub()
-        await pubsub.subscribe(channel)
+        keepalive_counter = 0
 
-        try:
-            keepalive_counter = 0
+        while not shutdown_event.is_set():
+            # Block up to 1s for the next queued command, then send a keepalive
+            # if none arrived within ~30s. BLPOP delivers immediately on enqueue.
+            popped = await r.blpop([queue_key], timeout=1)
 
-            while not shutdown_event.is_set():
-                # Check for pub/sub messages with 1s timeout, then send
-                # keepalive if no message arrived within 30s.
-                message = await pubsub.get_message(ignore_subscribe_messages=True, timeout=1.0)
-
-                if message and message["type"] == "message":
-                    data = message["data"]
-                    if isinstance(data, bytes):
-                        data = data.decode()
-                    # Determine SSE event type from the command field
-                    event_type = "tunnel_request"
-                    try:
-                        parsed = json.loads(data)
-                        cmd = parsed.get("command", "")
-                        if cmd == "relay_connect":
-                            event_type = "relay_connect"
-                        elif cmd == "revoke":
-                            event_type = "revoke"
-                    except json.JSONDecodeError, TypeError:
-                        logger.debug("Failed to parse SSE event type")
-                    yield f"event: {event_type}\ndata: {data}\n\n"
+            if popped is not None:
+                data = popped[1]
+                if isinstance(data, bytes):
+                    data = data.decode()
+                # Determine SSE event type from the command field
+                event_type = "tunnel_request"
+                try:
+                    cmd = json.loads(data).get("command", "")
+                    if cmd == "relay_connect":
+                        event_type = "relay_connect"
+                    elif cmd == "revoke":
+                        event_type = "revoke"
+                except json.JSONDecodeError, TypeError:
+                    logger.debug("Failed to parse SSE event type")
+                yield f"event: {event_type}\ndata: {data}\n\n"
+                keepalive_counter = 0
+            else:
+                keepalive_counter += 1
+                # Send heartbeat every ~30 iterations (30s at 1s poll)
+                if keepalive_counter >= 30:
+                    yield "event: heartbeat\ndata: {}\n\n"
                     keepalive_counter = 0
-                else:
-                    keepalive_counter += 1
-                    # Send heartbeat every ~30 iterations (30s at 1s poll)
-                    if keepalive_counter >= 30:
-                        yield "event: heartbeat\ndata: {}\n\n"
-                        keepalive_counter = 0
-        finally:
-            await pubsub.unsubscribe(channel)
-            await pubsub.close()
 
     return StreamingResponse(
         event_generator(),

--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -11,19 +11,21 @@ Consumers:
         POST /api/v1/connect — initiates web app proxy session
 
 Downstream effects:
-    This endpoint publishes a JSON command to a Redis pub/sub channel
-    agent:{agent_id}:instance:{instance_id}:commands (selected by
-    select_agent_instance). The SSE endpoint in agents.py delivers
-    this to the specific Go agent instance.
+    This endpoint enqueues a JSON command on a reliable per-instance Redis
+    list agent:{agent_id}:instance:{instance_id}:commands (via
+    agent_commands.enqueue_agent_command; instance selected by
+    select_agent_instance). The SSE endpoint in agents.py drains it (BLPOP)
+    and delivers it to the specific Go agent instance — surviving a brief
+    agent SSE reconnect rather than being lost like fire-and-forget pub/sub.
 
-    Pub/sub payload shape (new connection):
+    Command payload shape (new connection):
         {"command": "dial", "session_id": "...", "bridge_host": "...",
          "bridge_port": 443, "resource_name": "...", "resource_type": "ssh",
          "session_cert": "-----BEGIN CERTIFICATE-----...",
          "session_key": "-----BEGIN PRIVATE KEY-----...",
          "ca_certificate": "-----BEGIN CERTIFICATE-----..."}
 
-    Pub/sub payload shape (reconnect after bridge failure):
+    Command payload shape (reconnect after bridge failure):
         {"command": "redial", "session_id": "...", "bridge_host": "...",
          "bridge_port": 443, "resource_name": "...", "resource_type": "ssh",
          "session_cert": "-----BEGIN CERTIFICATE-----...",
@@ -48,6 +50,7 @@ import redis.asyncio as aioredis
 from fastapi import APIRouter, Depends, HTTPException, Request, status
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bamf.api.agent_commands import enqueue_agent_command
 from bamf.api.dependencies import get_current_user
 from bamf.api.models.connect import ConnectRequest, ConnectResponse
 from bamf.auth.ca import get_ca, serialize_certificate, serialize_private_key
@@ -524,23 +527,23 @@ async def _issue_session(
         agent_bridge_host = bridge_hostname
         agent_bridge_port = bridge_port
 
-    # Route command to the selected instance's channel
-    channel = f"agent:{agent_id}:instance:{instance_id}:commands"
-    await r.publish(
-        channel,
-        json.dumps(
-            {
-                "command": command,
-                "session_id": session_id,
-                "bridge_host": agent_bridge_host,
-                "bridge_port": agent_bridge_port,
-                "resource_name": resource_name,
-                "resource_type": resource_type,
-                "session_cert": serialize_certificate(agent_cert).decode(),
-                "session_key": serialize_private_key(agent_key).decode(),
-                "ca_certificate": ca.ca_cert_pem,
-            }
-        ),
+    # Enqueue the command on the selected instance's reliable delivery queue so
+    # it survives a brief agent SSE reconnect (see agent_commands).
+    await enqueue_agent_command(
+        r,
+        agent_id,
+        instance_id,
+        {
+            "command": command,
+            "session_id": session_id,
+            "bridge_host": agent_bridge_host,
+            "bridge_port": agent_bridge_port,
+            "resource_name": resource_name,
+            "resource_type": resource_type,
+            "session_cert": serialize_certificate(agent_cert).decode(),
+            "session_key": serialize_private_key(agent_key).decode(),
+            "ca_certificate": ca.ca_cert_pem,
+        },
     )
 
     # Increment instance tunnel count for load-balancing selection

--- a/services/tests/test_api/test_agent_commands.py
+++ b/services/tests/test_api/test_agent_commands.py
@@ -1,0 +1,35 @@
+"""Tests for reliable API→agent command delivery (agent_commands)."""
+
+import json
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from bamf.api.agent_commands import (
+    COMMAND_QUEUE_TTL_SECONDS,
+    command_queue_key,
+    enqueue_agent_command,
+)
+
+
+def test_command_queue_key():
+    assert command_queue_key("agent-1", "inst-9") == "agent:agent-1:instance:inst-9:commands"
+
+
+@pytest.mark.asyncio
+async def test_enqueue_rpushes_json_and_sets_ttl():
+    """A command is appended to the instance list (FIFO) with a refreshed TTL, so
+    it survives until an agent (re)connects and drains it."""
+    r = MagicMock()
+    r.rpush = AsyncMock()
+    r.expire = AsyncMock()
+
+    payload = {"command": "dial", "session_id": "s1"}
+    await enqueue_agent_command(r, "agent-1", "inst-9", payload)
+
+    key = "agent:agent-1:instance:inst-9:commands"
+    r.rpush.assert_awaited_once()
+    args = r.rpush.call_args.args
+    assert args[0] == key
+    assert json.loads(args[1]) == payload  # serialized, round-trips
+    r.expire.assert_awaited_once_with(key, COMMAND_QUEUE_TTL_SECONDS)


### PR DESCRIPTION
Closes #140.

## Command loss on reconnect (the main defect)
The API→agent command stream used fire-and-forget Redis **pub/sub**. A `dial`/`redial`/`relay_connect`/`revoke` published while the agent's SSE was briefly down (exponential-backoff reconnect) was **dropped with no redelivery** — the tunnel hung until the 30s setup timeout even though the agent was healthy.

Replaced pub/sub with a short-lived **per-instance Redis list drained via BLPOP**:
- New `agent_commands.enqueue_agent_command` (RPUSH + 60s TTL); producers in `connect.py` (dial/redial), `bridge_relay.py` (relay_connect), and `agents.py` (revoke) all use it.
- The SSE handler drains via `BLPOP` — **exactly-once** delivery to the single active consumer, and a command enqueued while disconnected **waits (TTL-bounded) and is delivered on reconnect**. No pub/sub duplicate-on-reconnect problem.

## SSE scanner buffer (latent)
Gave the agent's `bufio.Scanner` 1MB headroom (was the default 64KB) — a `tunnel_request` inlines three PEM blocks, and a future cert chain/larger key could trip `bufio.ErrTooLong` and silently drop the event.

## Contract
Added a `CONTRACT:` marker on the producer (`agent_commands.py`) documenting the command-type→event-type mapping shared with `pkg/agent/sse.go`/`agent.go` (registry consolidation is #125).

## Verification
- Unit tests (`test_agent_commands.py`): enqueue does RPUSH + EXPIRE; key format.
- `make test-python` (1042) / `test-go` / both lints pass.
- **Live on the dev stack**: BLPOP/RPUSH round-trip confirmed; the agent reconnects over the new BLPOP SSE handler, heartbeats 200, and an enqueued `dial` is received and processed (`received tunnel request command=dial`).