### PR TITLE
fix(bridge): evict pending session when a connection handler panics

### DIFF
--- a/pkg/bridge/server.go
+++ b/pkg/bridge/server.go
@@ -918,6 +918,21 @@ func (s *Server) handleTunnelConnection(ctx context.Context, conn net.Conn) {
 	s.pendingConns[sessionID] = pc
 	s.pendingConnsMu.Unlock()
 
+	// If this handler panics after registering (the outer recover can't see
+	// sessionID), our own select-timeout cleanup never runs, so the pending
+	// entry would leak until the peer matches — or forever if it never arrives.
+	// Recover here and evict it. On the normal path recover() is nil, so this is
+	// a no-op; after a successful match the entry is already gone (cleanupPending
+	// is idempotent).
+	defer func() {
+		if r := recover(); r != nil {
+			s.logger.Error("panic in tunnel handler after pending registration",
+				"session_id", shortID(sessionID), "panic", r)
+			s.cleanupPending(sessionID)
+			conn.Close()
+		}
+	}()
+
 	s.logger.Debug("connection waiting for match",
 		"protocol", protocol,
 		"session_id", shortID(sessionID),

--- a/pkg/bridge/server_test.go
+++ b/pkg/bridge/server_test.go
@@ -108,3 +108,22 @@ func TestBridgePinMatches(t *testing.T) {
 		})
 	}
 }
+
+// TestCleanupPendingIdempotent covers the safety the panic-recovery cleanup
+// relies on: evicting a pending session is a no-op when it's missing or already
+// matched, so calling it from a deferred recover can't corrupt state.
+func TestCleanupPendingIdempotent(t *testing.T) {
+	s := &Server{pendingConns: make(map[string]*pendingConnection)}
+
+	// Cleaning a session that was never registered is safe.
+	s.cleanupPending("never-registered")
+
+	// Register, clean once → gone.
+	s.pendingConns["sess"] = &pendingConnection{sessionID: "sess"}
+	s.cleanupPending("sess")
+	require.NotContains(t, s.pendingConns, "sess")
+
+	// Cleaning again (e.g. after a match already deleted it) is still safe.
+	s.cleanupPending("sess")
+	require.Empty(t, s.pendingConns)
+}


### PR DESCRIPTION
Closes #162.

The per-connection `recover()` from #151 closes the conn but can't clean up pending state — `sessionID` isn't known at that outer scope. If a handler panics **after** registering in `pendingConns`, its own select-timeout cleanup never runs, so the entry leaks until the peer matches (or forever if it never arrives; a stream of malformed certs could accumulate entries).

Added a panic-only deferred cleanup right after registration: recover, evict the pending entry, close the conn. No-op on the normal path (`recover()` is nil), and safe after a successful match (`cleanupPending` is idempotent — a new `TestCleanupPendingIdempotent` covers that). `make test-go` + `lint-go` pass.