### PR TITLE
security(agents): require cert-auth on heartbeat/status/events/drain/offline + CI guard

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -211,6 +211,19 @@ boundary pointing at the peer.
   (`podSecurityContext`, `nodeSelector`, `affinity`, `tolerations`) use schema
   `type: object` with no property restrictions. Secrets flow via `secretKeyRef`
   / `existingSecret`, never into a ConfigMap.
+- **Endpoint authentication (hard requirement)** — every **state-changing**
+  route (`POST`/`PUT`/`PATCH`/`DELETE`) and every credential-bearing stream
+  (e.g. the agent SSE, which carries session certs) MUST enforce authentication
+  via a recognized dependency: `get_current_session`/`get_current_user`,
+  `require_admin`/`require_admin_or_audit`, `get_agent_identity`,
+  `get_bridge_identity`, or `verify_internal_token`. An agent may only act as
+  itself (assert the cert CN matches the path agent, like
+  `agents.py:_require_cert_matches_agent`). This is enforced in CI by
+  `services/tests/test_api/test_endpoint_auth.py`, which fails on any mutating
+  route lacking auth — a genuinely public route (login/join flow) must be added
+  to its `PUBLIC_ROUTES` allowlist **with a reason**, which a reviewer sees.
+  (Reject-by-default; see issue #193, where agent endpoints once shipped
+  unauthenticated and enabled tunnel hijack.)
 
 ## Release discipline
 

--- a/services/bamf/api/routers/agents.py
+++ b/services/bamf/api/routers/agents.py
@@ -110,6 +110,20 @@ async def resolve_agent_id(agent_id_or_name: str, db: AsyncSession) -> tuple[UUI
     )
 
 
+def _require_cert_matches_agent(agent_identity: AgentIdentity, agent: Agent) -> None:
+    """An agent may only act as itself — the cert CN must match the resolved agent.
+
+    Guards the agent-self endpoints (heartbeat/status/events/drain/offline/renew)
+    against one agent's cert being used to manipulate another's state or receive
+    its tunnel commands (which carry session certs). See test_agent_endpoint_auth.
+    """
+    if agent_identity.name != agent.name:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail=f"Certificate CN '{agent_identity.name}' does not match agent '{agent.name}'",
+        )
+
+
 # ── Heartbeat request/resource models ─────────────────────────────────
 
 
@@ -289,6 +303,7 @@ async def agent_heartbeat(
     body: AgentHeartbeatRequest | None = None,
     db: AsyncSession = Depends(get_db),
     r: aioredis.Redis = Depends(get_redis),
+    agent_identity: AgentIdentity = Depends(get_agent_identity),
 ) -> SuccessResponse:
     """Agent heartbeat — refreshes TTL in Redis and updates resource catalog.
 
@@ -302,6 +317,7 @@ async def agent_heartbeat(
     )
 
     resolved_id, agent = await resolve_agent_id(agent_id, db)
+    _require_cert_matches_agent(agent_identity, agent)
     agent_id_str = str(resolved_id)
     agent_key = f"agent:{agent_id_str}:status"
 
@@ -381,12 +397,14 @@ async def update_agent_status(
     agent_id: str,
     db: AsyncSession = Depends(get_db),
     r: aioredis.Redis = Depends(get_redis),
+    agent_identity: AgentIdentity = Depends(get_agent_identity),
 ) -> SuccessResponse:
     """Update agent status.
 
     The agent_id can be either a UUID or the agent name.
     """
-    resolved_id, _ = await resolve_agent_id(agent_id, db)
+    resolved_id, agent = await resolve_agent_id(agent_id, db)
+    _require_cert_matches_agent(agent_identity, agent)
     agent_key = f"agent:{resolved_id}:status"
     await r.setex(agent_key, AGENT_TTL_SECONDS, "online")
 
@@ -650,6 +668,7 @@ async def agent_events(
     instance_id: str = Query(..., description="Unique instance identifier for this agent pod"),
     db: AsyncSession = Depends(get_db_read),
     r: aioredis.Redis = Depends(get_redis),
+    agent_identity: AgentIdentity = Depends(get_agent_identity),
 ) -> StreamingResponse:
     """SSE stream for delivering tunnel commands to agents.
 
