### PR TITLE
test(contracts): pin tokens + resources list envelopes with golden fixtures

### DIFF
--- a/cmd/bamf/cmd/contract_test.go
+++ b/cmd/bamf/cmd/contract_test.go
@@ -43,3 +43,44 @@ func TestAgentsListEnvelopeContract(t *testing.T) {
 	require.Equal(t, "prod", a.Labels["env"])
 	require.NotNil(t, a.LastHeartbeat)
 }
+
+// TestTokensListEnvelopeContract guards the same CursorPage "items" envelope for
+// `bamf tokens list` — the surface #120 explicitly named alongside `bamf agents`.
+// The decode struct here mirrors runTokensList in tokens.go.
+func TestTokensListEnvelopeContract(t *testing.T) {
+	var page struct {
+		Items []joinToken `json:"items"`
+	}
+	require.NoError(t, json.Unmarshal(contractFixture(t, "tokens_list.json"), &page))
+	require.Len(t, page.Items, 1,
+		"CLI must decode the CursorPage 'items' envelope, not a bare or renamed key")
+
+	tok := page.Items[0]
+	require.Equal(t, "prod-agents", tok.Name)
+	require.Equal(t, 2, tok.UseCount)
+	require.False(t, tok.IsRevoked)
+	require.NotNil(t, tok.MaxUses)
+	require.Equal(t, 10, *tok.MaxUses)
+	require.Equal(t, "prod", tok.AgentLabels["env"])
+	require.False(t, tok.ExpiresAt.IsZero())
+}
+
+// TestResourcesListEnvelopeContract guards the CUSTOM "resources" envelope for
+// `bamf resources`/`bamf ls` (runResources in resources.go decodes
+// {"resources": [...]}, not the CursorPage "items" key). A producer rename of
+// this key would silently empty the CLI the way #120 emptied `bamf agents`.
+func TestResourcesListEnvelopeContract(t *testing.T) {
+	var result struct {
+		Resources []resource `json:"resources"`
+	}
+	require.NoError(t, json.Unmarshal(contractFixture(t, "resources_list.json"), &result))
+	require.Len(t, result.Resources, 1,
+		"CLI must decode the custom 'resources' envelope, not a bare or renamed key")
+
+	r := result.Resources[0]
+	require.Equal(t, "web-prod-01", r.Name)
+	require.Equal(t, "ssh", r.ResourceType)
+	require.Equal(t, "available", r.Status)
+	require.Equal(t, "datacenter-agent-01", r.AgentName)
+	require.Equal(t, "prod", r.Labels["env"])
+}

--- a/services/tests/contracts/resources_list.json
+++ b/services/tests/contracts/resources_list.json
@@ -1,0 +1,16 @@
+{
+  "resources": [
+    {
+      "name": "web-prod-01",
+      "resource_type": "ssh",
+      "labels": { "env": "prod", "team": "platform" },
+      "agent_id": "019f380f-7a0c-7f8d-851e-4682b70cbc35",
+      "agent_name": "datacenter-agent-01",
+      "status": "available",
+      "hostname": "web-prod-01.internal",
+      "port": 22,
+      "connect_url": null,
+      "kubamf_url": null
+    }
+  ]
+}

--- a/services/tests/contracts/tokens_list.json
+++ b/services/tests/contracts/tokens_list.json
@@ -1,0 +1,17 @@
+{
+  "items": [
+    {
+      "id": "019f380f-7a0c-7f8d-851e-4682b70cbc35",
+      "name": "prod-agents",
+      "expires_at": "2026-07-08T12:00:00Z",
+      "max_uses": 10,
+      "use_count": 2,
+      "agent_labels": { "env": "prod" },
+      "is_revoked": false,
+      "created_at": "2026-07-07T12:00:00Z",
+      "created_by": "admin@example.com"
+    }
+  ],
+  "next_cursor": "cHJvZC1hZ2VudHM=",
+  "has_more": false
+}

--- a/services/tests/test_api/test_contract_fixtures.py
+++ b/services/tests/test_api/test_contract_fixtures.py
@@ -17,6 +17,8 @@ from pathlib import Path
 
 from bamf.api.models.agents import AgentResponse
 from bamf.api.models.common import CursorPage
+from bamf.api.models.tokens import JoinTokenResponse
+from bamf.api.routers.resources import ResourceListResponse, ResourceResponse
 
 CONTRACTS = Path(__file__).resolve().parents[1] / "contracts"
 
@@ -38,6 +40,45 @@ def test_agents_list_envelope_contract():
     # thus the Go consumer test) to be updated in lockstep.
     item = data["items"][0]
     dumped = json.loads(AgentResponse.model_validate(item).model_dump_json())
+    assert set(dumped) == set(item)
+
+
+def test_tokens_list_envelope_contract():
+    """`bamf tokens list` (cmd/bamf/cmd/tokens.go) decodes the CursorPage
+    ``items`` envelope of JoinTokenResponse — the surface #120 explicitly named.
+    Same both-sides guard as agents: the golden is validated here against the
+    real response model and in Go against the CLI's decode struct.
+    """
+    raw = (CONTRACTS / "tokens_list.json").read_text()
+
+    page = CursorPage[JoinTokenResponse].model_validate_json(raw)
+    assert len(page.items) == 1
+
+    data = json.loads(raw)
+    assert set(data) == {"items", "next_cursor", "has_more"}
+
+    item = data["items"][0]
+    dumped = json.loads(JoinTokenResponse.model_validate(item).model_dump_json())
+    assert set(dumped) == set(item)
+
+
+def test_resources_list_envelope_contract():
+    """`bamf resources`/`bamf ls` (cmd/bamf/cmd/resources.go) decodes the custom
+    ``resources`` envelope (ResourceListResponse), not the CursorPage ``items``
+    shape. Pinning it here + in Go stops a producer-side key rename from
+    silently emptying the CLI the way #120 emptied ``bamf agents``.
+    """
+    raw = (CONTRACTS / "resources_list.json").read_text()
+
+    page = ResourceListResponse.model_validate_json(raw)
+    assert len(page.resources) == 1
+
+    data = json.loads(raw)
+    # The custom envelope key is exactly what the Go CLI decodes.
+    assert set(data) == {"resources"}
+
+    item = data["resources"][0]
+    dumped = json.loads(ResourceResponse.model_validate(item).model_dump_json())
     assert set(dumped) == set(item)
 
 


### PR DESCRIPTION
Closes #198.

The list-envelope contract that caused #120 (empty `bamf agents`) was only dual-validated for **agents**. `bamf tokens list` and `bamf resources`/`bamf ls` were unguarded — a future producer-side key rename would silently resurrect #120 on those surfaces while both test suites stayed green.

Adds two golden fixtures, each validated on **both** sides of the API↔CLI boundary:

| Fixture | Envelope | Python producer | Go consumer |
|---|---|---|---|
| `tokens_list.json` | `{items, next_cursor, has_more}` | `CursorPage[JoinTokenResponse]` | `struct{ Items []joinToken }` (mirrors `runTokensList`) |
| `resources_list.json` | `{resources}` (custom, **not** `items`) | `ResourceListResponse` | `struct{ Resources []resource }` (mirrors `runResources`) |

Each side asserts the fixture decodes to exactly one item and that a fresh model instance's key set equals the fixture's — so a rename/removal on either side breaks the shared golden and forces a lockstep update, exactly the guard #120 lacked.

### Verification
- `go test ./cmd/bamf/cmd -run Contract` → 3/3 pass (agents + tokens + resources)
- `gmake test-python` → 1055 pass (incl. the two new producer tests)
- `gmake lint-python`, `gofmt`, `go vet` → clean