### PR TITLE
fix(helm): drop the agent's inapplicable preStop hook

### DIFF
--- a/helm/bamf/templates/deployment-agent.yaml
+++ b/helm/bamf/templates/deployment-agent.yaml
@@ -96,12 +96,10 @@ spec:
               port: 8081
             initialDelaySeconds: 5
             periodSeconds: 5
-          {{- if .Values.agent.preStopSleepSeconds }}
-          lifecycle:
-            preStop:
-              exec:
-                command: ["sleep", "{{ .Values.agent.preStopSleepSeconds }}"]
-          {{- end }}
+          {{- /* No preStop hook: the agent image is FROM scratch (no `sleep`),
+                 and the agent is an outbound-only client (SSE to the API, dials
+                 bridges on demand) with no inbound Service to drain. Graceful
+                 shutdown is the agent's SIGTERM handler + terminationGracePeriodSeconds. */}}
           volumeMounts:
             - name: config
               mountPath: /etc/bamf-agent

--- a/helm/bamf/values.schema.json
+++ b/helm/bamf/values.schema.json
@@ -587,7 +587,6 @@
         },
         "dataDir": { "type": "string" },
         "terminationGracePeriodSeconds": { "type": "integer", "minimum": 0 },
-        "preStopSleepSeconds": { "type": "integer", "minimum": 0 },
         "podAnnotations": { "type": "object" },
         "podLabels": { "type": "object" },
         "priorityClassName": { "type": "string" },

--- a/helm/bamf/values.yaml
+++ b/helm/bamf/values.yaml
@@ -561,9 +561,6 @@ agent:
   # to finish naturally. 30 min covers most interactive sessions.
   terminationGracePeriodSeconds: 1800
 
-  # Pre-stop sleep to allow in-flight heartbeats to complete
-  preStopSleepSeconds: 5
-
   podAnnotations: {}
   podLabels: {}
   priorityClassName: ""


### PR DESCRIPTION
Closes #146.

`deployment-agent.yaml` rendered `lifecycle.preStop.exec: ["sleep", N]`, but the agent image is `FROM scratch` (no shell / no `sleep`), so the kubelet fails the hook (`FailedPreStopHook`) and goes straight to SIGTERM. The agent is also an **outbound-only** client (SSE to the API, dials bridges on demand) with no inbound Service to drain — the preStop-drain rationale doesn't apply.

Removed the preStop block + the agent's `preStopSleepSeconds` from values and schema. Graceful shutdown remains the agent's SIGTERM handler + `terminationGracePeriodSeconds`. The pattern stays intact for the traffic-serving pods (api/web/proxy/bridge).

Verified: `helm lint` clean, schema valid, agent renders with no `lifecycle`/`preStop`, all topologies render.