### PR TITLE
feat(revocation): push revoke to a revoked agent + commit before Redis

### DIFF
--- a/services/bamf/api/routers/certificates.py
+++ b/services/bamf/api/routers/certificates.py
@@ -1,8 +1,11 @@
 """Certificates router for CA operations."""
 
+import redis.asyncio as aioredis
 from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy import select
 from sqlalchemy.ext.asyncio import AsyncSession
 
+from bamf.api.agent_commands import enqueue_agent_command
 from bamf.api.dependencies import (
     get_current_session,
     require_admin,
@@ -17,15 +20,35 @@ from bamf.api.models.certificates import (
     UserCertificateResponse,
 )
 from bamf.auth.ca import get_ca, serialize_certificate, serialize_private_key
-from bamf.auth.revocation import list_revoked_certificates, revoke_certificate
+from bamf.auth.revocation import (
+    add_revoked_to_redis,
+    list_revoked_certificates,
+    record_revocation,
+)
 from bamf.auth.sessions import Session
-from bamf.db.models import utc_now
+from bamf.db.models import Agent, utc_now
 from bamf.db.session import get_db
 from bamf.logging_config import get_logger
+from bamf.redis.client import get_redis
 from bamf.services.audit_service import log_audit_event
 
 router = APIRouter(prefix="/certificates", tags=["certificates"])
 logger = get_logger(__name__)
+
+
+async def _notify_revoked_agent(db: AsyncSession, r: aioredis.Redis, fingerprint: str) -> None:
+    """If the revoked fingerprint belongs to an agent, tell its live instances to
+    shut down now (via the reliable command queue) instead of running until their
+    next API call is rejected with 401."""
+    result = await db.execute(select(Agent).where(Agent.certificate_fingerprint == fingerprint))
+    agent = result.scalar_one_or_none()
+    if agent is None:
+        return  # bridge/user cert, or an unknown fingerprint — nothing to notify
+    instances = await r.hgetall(f"agent:{agent.id}:instances")
+    for iid in instances or {}:
+        await enqueue_agent_command(
+            r, str(agent.id), iid, {"command": "revoke", "reason": "Certificate revoked"}
+        )
 
 
 @router.get("/ca", response_model=CACertificateResponse)
@@ -101,6 +124,7 @@ async def issue_service_certificate(
 async def revoke_certificate_endpoint(
     body: RevokeCertificateRequest,
     db: AsyncSession = Depends(get_db),
+    r: aioredis.Redis = Depends(get_redis),
     current_user: Session = Depends(require_admin),
 ) -> RevokedCertificateResponse:
     """Revoke a certificate by fingerprint (admin).
@@ -108,12 +132,17 @@ async def revoke_certificate_endpoint(
     Durable (Postgres) + enforced at the API cert-auth layer for agent/bridge
     certs. Tunnel session certs are 30s TTL and won't be re-minted for a revoked
     identity, so the bridge keeps its zero-runtime-dependency design.
+
+    Ordering: the DB row is committed BEFORE the Redis denylist add, so a rolled
+    back transaction can't leave a Redis entry Postgres doesn't have. If the
+    fingerprint belongs to an agent, its live instances are told to shut down
+    promptly rather than waiting to be 401'd on their next call.
     """
     if not body.fingerprint:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST, detail="fingerprint is required"
         )
-    await revoke_certificate(
+    fingerprint = await record_revocation(
         db, body.fingerprint, reason=body.reason, revoked_by=current_user.email
     )
     await log_audit_event(
@@ -123,12 +152,16 @@ async def revoke_certificate_endpoint(
         actor_type="user",
         actor_id=current_user.email,
         target_type="certificate",
-        target_id=body.fingerprint,
+        target_id=fingerprint,
         success=True,
         details={"reason": body.reason},
     )
+    # Commit the durable revocation before touching Redis / agents.
+    await db.commit()
+    await add_revoked_to_redis(r, fingerprint)
+    await _notify_revoked_agent(db, r, fingerprint)
     return RevokedCertificateResponse(
-        fingerprint=body.fingerprint,
+        fingerprint=fingerprint,
         revoked_at=utc_now(),
         reason=body.reason,
         revoked_by=current_user.email,

--- a/services/bamf/auth/revocation.py
+++ b/services/bamf/auth/revocation.py
@@ -50,14 +50,19 @@ async def is_certificate_revoked(fingerprint: str) -> bool:
         return False
 
 
-async def revoke_certificate(
+async def record_revocation(
     db: AsyncSession,
     fingerprint: str,
     reason: str | None = None,
     revoked_by: str | None = None,
     subject_cn: str | None = None,
-) -> None:
-    """Add a certificate fingerprint to the durable denylist and the Redis set."""
+) -> str:
+    """Insert a revocation row (idempotent). Returns the normalized fingerprint.
+
+    DB-only — does NOT touch Redis, so a caller can commit the transaction first
+    and only then publish to the enforcement set (add_revoked_to_redis), avoiding
+    a Redis entry that outlives a rolled-back DB write.
+    """
     fingerprint = _normalize_fingerprint(fingerprint)
     if await db.get(RevokedCertificate, fingerprint) is None:
         db.add(
@@ -70,8 +75,28 @@ async def revoke_certificate(
             )
         )
         await db.flush()
-    redis = get_redis_client()
-    await redis.sadd(_REVOKED_SET, fingerprint)
+    return fingerprint
+
+
+async def add_revoked_to_redis(r, fingerprint: str) -> None:
+    """Add a fingerprint to the Redis enforcement denylist set."""
+    await r.sadd(_REVOKED_SET, _normalize_fingerprint(fingerprint))
+
+
+async def revoke_certificate(
+    db: AsyncSession,
+    fingerprint: str,
+    reason: str | None = None,
+    revoked_by: str | None = None,
+    subject_cn: str | None = None,
+) -> None:
+    """Add a certificate fingerprint to the durable denylist and the Redis set.
+
+    Convenience combining record_revocation + add_revoked_to_redis for callers
+    that don't need to control commit ordering.
+    """
+    fingerprint = await record_revocation(db, fingerprint, reason, revoked_by, subject_cn)
+    await add_revoked_to_redis(get_redis_client(), fingerprint)
     logger.info("certificate revoked", fingerprint=fingerprint[:16], revoked_by=revoked_by)
 
 

--- a/services/tests/test_api/test_certificates_router.py
+++ b/services/tests/test_api/test_certificates_router.py
@@ -184,9 +184,12 @@ class TestIssueServiceCertificate:
 
 def _revoke_app(session: Session) -> FastAPI:
     """Build an app that runs the REAL require_admin/require_admin_or_audit
-    gates against the given session, with a fake DB and no real Redis/PG."""
+    gates against the given session, with a fake DB + Redis (no real PG/Redis)."""
+    from unittest.mock import AsyncMock
+
     from bamf.api.dependencies import get_current_session as real_get_current_session
     from bamf.db.session import get_db
+    from bamf.redis.client import get_redis
 
     app = FastAPI()
     app.include_router(router, prefix="/api/v1")
@@ -195,12 +198,14 @@ def _revoke_app(session: Session) -> FastAPI:
         return session
 
     async def override_db():
-        from unittest.mock import AsyncMock
-
         yield AsyncMock()
+
+    async def override_redis():
+        return AsyncMock()
 
     app.dependency_overrides[real_get_current_session] = override_session
     app.dependency_overrides[get_db] = override_db
+    app.dependency_overrides[get_redis] = override_redis
     return app
 
 
@@ -208,29 +213,36 @@ async def _revoke_client(app: FastAPI) -> AsyncClient:
     return AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
 
 
+def _patch_revoke_internals():
+    """Patch the revoke endpoint's collaborators (DB record, Redis add, agent
+    notify, audit) so the tests exercise routing/RBAC/errors, not real IO."""
+    from unittest.mock import AsyncMock
+
+    return (
+        patch(
+            "bamf.api.routers.certificates.record_revocation",
+            new_callable=AsyncMock,
+            return_value="aabbcc",
+        ),
+        patch("bamf.api.routers.certificates.add_revoked_to_redis", new_callable=AsyncMock),
+        patch("bamf.api.routers.certificates._notify_revoked_agent", new_callable=AsyncMock),
+        patch("bamf.api.routers.certificates.log_audit_event", new_callable=AsyncMock),
+    )
+
+
 class TestRevokeCertificate:
     @pytest.mark.asyncio
     async def test_admin_can_revoke(self):
-        from unittest.mock import AsyncMock
-
         app = _revoke_app(ADMIN_SESSION)
+        p_record, p_redis, p_notify, p_audit = _patch_revoke_internals()
         async with await _revoke_client(app) as client:
-            with (
-                patch(
-                    "bamf.api.routers.certificates.revoke_certificate",
-                    new_callable=AsyncMock,
-                ) as mock_revoke,
-                patch(
-                    "bamf.api.routers.certificates.log_audit_event",
-                    new_callable=AsyncMock,
-                ),
-            ):
+            with p_record as mock_record, p_redis, p_notify, p_audit:
                 resp = await client.post(
                     "/api/v1/certificates/revoke",
                     json={"fingerprint": "aa:bb:cc", "reason": "leaked"},
                 )
         assert resp.status_code == 200
-        mock_revoke.assert_awaited_once()
+        mock_record.assert_awaited_once()
 
     @pytest.mark.asyncio
     async def test_non_admin_forbidden(self):
@@ -244,20 +256,10 @@ class TestRevokeCertificate:
 
     @pytest.mark.asyncio
     async def test_empty_fingerprint_rejected(self):
-        from unittest.mock import AsyncMock
-
         app = _revoke_app(ADMIN_SESSION)
+        p_record, p_redis, p_notify, p_audit = _patch_revoke_internals()
         async with await _revoke_client(app) as client:
-            with (
-                patch(
-                    "bamf.api.routers.certificates.revoke_certificate",
-                    new_callable=AsyncMock,
-                ),
-                patch(
-                    "bamf.api.routers.certificates.log_audit_event",
-                    new_callable=AsyncMock,
-                ),
-            ):
+            with p_record, p_redis, p_notify, p_audit:
                 resp = await client.post(
                     "/api/v1/certificates/revoke",
                     json={"fingerprint": ""},
@@ -296,3 +298,52 @@ class TestListRevokedCertificates:
         async with await _revoke_client(app) as client:
             resp = await client.get("/api/v1/certificates/revoked")
         assert resp.status_code == 403
+
+
+class TestNotifyRevokedAgent:
+    """Revoking an agent cert pushes a revoke command to its live instances so it
+    shuts down promptly; a non-agent fingerprint is a no-op."""
+
+    @pytest.mark.asyncio
+    async def test_notifies_each_agent_instance(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from bamf.api.routers.certificates import _notify_revoked_agent
+
+        agent = MagicMock()
+        agent.id = "agent-uuid"
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=agent)
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=result)
+        r = MagicMock()
+        r.hgetall = AsyncMock(return_value={"inst-a": "x", "inst-b": "y"})
+
+        with patch(
+            "bamf.api.routers.certificates.enqueue_agent_command", new_callable=AsyncMock
+        ) as enq:
+            await _notify_revoked_agent(db, r, "aabbcc")
+
+        assert enq.await_count == 2  # one revoke per live instance
+        assert all(call.args[3]["command"] == "revoke" for call in enq.await_args_list)
+
+    @pytest.mark.asyncio
+    async def test_noop_when_fingerprint_is_not_an_agent(self):
+        from unittest.mock import AsyncMock, MagicMock
+
+        from bamf.api.routers.certificates import _notify_revoked_agent
+
+        result = MagicMock()
+        result.scalar_one_or_none = MagicMock(return_value=None)  # bridge/user cert
+        db = AsyncMock()
+        db.execute = AsyncMock(return_value=result)
+        r = MagicMock()
+        r.hgetall = AsyncMock()
+
+        with patch(
+            "bamf.api.routers.certificates.enqueue_agent_command", new_callable=AsyncMock
+        ) as enq:
+            await _notify_revoked_agent(db, r, "aabbcc")
+
+        enq.assert_not_awaited()
+        r.hgetall.assert_not_awaited()


### PR DESCRIPTION
Closes #161 (v0.7.0 revocation follow-ups).

## 1. Prompt shutdown
`POST /certificates/revoke` now looks up whether the fingerprint belongs to an agent (`Agent.certificate_fingerprint`) and, if so, enqueues a `revoke` command to each of its live instances via the reliable command queue (#140) — so the agent shuts down promptly instead of running until its next API call is 401'd. Non-agent fingerprints (bridge/user certs) are a no-op.

## 2. Write ordering
Split `revoke_certificate` into `record_revocation` (DB only) + `add_revoked_to_redis`. The endpoint **commits the durable row before** touching the Redis enforcement set, so a rolled-back transaction can't leave a Redis entry Postgres lacks. `revoke_certificate` stays as a combined convenience for other callers.

## Tests
- `_notify_revoked_agent`: one `revoke` enqueued per live instance; no-op for a non-agent fingerprint.
- Revoke-endpoint RBAC/error tests updated for the new collaborators (record/add/notify/audit) + a mocked Redis dependency.
- `make test-python` 1044 passed; `lint-python` clean. Delivery path (queue→SSE→agent) already verified live in #140.