### PR TITLE
fix(config): make audit retention, api_audit_enabled, and proxy HPA knobs real

### DIFF
--- a/docs/architecture/security.md
+++ b/docs/architecture/security.md
@@ -436,8 +436,9 @@ All security-relevant events are recorded:
 - Admin actions (user/role/token CRUD, with before/after state)
 
 Events include actor identity, timestamp, request ID, and source IP. Audit
-logs are stored in PostgreSQL with time-based partitioning and configurable
-retention (default 90 days).
+logs are stored in PostgreSQL with a configurable retention window (default 90
+days); a background sweep in the API prunes rows past the window (set
+`retention_days: 0` to keep them indefinitely).
 
 See [Monitoring](../operations/monitoring.md) for querying the audit log.
 

--- a/docs/operations/monitoring.md
+++ b/docs/operations/monitoring.md
@@ -137,5 +137,7 @@ curl "https://bamf.example.com/api/v1/audit?limit=100"
 curl "https://bamf.example.com/api/v1/audit?limit=100&cursor=${NEXT_CURSOR}"
 ```
 
-Audit log retention is configurable (default: 90 days). Older entries are
-automatically purged via time-based table partitioning.
+Audit log retention is configurable via `core.api.config.audit.retention_days`
+(default: 90 days). A background sweep in the API periodically deletes audit
+rows older than the window in batches; set `retention_days: 0` to disable
+pruning and keep audit rows indefinitely.

--- a/docs/reference/helm-values.md
+++ b/docs/reference/helm-values.md
@@ -68,7 +68,8 @@ core:
         agent_ttl_hours: 8760        # Agent cert lifetime (1 year)
         bridge_ttl_hours: 24         # Bridge cert lifetime
       audit:
-        retention_days: 90           # Audit log retention
+        retention_days: 90           # Audit log retention; 0 disables pruning (keep forever)
+        api_audit_enabled: true      # Record API self-audit request/response exchanges
       rate_limit:                    # Application-level rate limiting (see below)
         enabled: true
         requests_per_minute: 100     # Per-IP limit for unauthenticated requests

--- a/helm/bamf/templates/configmap-api.yaml
+++ b/helm/bamf/templates/configmap-api.yaml
@@ -23,6 +23,7 @@ data:
     # Audit configuration
     audit:
       retention_days: {{ .Values.core.api.config.audit.retention_days }}
+      api_audit_enabled: {{ .Values.core.api.config.audit.api_audit_enabled }}
 
     # Application-level rate limiting
     rate_limit:

--- a/helm/bamf/templates/hpa-proxy.yaml
+++ b/helm/bamf/templates/hpa-proxy.yaml
@@ -22,12 +22,4 @@ spec:
           type: Utilization
           averageUtilization: {{ .Values.outpost.proxy.autoscaling.targetCPUUtilizationPercentage }}
     {{- end }}
-    {{- if .Values.outpost.proxy.autoscaling.targetMemoryUtilizationPercentage }}
-    - type: Resource
-      resource:
-        name: memory
-        target:
-          type: Utilization
-          averageUtilization: {{ .Values.outpost.proxy.autoscaling.targetMemoryUtilizationPercentage }}
-    {{- end }}
 {{- end }}

--- a/helm/bamf/values.schema.json
+++ b/helm/bamf/values.schema.json
@@ -145,7 +145,7 @@
                   "type": "object",
                   "additionalProperties": false,
                   "properties": {
-                    "retention_days": { "type": "integer", "minimum": 1 },
+                    "retention_days": { "type": "integer", "minimum": 0 },
                     "api_audit_enabled": { "type": "boolean" }
                   }
                 },

--- a/helm/bamf/values.yaml
+++ b/helm/bamf/values.yaml
@@ -52,7 +52,8 @@ core:
         agent_ttl_hours: 8760
         bridge_ttl_hours: 24
       audit:
-        retention_days: 90
+        retention_days: 90              # 0 disables pruning (keep audit rows forever)
+        api_audit_enabled: true         # record API self-audit exchanges
       # Application-level rate limiting (Redis sliding window; complements the
       # ingress-level gateway.rateLimit). Per-tier limit 0 = unlimited.
       rate_limit:

--- a/services/bamf/api/app.py
+++ b/services/bamf/api/app.py
@@ -75,6 +75,12 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
 
     revocation_reconcile_task = asyncio.create_task(reconcile_revoked_loop())
 
+    # Enforce the audit-log retention window (settings.audit.retention_days).
+    # Without this the window was advisory — expired rows accumulated forever.
+    from bamf.services.audit_service import prune_audit_logs_loop
+
+    audit_prune_task = asyncio.create_task(prune_audit_logs_loop())
+
     init_connectors()
     logger.info("SSO connectors initialized")
 
@@ -83,6 +89,7 @@ async def lifespan(app: FastAPI) -> AsyncGenerator[None]:
     # Shutdown — signal SSE generators to close before tearing down connections
     logger.info("Shutting down BAMF API server")
     revocation_reconcile_task.cancel()
+    audit_prune_task.cancel()
     shutdown_event.set()
     # Brief pause so SSE generators see the event and close cleanly
     await asyncio.sleep(0.5)

--- a/services/bamf/config.py
+++ b/services/bamf/config.py
@@ -192,7 +192,11 @@ class RateLimitConfig(BaseModel):
 class AuditConfig(BaseSettings):
     """Audit log configuration."""
 
-    retention_days: int = Field(default=90, description="Audit log retention in days")
+    retention_days: int = Field(
+        default=90,
+        description="Audit log retention in days; expired rows are pruned by a "
+        "background sweep. Set to 0 to disable pruning (keep audit rows forever).",
+    )
     api_audit_enabled: bool = Field(default=True, description="Enable API self-audit middleware")
     api_audit_body_max_bytes: int = Field(
         default=65536, description="Max request/response body size to capture in API audit (bytes)"

--- a/services/bamf/services/audit_service.py
+++ b/services/bamf/services/audit_service.py
@@ -1,13 +1,27 @@
 """Audit logging service."""
 
+import asyncio
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import structlog
+from sqlalchemy import delete, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bamf.db.models import AuditLog
 
 logger = structlog.get_logger(__name__)
+
+# Audit-log retention pruning. The documented contract is a fixed retention
+# window (default 90 days); nothing pruned expired rows before, so the window
+# was advisory. This loop enforces it. A retention of 0 (or negative) disables
+# pruning entirely — audit rows are then kept indefinitely.
+_PRUNE_INTERVAL_SECONDS = (
+    6 * 3600
+)  # sweep every 6h; each sweep is a cheap no-op when nothing expired
+_PRUNE_LOCK_KEY = "bamf:audit:prune:lock"
+_PRUNE_LOCK_TTL_SECONDS = 1800
+_PRUNE_BATCH_SIZE = 5000
 
 
 async def log_audit_event(
@@ -84,3 +98,69 @@ async def log_audit_event(
     )
 
     return entry
+
+
+async def prune_audit_logs(
+    db: AsyncSession,
+    retention_days: int,
+    *,
+    batch_size: int = _PRUNE_BATCH_SIZE,
+) -> int:
+    """Delete audit_logs older than ``retention_days``; return the count removed.
+
+    Deletes in batches (committing each) so a large backlog never holds a long
+    lock on the table. A ``retention_days`` of 0 or less is a no-op (retention
+    disabled), so callers can turn pruning off via config without special-casing.
+    """
+    if retention_days <= 0:
+        return 0
+
+    cutoff = datetime.now(UTC) - timedelta(days=retention_days)
+    total = 0
+    while True:
+        expired_ids = select(AuditLog.id).where(AuditLog.timestamp < cutoff).limit(batch_size)
+        result = await db.execute(delete(AuditLog).where(AuditLog.id.in_(expired_ids)))
+        deleted = result.rowcount or 0
+        await db.commit()
+        total += deleted
+        if deleted < batch_size:
+            break
+    return total
+
+
+async def prune_audit_logs_loop(interval_seconds: int = _PRUNE_INTERVAL_SECONDS) -> None:
+    """Background task: periodically prune audit_logs past the retention window.
+
+    Multi-replica safe: a Redis ``SET NX`` lock elects one pruner per interval so
+    replicas don't all issue the same DELETE. The delete is idempotent regardless,
+    so a lost lock or expired holder never corrupts state — at worst a sweep is
+    skipped and retried next interval.
+    """
+    from bamf.config import settings
+    from bamf.db.session import async_session_factory
+    from bamf.redis.client import get_redis_client
+
+    while True:
+        try:
+            await asyncio.sleep(interval_seconds)
+            retention_days = settings.audit.retention_days
+            if retention_days <= 0:
+                continue
+            acquired = await get_redis_client().set(
+                _PRUNE_LOCK_KEY, "1", nx=True, ex=_PRUNE_LOCK_TTL_SECONDS
+            )
+            if not acquired:
+                continue
+            async with async_session_factory() as db:
+                deleted = await prune_audit_logs(db, retention_days)
+            if deleted:
+                logger.info(
+                    "pruned expired audit logs",
+                    deleted=deleted,
+                    retention_days=retention_days,
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception:
+            # Never let a transient DB/Redis error kill the pruner.
+            logger.warning("audit prune iteration failed", exc_info=True)

--- a/services/tests/test_audit_pruning.py
+++ b/services/tests/test_audit_pruning.py
@@ -1,0 +1,73 @@
+"""Tests for audit-log retention pruning (services.audit_service.prune_audit_logs).
+
+Enforces the documented retention window: expired rows are deleted, everything
+inside the window is kept, retention_days=0 disables pruning, and the batched
+delete loop drains a backlog larger than one batch.
+"""
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from bamf.db.models import AuditLog
+from bamf.services.audit_service import prune_audit_logs
+
+
+async def _add_entry(db: AsyncSession, ts: datetime) -> None:
+    db.add(
+        AuditLog(
+            event_type="admin",
+            action="test",
+            actor_type="user",
+            actor_id="a@example.com",
+            details={},
+            success=True,
+            timestamp=ts,
+        )
+    )
+
+
+async def _count(db: AsyncSession) -> int:
+    return (await db.execute(select(func.count()).select_from(AuditLog))).scalar_one()
+
+
+@pytest.mark.asyncio
+async def test_prune_removes_only_expired(db_session: AsyncSession):
+    now = datetime.now(UTC)
+    await _add_entry(db_session, now - timedelta(days=120))  # expired
+    await _add_entry(db_session, now - timedelta(days=91))  # expired
+    await _add_entry(db_session, now - timedelta(days=10))  # kept
+    await _add_entry(db_session, now)  # kept
+    await db_session.commit()
+
+    deleted = await prune_audit_logs(db_session, retention_days=90)
+
+    assert deleted == 2
+    assert await _count(db_session) == 2
+
+
+@pytest.mark.asyncio
+async def test_prune_disabled_when_retention_zero(db_session: AsyncSession):
+    await _add_entry(db_session, datetime.now(UTC) - timedelta(days=1000))
+    await db_session.commit()
+
+    deleted = await prune_audit_logs(db_session, retention_days=0)
+
+    assert deleted == 0
+    assert await _count(db_session) == 1
+
+
+@pytest.mark.asyncio
+async def test_prune_drains_backlog_larger_than_one_batch(db_session: AsyncSession):
+    old = datetime.now(UTC) - timedelta(days=200)
+    for _ in range(7):
+        await _add_entry(db_session, old)
+    await db_session.commit()
+
+    # batch_size=3 forces the loop to iterate (3 + 3 + 1) rather than one delete.
+    deleted = await prune_audit_logs(db_session, retention_days=90, batch_size=3)
+
+    assert deleted == 7
+    assert await _count(db_session) == 0


### PR DESCRIPTION
Closes #196.

Three config surfaces accepted input but had no effect.

### 1. `audit.retention_days` was enforced by nothing
The documented retention window was advisory — expired audit rows accumulated forever. Added a background pruning sweep:
- **`services/audit_service.py`** — `prune_audit_logs()` deletes rows older than the window in **batches** (each committed, so a large backlog never holds a long lock on the table); `prune_audit_logs_loop()` runs it every 6h, electing a **single pruner across replicas** via a Redis `SET NX` lock (the DELETE is idempotent, so a lost/expired lock never corrupts state — worst case a sweep is retried next interval). `retention_days=0` disables pruning entirely.
- **`app.py`** lifespan starts/cancels the loop alongside the existing revocation reconciler (same pattern).
- **Tests** cover expired-only deletion, the disabled (`0`) case, and the batched backlog drain.

### 2. `audit.api_audit_enabled` was unreachable from Helm
The Python side was fully wired (`config.py` + `middleware.py`), but the key was **absent from `values.yaml`** and the ConfigMap rendered the audit block field-by-field (`retention_days` only), so it could never reach the rendered config even via `--set`. Added it to `values.yaml` + `configmap-api.yaml`. (`values.schema.json` already declared it; relaxed `retention_days` `minimum` from 1→0 so pruning can actually be disabled.)

### 3. `hpa-proxy.yaml` dead memory-scaling branch
Gated a memory metric on `outpost.proxy.autoscaling.targetMemoryUtilizationPercentage`, never defined in `values.yaml` (copy-paste remnant from `core.api`) — the block could never render. **Dropped the dead branch** (the proxy is CPU-scaled); adding the value would silently change default scaling behaviour.

Also corrected two docs (`operations/monitoring.md`, `architecture/security.md`) that described retention as "time-based table partitioning" — the table isn't partitioned; it's now a real background sweep.

### Verification
- `gmake test-python` → 1046 pass (+3 pruning tests); `gmake lint-python` → clean
- `helm lint` → clean; `helm template` renders `api_audit_enabled`; `--set …retention_days=0` now passes schema
- `scripts/docs-xref.sh` → resolves