### PR TITLE
docs: fix stale --debug reference in SSH troubleshooting guide

### DIFF
--- a/docs/guides/ssh.md
+++ b/docs/guides/ssh.md
@@ -217,6 +217,6 @@ User certificates are valid for 12 hours by default.
 
 **SSH flags not working** — BAMF passes all flags through to the native `ssh`
 command. If a flag works with `ssh` directly, it works with `bamf ssh`. If
-you're having trouble, try running with `--debug` to see the actual `ssh`
-command being executed.
+you're having trouble, add `ssh`'s own `-v` (or `-vvv`) verbose flag to see the
+connection details, including the `bamf pipe %h %r` ProxyCommand BAMF injects.
 


### PR DESCRIPTION
Pre-release (v0.8.5) audit follow-up. The adversarial review of `git diff v0.8.4..HEAD` caught one internal contradiction the #200 truthfulness sweep missed:

`docs/guides/ssh.md` told users to run with `--debug` to see the executed `ssh` command, but `--debug` is inert (nothing reads it) and the SSH path never prints the command — and #200 already removed `--debug` from `docs/reference/cli.md`, so the two pages contradicted each other.

Replaced with accurate guidance: use `ssh`'s own `-v`/`-vvv` (passes straight through) to see the injected `bamf pipe %h %r` ProxyCommand.

The review returned **no blockers** otherwise; two remaining non-blocking items (inert `~/.bamf/keys/` dir + dead `--config`/`--debug` CLI flags; the now-caller-less `POST /agents/{id}/status` endpoint) are routed to #199 as cleanup.