### PR TITLE
ci: add per-job timeouts and a Next.js prerender build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
   prepare:
     name: Prepare
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       packages: read
@@ -88,6 +89,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/lint.sh go
@@ -97,6 +99,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/test.sh go
@@ -106,6 +109,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/build.sh binaries
@@ -115,6 +119,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/security-scan.sh go
@@ -125,6 +130,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/lint.sh python
@@ -134,6 +140,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/test.sh python
@@ -143,6 +150,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/security-scan.sh python
@@ -153,15 +161,24 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/lint.sh web
+      # AGENTS.md requires `npm run build` for web changes — the Next.js
+      # prerender catches breakage that eslint + tsc do not.
+      - name: Next.js build (prerender check)
+        working-directory: web
+        run: |
+          npm ci
+          npm run build
 
   web-audit:
     name: npm Audit
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: node:25-alpine
     defaults:
       run:
@@ -179,6 +196,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - name: Helm lint (containerized)
@@ -207,6 +225,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       security-events: write
@@ -242,6 +261,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     container: zricethezav/gitleaks:latest
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -253,6 +273,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       security-events: write
@@ -290,6 +311,7 @@ jobs:
     name: Dependency Review
     if: github.event_name == 'pull_request'
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: write
@@ -307,6 +329,7 @@ jobs:
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ${{ matrix.arch == 'arm64' && 'ubuntu-24.04-arm' || 'ubuntu-latest' }}
+    timeout-minutes: 30
     permissions:
       contents: read
       packages: write
@@ -360,6 +383,7 @@ jobs:
       && needs.build-images.result == 'success'
       && needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     permissions:
       contents: read
       packages: read
@@ -422,6 +446,7 @@ jobs:
       && needs.prepare.outputs.is_pr != 'true'
       && !contains(needs.*.result, 'failure')
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: read
       packages: write
@@ -455,6 +480,7 @@ jobs:
       && needs.prepare.result == 'success'
       && (needs.create-manifests.result == 'success' || needs.create-manifests.result == 'skipped')
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     permissions:
       contents: write
       packages: write
@@ -592,6 +618,7 @@ jobs:
       && needs.prepare.outputs.is_tag == 'true'
       && (needs.build-images.result == 'failure' || needs.scan-images.result == 'failure' || needs.create-manifests.result == 'failure' || needs.release.result == 'failure')
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     permissions:
       contents: write
     steps:
@@ -631,6 +658,7 @@ jobs:
       - create-manifests
       - release
     runs-on: ubuntu-latest
+    timeout-minutes: 10
     steps:
       - name: Check results
         run: |


### PR DESCRIPTION
Addresses part of #127 (CI hardening).

- **Per-job `timeout-minutes`** — every one of the 21 jobs now has a ceiling (was **zero** across the workflow, so a hung job could burn the 6h default × the whole matrix). Lint/test 15–20, image builds 30, release 25, gates 10.
- **`npm run build` in web-lint** — the Next.js prerender that AGENTS.md requires for web changes; catches breakage eslint + `tsc` miss (exactly how I caught the postcss build earlier).

Verified: workflow YAML parses; all jobs carry a timeout.

Remaining #127 items stay open: migration-check job, helm config-contract enforcement (the Pydantic-model render check), Web E2E job, GHCR-login retry, and the `ci-pass` skip-counts-as-pass fix.