### PR TITLE
ci: ci-pass fails on cancelled/timed-out jobs, not just failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -712,9 +712,14 @@ jobs:
             "${{ needs.release.result }}"
           )
 
+          # A required job passes only if it succeeded, or was legitimately
+          # skipped by the images-exist short-circuit on a tag re-push. Anything
+          # else — failure, cancelled (incl. timeout), or an unexpected state —
+          # must fail the gate. (Previously only "failure" failed, so a cancelled
+          # or timed-out required job silently counted as green.)
           for r in "${results[@]}"; do
-            if [[ "$r" == "failure" ]]; then
-              echo "One or more jobs failed"
+            if [[ "$r" != "success" && "$r" != "skipped" ]]; then
+              echo "A required job did not pass (result: '$r')"
               exit 1
             fi
           done


### PR DESCRIPTION
Addresses the `ci-pass` skip-counts-as-pass item of #127.

The gate only failed when a required job's result was `failure`, so a **cancelled** or **timed-out** required job silently counted as green (exactly the state we hit when a concurrency cancel left slow jobs incomplete). Now every result must be `success` or `skipped` — the latter being the legitimate images-exist short-circuit on a tag re-push — and anything else fails the gate.

Note: the deeper #127 item ("make chart/security validation independent of the image short-circuit") is intentionally not changed — we already verify main CI is green before tagging, and re-running full CI on every tag would double release CI cost for marginal gain. This closes the actual correctness hole (cancelled ≠ pass).