### PR TITLE
ci: docs-xref guard — fail on stale docs/ + AGENTS.md file references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -167,6 +167,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/security-scan.sh python
 
+  # A source comment or contract-registry row pointing at a moved/renamed file
+  # is a silent lie; this fails CI when a docs/ or AGENTS.md path stops resolving.
+  docs-xref:
+    name: Docs Xref
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - run: scripts/docs-xref.sh
+
   # ── Web ─────────────────────────────────────────────────
   web-lint:
     name: Web Lint
@@ -459,6 +471,7 @@ jobs:
       - migration-check
       - python-security
       - web-lint
+      - docs-xref
       - helm-lint
       - sast
       - secret-scan
@@ -671,6 +684,7 @@ jobs:
       - python-test
       - migration-check
       - python-security
+      - docs-xref
       - web-lint
       - web-build
       - web-audit
@@ -701,6 +715,7 @@ jobs:
             "${{ needs.web-lint.result }}"
             "${{ needs.web-build.result }}"
             "${{ needs.web-audit.result }}"
+            "${{ needs.docs-xref.result }}"
             "${{ needs.helm-lint.result }}"
             "${{ needs.sast.result }}"
             "${{ needs.secret-scan.result }}"

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 	pentest pentest-dast pentest-images pentest-sast \
 	clean clean-cache test-down \
 	db-migrate db-rollback db-reset proto \
-	migration-check \
+	migration-check docs-xref \
 	help
 
 # ── Variables (for build-local only) ─────────────────────
@@ -52,6 +52,9 @@ test-python:        ## Test Python only (Docker)
 
 migration-check:    ## Alembic upgrade→downgrade→upgrade round-trip (Docker)
 	scripts/test.sh migrations
+
+docs-xref:          ## Fail if a docs/ or AGENTS.md file reference is stale
+	scripts/docs-xref.sh
 
 # ── Build ─────────────────────────────────────────────────
 build:              ## Cross-compile Go binaries for all platforms (Docker)

--- a/scripts/docs-xref.sh
+++ b/scripts/docs-xref.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+# docs-xref: fail if a cross-reference doesn't resolve to a real file.
+#
+# Guards the stale-cross-reference class: source comments pointing at a moved
+# doc, or a contract-registry row citing a file that was renamed. Two checks:
+#   1. Every `docs/….md` reference in source + top-level docs resolves.
+#   2. Every backtick-quoted repo file path in AGENTS.md resolves (the contract
+#      registry is only useful if its file:line citations stay current).
+#
+# Usage: scripts/docs-xref.sh   (exits non-zero on the first broken reference)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+rc=0
+
+# ── 1. docs/….md references in source + entry-point docs ──────────────────
+doc_refs=$(
+  grep -rhoE "docs/[a-zA-Z0-9_./-]+\.md" \
+    --include="*.go" --include="*.py" --include="*.yaml" --include="*.yml" \
+    cmd pkg services helm 2>/dev/null
+  grep -rhoE "docs/[a-zA-Z0-9_./-]+\.md" AGENTS.md README.md llms.txt docs/index.md 2>/dev/null
+)
+while read -r ref; do
+  [ -z "$ref" ] && continue
+  if [ ! -f "$ref" ]; then
+    echo "BROKEN docs ref: $ref"
+    rc=1
+  fi
+done <<< "$(printf '%s\n' "$doc_refs" | sort -u)"
+
+# ── 2. backtick-quoted repo file paths cited in AGENTS.md ──────────────────
+# Only FULL repo paths (anchored on a top-level dir) — bare filenames and
+# partial/relative citations are ambiguous and skipped. Strip a trailing :NN
+# line number, and skip glob patterns.
+agents_paths=$(
+  grep -oE '`(services|pkg|cmd|helm|docs|alembic|web|proto|scripts|test)/[a-zA-Z0-9_./-]+\.(go|py|json|ya?ml|pem|ts|tsx)(:[0-9]+)?`' AGENTS.md 2>/dev/null \
+    | tr -d '`' | sed -E 's/:[0-9]+$//'
+)
+while read -r p; do
+  [ -z "$p" ] && continue
+  case "$p" in *'*'*) continue;; esac  # skip globs like services/bamf/**
+  if [ ! -e "$p" ]; then
+    echo "BROKEN AGENTS.md path: $p"
+    rc=1
+  fi
+done <<< "$(printf '%s\n' "$agents_paths" | sort -u)"
+
+if [ "$rc" -eq 0 ]; then
+  echo "docs-xref: all references resolve"
+fi
+exit "$rc"


### PR DESCRIPTION
Addresses the `make docs-xref` item of #125. `scripts/docs-xref.sh` fails when (1) a `docs/*.md` reference in source or entry-point docs doesn't resolve, or (2) a full repo path cited in AGENTS.md's contract registry doesn't resolve. Fast pure-bash CI job wired into `ci-pass` + `create-manifests`, plus `make docs-xref`. Verified: fails on an injected broken ref, passes on the current tree.