### PR TITLE
ci: enforce "no secrets in ConfigMaps" across topologies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -254,6 +254,10 @@ jobs:
             echo "all 4 topologies rendered"
           '
 
+      # Enforce "secrets never land in a ConfigMap" (AGENTS.md) across topologies.
+      - name: Helm config contract (no secrets in ConfigMaps)
+        run: scripts/helm-config-contract.sh
+
   # ── Security ────────────────────────────────────────────
   sast:
     name: SAST (Semgrep)

--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@
 	pentest pentest-dast pentest-images pentest-sast \
 	clean clean-cache test-down \
 	db-migrate db-rollback db-reset proto \
-	migration-check docs-xref \
+	migration-check docs-xref helm-config-contract \
 	help
 
 # ── Variables (for build-local only) ─────────────────────
@@ -55,6 +55,9 @@ migration-check:    ## Alembic upgrade→downgrade→upgrade round-trip (Docker)
 
 docs-xref:          ## Fail if a docs/ or AGENTS.md file reference is stale
 	scripts/docs-xref.sh
+
+helm-config-contract: ## Assert no secrets land in a rendered ConfigMap
+	scripts/helm-config-contract.sh
 
 # ── Build ─────────────────────────────────────────────────
 build:              ## Cross-compile Go binaries for all platforms (Docker)

--- a/scripts/helm-config-contract.sh
+++ b/scripts/helm-config-contract.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# helm-config-contract: enforce the AGENTS.md hard rule "secrets flow via
+# secretKeyRef / existingSecret, never into a ConfigMap." Renders every
+# documented topology and fails if any ConfigMap data value contains a
+# secret-looking assignment (password/token/secret/key = <literal>).
+#
+# Uses helm via Docker (no local helm needed) + python3 (present on CI runners).
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+HELM=(docker run --rm -v "$PWD:/chart" -w /chart alpine/helm:3.17.2)
+AGENT="agent.enabled=true,agent.joinToken=dummy,agent.config.name=ci-agent"
+TOPOLOGIES=(
+  "core.enabled=true,outpost.enabled=true,agent.enabled=false"
+  "core.enabled=false,outpost.enabled=true,agent.enabled=false"
+  "core.enabled=false,outpost.enabled=false,$AGENT"
+  "core.enabled=true,outpost.enabled=true,$AGENT"
+)
+
+rc=0
+for sets in "${TOPOLOGIES[@]}"; do
+  if ! "${HELM[@]}" template helm/bamf --set "$sets" \
+      | python3 scripts/lib/scan_configmap_secrets.py; then
+    echo "  ^ topology: $sets"
+    rc=1
+  fi
+done
+
+if [ "$rc" -eq 0 ]; then
+  echo "helm-config-contract: no secret values in any ConfigMap"
+fi
+exit "$rc"

--- a/scripts/lib/scan_configmap_secrets.py
+++ b/scripts/lib/scan_configmap_secrets.py
@@ -1,0 +1,48 @@
+"""Fail if a rendered ConfigMap carries a secret-looking value.
+
+Reads a `helm template` stream on stdin. Secrets must flow via secretKeyRef /
+existingSecret (Secret resources / env), never inline in a ConfigMap. Exit 1 on
+the first offending line.
+
+A line is flagged only when BOTH hold: the key looks secret-ish (contains
+password/secret/token/private_key/api_key, allowing prefixes like `db_password`)
+AND the value is a real literal (not a bool, number, empty, or a k8s reference).
+So config flags like `password_reset_enabled: true` and non-secret keys like
+`redis_url:` don't false-positive.
+"""
+
+import re
+import sys
+
+import yaml
+
+_SECRET_KEY = re.compile(r"(?i)(password|passwd|secret|token|private_key|api_?key)")
+_KV = re.compile(r"\s*([A-Za-z0-9_-]+)\s*[:=]\s*(.*)")
+
+
+def _is_secret_value(v: str) -> bool:
+    v = v.strip().strip("\"'")
+    if not v:
+        return False
+    if v.lower() in ("true", "false", "null", "none", "~"):
+        return False
+    if re.fullmatch(r"-?\d+(\.\d+)?[a-z%]*", v):  # numbers, durations, sizes
+        return False
+    return True
+
+
+found = False
+for doc in yaml.safe_load_all(sys.stdin):
+    if not doc or doc.get("kind") != "ConfigMap":
+        continue
+    name = doc.get("metadata", {}).get("name", "?")
+    for value in (doc.get("data") or {}).values():
+        for line in str(value).splitlines():
+            if "secretKeyRef" in line or "existingSecret" in line:
+                continue
+            m = _KV.match(line)
+            if m and _SECRET_KEY.search(m.group(1)) and _is_secret_value(m.group(2)):
+                print(f"SECRET IN CONFIGMAP {name}: {line.strip()[:100]}")
+                found = True
+
+sys.exit(1 if found else 0)


### PR DESCRIPTION
Addresses the helm config-contract item of #127. `scripts/helm-config-contract.sh` renders all 4 topologies and fails if any ConfigMap carries a secret-ish key assigned a real literal (AGENTS.md hard rule). Robust: catches prefixed keys like `db_password: hunter2`, ignores config flags (`password_reset_enabled: true`), numbers, and `secretKeyRef` references (all verified). Runs as a step in helm-lint (gated by ci-pass) + `make helm-config-contract`.