@@ -685,7 +704,8 @@ async def agent_events(
     The agent_id can be either a UUID or the agent name (for Go agent compatibility
     when loading cached certificates where the CN contains the name).
     """
-    resolved_id, _ = await resolve_agent_id(agent_id, db)
+    resolved_id, agent = await resolve_agent_id(agent_id, db)
+    _require_cert_matches_agent(agent_identity, agent)
     agent_id_str = str(resolved_id)
     # Reliable per-instance command queue (drained via BLPOP). A command enqueued
     # while this stream was down waits here (bounded by TTL) and is delivered on
@@ -743,6 +763,7 @@ async def drain_agent_instance(
     body: AgentDrainRequest,
     db: AsyncSession = Depends(get_db_read),
     r: aioredis.Redis = Depends(get_redis),
+    agent_identity: AgentIdentity = Depends(get_agent_identity),
 ) -> SuccessResponse:
     """Mark an agent instance as draining (shutting down).
 
@@ -752,7 +773,8 @@ async def drain_agent_instance(
     """
     from bamf.services.agent_instances import drain_instance
 
-    resolved_id, _ = await resolve_agent_id(agent_id, db)
+    resolved_id, agent = await resolve_agent_id(agent_id, db)
+    _require_cert_matches_agent(agent_identity, agent)
     agent_id_str = str(resolved_id)
 
     await drain_instance(r, agent_id_str, body.instance_id)
@@ -766,6 +788,7 @@ async def remove_agent_instance(
     instance_id: str,
     db: AsyncSession = Depends(get_db_read),
     r: aioredis.Redis = Depends(get_redis),
+    agent_identity: AgentIdentity = Depends(get_agent_identity),
 ) -> SuccessResponse:
     """Remove an agent instance that has fully shut down.
 
@@ -774,7 +797,8 @@ async def remove_agent_instance(
     """
     from bamf.services.agent_instances import remove_instance
 
-    resolved_id, _ = await resolve_agent_id(agent_id, db)
+    resolved_id, agent = await resolve_agent_id(agent_id, db)
+    _require_cert_matches_agent(agent_identity, agent)
     agent_id_str = str(resolved_id)
 
     await remove_instance(r, agent_id_str, instance_id)

--- a/services/tests/test_api/test_endpoint_auth.py
+++ b/services/tests/test_api/test_endpoint_auth.py
@@ -1,0 +1,123 @@
+"""Anti-recurrence guard: every state-changing (and credential-streaming) API
+route must enforce authentication.
+
+This exists because agent heartbeat/status/events/drain/offline once shipped
+**unauthenticated** (issue #193 — the /events stream leaks session certs, enabling
+agent impersonation and tunnel hijack). A mutating route without a recognized
+auth dependency now fails CI. Adding a new public route is a conscious act: put
+it on PUBLIC_ROUTES with a reason (which a reviewer sees), or add auth.
+
+Recognized auth = a FastAPI dependency of one of AUTH_DEPS in the route's
+dependant tree. Endpoints that authenticate manually in-body (e.g. the login
+flow validating a code, or an admin check via `_require_session`) are listed in
+PUBLIC_ROUTES with the mechanism noted.
+"""
+
+from bamf.api.app import create_application
+
+# Dependency-injected auth guards. verify_internal_token authenticates the
+# co-located/outpost proxy + bridge internal calls.
+AUTH_DEPS = {
+    "get_current_session",
+    "get_current_user",
+    "require_admin",
+    "require_admin_or_audit",
+    "get_agent_identity",
+    "get_bridge_identity",
+    "verify_internal_token",
+}
+
+# (METHOD, path) that are intentionally reachable without a DI auth dependency,
+# each with the reason. Anything NOT here must carry an AUTH_DEPS dependency.
+PUBLIC_ROUTES = {
+    # Pre-auth login flow (the caller has no session yet).
+    ("POST", "/auth/local/authorize"),  # validates email+password+PKCE
+    ("POST", "/auth/local/login"),  # validates email+password
+    ("POST", "/auth/token"),  # OAuth code+PKCE exchange
+    ("POST", "/auth/saml/acs"),  # SAML assertion consumer
+    ("POST", "/auth/logout"),  # revokes the presented bearer token
+    ("POST", "/auth/logout/all"),  # manual bearer → revoke caller's sessions
+    ("DELETE", "/auth/sessions/user/{email}"),  # manual _require_session + admin check
+    # Token-in-body join/bootstrap (the caller has no cert yet).
+    ("POST", "/agents/join"),  # agent join token
+    ("POST", "/outposts/join"),  # outpost join token
+    ("POST", "/internal/bridges/bootstrap"),  # bridge bootstrap token
+}
+
+
+def _dep_names(dependant) -> set[str]:
+    names = set()
+    call = getattr(dependant, "call", None)
+    if call is not None and hasattr(call, "__name__"):
+        names.add(call.__name__)
+    for sub in getattr(dependant, "dependencies", []):
+        names |= _dep_names(sub)
+    return names
+
+
+def _mutating_routes():
+    app = create_application()
+    routes = []
+
+    def collect(rs):
+        for r in rs:
+            orig = getattr(r, "original_router", None)
+            if orig is not None:
+                collect(orig.routes)
+            elif hasattr(r, "dependant") and getattr(r, "methods", None):
+                routes.append(r)
+
+    collect(app.routes)
+    mutating = {"POST", "PUT", "PATCH", "DELETE"}
+    return [r for r in routes if mutating & r.methods]
+
+
+def test_all_mutating_routes_enforce_auth():
+    offenders = []
+    for r in _mutating_routes():
+        method = sorted(m for m in r.methods if m in {"POST", "PUT", "PATCH", "DELETE"})[0]
+        if AUTH_DEPS & _dep_names(r.dependant):
+            continue
+        if (method, r.path) in PUBLIC_ROUTES:
+            continue
+        offenders.append(f"{method} {r.path}")
+    assert not offenders, (
+        "State-changing routes without a recognized auth dependency (add auth or, "
+        f"if truly public, add to PUBLIC_ROUTES with a reason): {sorted(offenders)}"
+    )
+
+
+def test_public_routes_allowlist_has_no_stale_entries():
+    """Keep the allowlist honest — every PUBLIC_ROUTES entry must still be a real
+    mutating route (so a removed/renamed endpoint can't hide a future gap)."""
+    live = {
+        (sorted(m for m in r.methods if m in {"POST", "PUT", "PATCH", "DELETE"})[0], r.path)
+        for r in _mutating_routes()
+    }
+    stale = PUBLIC_ROUTES - live
+    assert not stale, f"PUBLIC_ROUTES entries no longer exist as routes: {sorted(stale)}"
+
+
+def test_require_cert_matches_agent_rejects_other_agents():
+    """#193 regression: an agent cert may only act on its own agent record —
+    a CN that doesn't match the resolved agent is 403 (no cross-agent control)."""
+    from datetime import UTC, datetime
+    from unittest.mock import MagicMock
+
+    import pytest
+    from fastapi import HTTPException
+
+    from bamf.api.dependencies import AgentIdentity
+    from bamf.api.routers.agents import _require_cert_matches_agent
+
+    ident = AgentIdentity(name="agent-a", certificate=MagicMock(), expires_at=datetime.now(UTC))
+
+    same = MagicMock()
+    same.name = "agent-a"
+    _require_cert_matches_agent(ident, same)  # matching CN → no raise
+
+    other = MagicMock()
+    other.name = "agent-b"
+    with pytest.raises(HTTPException) as exc:
+        _require_cert_matches_agent(ident, other)
+    assert exc.value.status_code == 403


### PR DESCRIPTION
Closes #193 (critical).

## The hole
Four of the five agent-self endpoints enforced **no authentication** — only `/renew` did. `GET /agents/{id}/events` streams `dial` commands containing `session_cert` + `session_key` (the per-tunnel mTLS creds to reach the bridge **as the agent**). An attacker who knows an agent name could POST an unauthenticated `heartbeat` (register a fake instance), subscribe to the unauthenticated `/events`, receive a session cert, and **impersonate the agent to hijack/MITM a live tunnel**.

## Fix
- `get_agent_identity` (`X-Bamf-Client-Cert`) added to `heartbeat`, `status`, `events`, `drain`, `offline`, plus a `_require_cert_matches_agent` CN check (an agent may only act as itself), matching `/renew`. The Go agent already sends the cert on all these calls → backward-compatible.
- **Verified live** on the dev stack: legitimate agent heartbeat/events → `200`; unauthenticated attacker → `401` on all five (was `200`).

## Never-again guard
- `services/tests/test_api/test_endpoint_auth.py` fails CI if **any** mutating route (`POST/PUT/PATCH/DELETE`) or credential-stream lacks a recognized auth dependency. A genuinely-public route must be added to a reasoned `PUBLIC_ROUTES` allowlist (reviewer-visible). Proven to catch a stripped-auth regression (it named `POST /agents/{id}/heartbeat`).
- New **hard requirement** in AGENTS.md codifying endpoint auth + the guard.

`make test-python` 1053 pass; `lint-python`/`docs-xref` clean.