### PR TITLE
feat(contracts): golden-fixture guard for the list-envelope + contract registry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -164,6 +164,24 @@ Routing rules of thumb:
 - A **behaviour-changing fix for a reported bug** → a regression test named
   after the failure mode that fails pre-fix and passes after.
 
+## Cross-component contract registry
+
+Every cross-language coupling below is joined by **hand-copied string literals**
+across Go/Python/TS that are tested in isolation — so a test can stay green while
+encoding a contract the peer never honored (this shipped two live bugs: the
+`bamf agents` / `bamf tokens list` envelope drift). When you touch one side of a
+row, update the other side **and** its guard. Add a `CONTRACT:` comment at each
+boundary pointing at the peer.
+
+| Contract | Sides (file:line) | Kept in sync by |
+|---|---|---|
+| **List-envelope** `CursorPage{items,next_cursor,has_more}` | producer `services/bamf/api/models/common.py` (`CursorPage`) ↔ CLI `cmd/bamf/cmd/agents.go`, `tokens.go` (`Items` structs) | **Golden fixture** `services/tests/contracts/agents_list.json` — validated by `services/tests/test_api/test_contract_fixtures.py` (producer) **and** `cmd/bamf/cmd/contract_test.go` (consumer). A key/field drift fails both. |
+| **Session-cert SAN URIs** (`bamf://session|resource|bridge|role|type`) | issued `services/bamf/auth/ca.py` (`issue_session_certificate`) ↔ parsed `pkg/bridge/server.go` (`extractSessionInfo`) | Go table tests in `pkg/bridge/server_test.go` (`TestExtractSessionInfo`); keep the 5-URI set in sync. *(Golden-cert fixture: TODO.)* |
+| **Agent SSE command set** (`dial`/`redial`/`relay_connect`/`revoke` → event type) | producer `services/bamf/api/agent_commands.py`, `routers/agents.py` ↔ consumer `pkg/agent/sse.go`, `agent.go` | `CONTRACT:` markers on `agent_commands.py`; producer maps `command`→event, consumer switches on it. *(Guard: TODO.)* |
+| **Helm values ↔ schema ↔ templates** | `helm/bamf/values.yaml` ↔ `values.schema.json` ↔ `templates/` | `helm lint` (schema `additionalProperties:false`) + the 4-topology render matrix in CI. |
+| **Redis key schemas** | scattered f-strings across `services/bamf/**` | *(TODO: a `bamf/redis_keys.py` builder module + an introspection test banning raw `f"session:{`/`f"bridge:{` literals. Note `session:{id}` (tunnel) vs `bamf:session:{token}` (user session) are distinct — merging them would be catastrophic.)* |
+| **proto ↔ `pkg/pb/`** | `proto/` ↔ generated `pkg/pb/` | *(TODO: `make proto` regenerate-and-diff, or delete if orphaned.)* |
+
 ## Conventions
 
 - **Issue-first** — every change beyond a genuinely trivial tweak (typo,

--- a/cmd/bamf/cmd/agents.go
+++ b/cmd/bamf/cmd/agents.go
@@ -86,7 +86,10 @@ func runAgents(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("API error: %s", resp.Status)
 	}
 
-	// The API paginates list endpoints with a CursorPage envelope: {"items":[...]}.
+	// CONTRACT: the API paginates list endpoints with a CursorPage envelope
+	// ({"items":[...]}, services/bamf/api/models/common.py). Decoding any other
+	// key silently yields an empty list (was bug #120). Guarded by the golden
+	// fixture in contract_test.go / services/tests/contracts/agents_list.json.
 	var result struct {
 		Items []agent `json:"items"`
 	}

--- a/cmd/bamf/cmd/contract_test.go
+++ b/cmd/bamf/cmd/contract_test.go
@@ -1,0 +1,45 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// contractFixture reads a golden fixture shared with the Python producer tests
+// (services/tests/contracts/). The same committed file both sides validate IS
+// the contract — see services/tests/test_api/test_contract_fixtures.py.
+func contractFixture(t *testing.T, name string) []byte {
+	t.Helper()
+	// `go test` runs with the working dir set to the package dir
+	// (cmd/bamf/cmd); the repo root is three levels up.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	root := filepath.Join(wd, "..", "..", "..")
+	data, err := os.ReadFile(filepath.Join(root, "services", "tests", "contracts", name))
+	require.NoError(t, err, "shared contract fixture must exist")
+	return data
+}
+
+// TestAgentsListEnvelopeContract guards the API↔CLI list-envelope contract: the
+// CLI must decode the CursorPage "items" envelope and the item fields it uses.
+// This is exactly the guard the "bamf agents is always empty" bug (#120) lacked
+// — the Go struct decoded a different key while the Go tests stayed green.
+func TestAgentsListEnvelopeContract(t *testing.T) {
+	var page struct {
+		Items []agent `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(contractFixture(t, "agents_list.json"), &page))
+	require.Len(t, page.Items, 1,
+		"CLI must decode the CursorPage 'items' envelope, not a bare or renamed key")
+
+	a := page.Items[0]
+	require.Equal(t, "web-prod-01", a.Name)
+	require.Equal(t, "online", a.Status)
+	require.Equal(t, 3, a.ResourceCount)
+	require.Equal(t, "prod", a.Labels["env"])
+	require.NotNil(t, a.LastHeartbeat)
+}

--- a/services/bamf/api/models/common.py
+++ b/services/bamf/api/models/common.py
@@ -51,7 +51,14 @@ class PaginationParams(BAMFBaseModel):
 
 
 class CursorPage[T](BAMFBaseModel):
-    """Cursor-based pagination response."""
+    """Cursor-based pagination response.
+
+    CONTRACT: this is the wire shape every list endpoint returns. The Go CLI
+    decodes the ``items`` key (cmd/bamf/cmd/agents.go, tokens.go); a rename here
+    silently empties those lists. Guarded by the golden fixture
+    services/tests/contracts/agents_list.json (test_contract_fixtures.py +
+    cmd/bamf/cmd/contract_test.go).
+    """
 
     items: list[T]
     next_cursor: str | None = Field(

--- a/services/tests/contracts/agents_list.json
+++ b/services/tests/contracts/agents_list.json
@@ -1,0 +1,18 @@
+{
+  "items": [
+    {
+      "name": "web-prod-01",
+      "id": "019f380f-7a0c-7f8d-851e-4682b70cbc35",
+      "labels": { "env": "prod", "team": "platform" },
+      "status": "online",
+      "last_heartbeat": "2026-07-07T12:00:00Z",
+      "connected_bridge_id": "bamf-bridge-0",
+      "certificate_expires_at": "2027-07-07T12:00:00Z",
+      "resource_count": 3,
+      "created_at": "2026-01-01T00:00:00Z",
+      "updated_at": "2026-07-07T12:00:00Z"
+    }
+  ],
+  "next_cursor": "d2ViLXByb2QtMDE=",
+  "has_more": false
+}

--- a/services/tests/test_api/test_contract_fixtures.py
+++ b/services/tests/test_api/test_contract_fixtures.py
@@ -1,0 +1,41 @@
+"""Cross-language contract guards.
+
+The golden fixtures under ``services/tests/contracts/`` are shared with the Go
+consumer tests (``cmd/bamf/cmd/contract_test.go``). The same committed file is
+validated by both sides, so neither can silently encode a contract the peer
+never honored — the failure mode behind the ``bamf agents`` / ``bamf tokens
+list`` envelope-drift bug (#120), where the Go struct decoded ``agents`` while
+the API returned ``items`` and both test suites stayed green.
+
+If the API model drifts, the producer assertions here fail. If the CLI consumer
+drifts, the Go test fails. Updating one side forces updating the shared golden,
+which re-checks the other.
+"""
+
+import json
+from pathlib import Path
+
+from bamf.api.models.agents import AgentResponse
+from bamf.api.models.common import CursorPage
+
+CONTRACTS = Path(__file__).resolve().parents[1] / "contracts"
+
+
+def test_agents_list_envelope_contract():
+    raw = (CONTRACTS / "agents_list.json").read_text()
+
+    # Producer honors the shape: the golden validates against the real response
+    # model the endpoint returns (CursorPage[AgentResponse]).
+    page = CursorPage[AgentResponse].model_validate_json(raw)
+    assert len(page.items) == 1
+
+    data = json.loads(raw)
+    # The envelope is exactly the CursorPage shape the Go CLI decodes.
+    assert set(data) == {"items", "next_cursor", "has_more"}
+
+    # A fresh model instance must serialize to exactly the golden's item keys, so
+    # a producer-side field rename/removal breaks here and forces the golden (and
+    # thus the Go consumer test) to be updated in lockstep.
+    item = data["items"][0]
+    dumped = json.loads(AgentResponse.model_validate(item).model_dump_json())
+    assert set(dumped) == set(item)


### PR DESCRIPTION
Addresses the flagship items of #125 (contract registry + a CI guard that fails on drift).

## The guard
A single committed golden — `services/tests/contracts/agents_list.json` — is validated by **both** sides:
- **Producer** (`test_contract_fixtures.py`): the real `CursorPage[AgentResponse]` model must round-trip it, and a fresh instance must serialize to exactly the golden's keys (catches a producer field rename/removal).
- **Consumer** (`cmd/bamf/cmd/contract_test.go`): the CLI struct must decode the `items` envelope with the item fields it uses (catches envelope-key drift + field renames).

**Proven:** an intentional `items`→`agents` drift (the exact #120 bug) fails **both** the Go test (`Items` empty) and the Python test (`ValidationError`); restoring the golden goes green. Runs in the existing test-go / test-python jobs — no new CI job.

## Registry + markers
- AGENTS.md gains a **cross-component contract registry** table naming each fragile coupling, its two+ sides with file paths, and its guard (or a `TODO`).
- `CONTRACT:` comments at the two envelope boundaries (`CursorPage`, `agents.go`).

Partial for #125 — session-cert golden fixture, SSE-command guard, a `redis_keys` builder module, `make proto` diff, and `make docs-xref` remain (listed as TODO in the registry).