### PR TITLE
refactor(api): break the app↔agents import cycle (CodeQL py/cyclic-import)

### DIFF
--- a/services/bamf/api/app.py
+++ b/services/bamf/api/app.py
@@ -15,15 +15,15 @@ from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 
+# Shutdown event lives in a leaf module so routers can import it without an
+# app → routers → app import cycle. Re-exported here for existing references.
+from bamf.api.lifecycle import shutdown_event
 from bamf.auth.ca import init_ca
 from bamf.auth.connectors import init_connectors
 from bamf.config import settings
 from bamf.db.session import close_db, init_db
 from bamf.logging_config import configure_logging, get_logger
 from bamf.redis.client import close_redis, init_redis
-
-# Shutdown event — SSE generators check this to close promptly during shutdown.
-shutdown_event = asyncio.Event()
 
 from .health import router as health_router
 from .routers.agents import router as agents_router

--- a/services/bamf/api/lifecycle.py
+++ b/services/bamf/api/lifecycle.py
@@ -1,0 +1,12 @@
+"""Process-lifecycle signals shared across the app and routers.
+
+A leaf module by design: it imports nothing from ``bamf.api.app`` or the routers,
+so importing it from a router does not create an import cycle (app → routers →
+app). The lifespan handler sets ``shutdown_event`` on SIGTERM; long-lived SSE
+generators check it to close promptly during shutdown.
+"""
+
+import asyncio
+
+# Set by the FastAPI lifespan on shutdown; watched by SSE generators.
+shutdown_event = asyncio.Event()

--- a/services/bamf/api/routers/agents.py
+++ b/services/bamf/api/routers/agents.py
@@ -41,6 +41,7 @@ from bamf.api.dependencies import (
     require_admin,
     require_admin_or_audit,
 )
+from bamf.api.lifecycle import shutdown_event
 from bamf.api.models.agents import (
     AgentRegisterRequest,
     AgentRegisterResponse,
@@ -692,8 +693,6 @@ async def agent_events(
     queue_key = command_queue_key(agent_id_str, instance_id)
 
     async def event_generator() -> AsyncGenerator[str]:
-        from bamf.api.app import shutdown_event
-
         keepalive_counter = 0
 
         while not shutdown_event.is_set():


### PR DESCRIPTION
Resolves code-scanning alert **#155** (`py/cyclic-import`).

The agent SSE handler did a deferred `from bamf.api.app import shutdown_event`, which CodeQL flagged as an `app → routers.agents → app` cycle. Moved `shutdown_event` into a **leaf module** (`bamf.api.lifecycle`) that imports nothing from app/routers; `app.py` re-exports it and `agents.py` imports it at top level. No runtime behavior change — `make test-python` 1044 pass, `lint-python` clean.