### PR TITLE
ci: add a migration-check job (broken migrations no longer merge green)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -145,6 +145,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/test.sh python
 
+  # A broken Alembic migration otherwise merges green (CI never ran it). This
+  # runs the full upgrade → downgrade base → upgrade round-trip against Postgres.
+  migration-check:
+    name: Migration Check
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - run: scripts/test.sh migrations
+
   python-security:
     name: Python Security (pip-audit)
     needs: prepare
@@ -444,6 +456,7 @@ jobs:
       - go-security
       - python-lint
       - python-test
+      - migration-check
       - python-security
       - web-lint
       - helm-lint
@@ -656,6 +669,7 @@ jobs:
       - go-security
       - python-lint
       - python-test
+      - migration-check
       - python-security
       - web-lint
       - web-build
@@ -682,6 +696,7 @@ jobs:
             "${{ needs.go-security.result }}"
             "${{ needs.python-lint.result }}"
             "${{ needs.python-test.result }}"
+            "${{ needs.migration-check.result }}"
             "${{ needs.python-security.result }}"
             "${{ needs.web-lint.result }}"
             "${{ needs.web-build.result }}"

--- a/Makefile
+++ b/Makefile
@@ -14,6 +14,7 @@
 	pentest pentest-dast pentest-images pentest-sast \
 	clean clean-cache test-down \
 	db-migrate db-rollback db-reset proto \
+	migration-check \
 	help
 
 # ── Variables (for build-local only) ─────────────────────
@@ -48,6 +49,9 @@ test-go:            ## Test Go only (Docker)
 
 test-python:        ## Test Python only (Docker)
 	scripts/test.sh python
+
+migration-check:    ## Alembic upgrade→downgrade→upgrade round-trip (Docker)
+	scripts/test.sh migrations
 
 # ── Build ─────────────────────────────────────────────────
 build:              ## Cross-compile Go binaries for all platforms (Docker)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -43,3 +43,16 @@ services:
     image: ${TEST_IMAGE:-bamf-test:local}
     command: >
       sh -c "ruff check . && ruff format --check ."
+
+  # Migration round-trip: upgrade to head, downgrade ALL the way to base (exercises
+  # every downgrade()), then upgrade again (idempotency). A broken up/down fails.
+  migrate:
+    image: ${TEST_IMAGE:-bamf-test:local}
+    working_dir: /app/alembic
+    environment:
+      DATABASE_URL: "postgresql+asyncpg://bamf:bamf-test@postgres:5432/bamf_test"
+    command: >
+      sh -c "alembic upgrade head && alembic downgrade base && alembic upgrade head"
+    depends_on:
+      postgres:
+        condition: service_healthy

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -19,19 +19,29 @@ test_python() {
   success "Python tests passed"
 }
 
+test_migrations() {
+  info "Checking Alembic migrations (upgrade → downgrade base → upgrade)..."
+  ensure_test_image
+  docker compose -f "$REPO_ROOT/docker-compose.test.yml" run --rm migrate
+  docker compose -f "$REPO_ROOT/docker-compose.test.yml" down -v >/dev/null 2>&1 || true
+  success "Migrations round-trip cleanly"
+}
+
 target="${1:-all}"
 
 case "$target" in
-  go)     test_go ;;
-  python) test_python ;;
+  go)         test_go ;;
+  python)     test_python ;;
+  migrations) test_migrations ;;
   all)
     test_go
     test_python
+    test_migrations
     success "All tests passed"
     ;;
   *)
     error "Unknown target: $target"
-    echo "Usage: $0 [go|python|all]"
+    echo "Usage: $0 [go|python|migrations|all]"
     exit 1
     ;;
 esac


### PR DESCRIPTION
Addresses the migration-check item of #127.

CI never ran Alembic, so a migration with a broken \`upgrade()\` or a missing/broken \`downgrade()\` merged **green**. Adds:
- a **migrate** service in \`docker-compose.test.yml\` that runs the full round-trip against Postgres: \`upgrade head → downgrade base → upgrade head\` (exercises every downgrade + idempotency);
- \`scripts/test.sh migrations\` + \`make migration-check\`;
- a CI **migration-check** job wired into \`ci-pass\` **and** \`create-manifests\` needs, so a broken migration also blocks the release path.

Verified locally — the round-trip runs all 9 migrations up and down cleanly.