### PR TITLE
chore: pre-release cleanup — test the prune loop body, drop a stale comment

### DIFF
--- a/services/bamf/api/routers/auth.py
+++ b/services/bamf/api/routers/auth.py
@@ -753,9 +753,6 @@ async def logout_all(request: Request) -> JSONResponse:
     return response
 
 
-# --- CA public key ---
-
-
 # --- Helpers ---
 
 

--- a/services/bamf/services/audit_service.py
+++ b/services/bamf/services/audit_service.py
@@ -128,37 +128,45 @@ async def prune_audit_logs(
     return total
 
 
-async def prune_audit_logs_loop(interval_seconds: int = _PRUNE_INTERVAL_SECONDS) -> None:
-    """Background task: periodically prune audit_logs past the retention window.
+async def _prune_once() -> int:
+    """Run a single retention sweep if this replica wins the lock.
 
-    Multi-replica safe: a Redis ``SET NX`` lock elects one pruner per interval so
-    replicas don't all issue the same DELETE. The delete is idempotent regardless,
-    so a lost lock or expired holder never corrupts state — at worst a sweep is
-    skipped and retried next interval.
+    Returns the number of rows deleted — 0 when pruning is disabled
+    (``retention_days <= 0``), when another replica holds the lock, or when
+    nothing was expired. Multi-replica safe: a Redis ``SET NX`` lock elects one
+    pruner per interval so replicas don't all issue the same DELETE. The delete
+    is idempotent regardless, so a lost lock or expired holder never corrupts
+    state — at worst a sweep is skipped and retried next interval.
     """
     from bamf.config import settings
     from bamf.db.session import async_session_factory
     from bamf.redis.client import get_redis_client
 
+    retention_days = settings.audit.retention_days
+    if retention_days <= 0:
+        return 0
+    acquired = await get_redis_client().set(
+        _PRUNE_LOCK_KEY, "1", nx=True, ex=_PRUNE_LOCK_TTL_SECONDS
+    )
+    if not acquired:
+        return 0
+    async with async_session_factory() as db:
+        deleted = await prune_audit_logs(db, retention_days)
+    if deleted:
+        logger.info(
+            "pruned expired audit logs",
+            deleted=deleted,
+            retention_days=retention_days,
+        )
+    return deleted
+
+
+async def prune_audit_logs_loop(interval_seconds: int = _PRUNE_INTERVAL_SECONDS) -> None:
+    """Background task: periodically prune audit_logs past the retention window."""
     while True:
         try:
             await asyncio.sleep(interval_seconds)
-            retention_days = settings.audit.retention_days
-            if retention_days <= 0:
-                continue
-            acquired = await get_redis_client().set(
-                _PRUNE_LOCK_KEY, "1", nx=True, ex=_PRUNE_LOCK_TTL_SECONDS
-            )
-            if not acquired:
-                continue
-            async with async_session_factory() as db:
-                deleted = await prune_audit_logs(db, retention_days)
-            if deleted:
-                logger.info(
-                    "pruned expired audit logs",
-                    deleted=deleted,
-                    retention_days=retention_days,
-                )
+            await _prune_once()
         except asyncio.CancelledError:
             raise
         except Exception:

--- a/services/tests/test_audit_pruning.py
+++ b/services/tests/test_audit_pruning.py
@@ -5,14 +5,16 @@ inside the window is kept, retention_days=0 disables pruning, and the batched
 delete loop drains a backlog larger than one batch.
 """
 
+from contextlib import asynccontextmanager
 from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock
 
 import pytest
 from sqlalchemy import func, select
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from bamf.db.models import AuditLog
-from bamf.services.audit_service import prune_audit_logs
+from bamf.services.audit_service import _prune_once, prune_audit_logs
 
 
 async def _add_entry(db: AsyncSession, ts: datetime) -> None:
@@ -70,4 +72,55 @@ async def test_prune_drains_backlog_larger_than_one_batch(db_session: AsyncSessi
     deleted = await prune_audit_logs(db_session, retention_days=90, batch_size=3)
 
     assert deleted == 7
+    assert await _count(db_session) == 0
+
+
+# ── _prune_once: the loop-body decision logic (lock election + gating) ──────
+
+
+@pytest.mark.asyncio
+async def test_prune_once_disabled_when_retention_zero(monkeypatch):
+    """retention_days=0 short-circuits before touching Redis or the DB."""
+    monkeypatch.setattr("bamf.config.settings.audit.retention_days", 0)
+    redis_mock = AsyncMock()
+    monkeypatch.setattr("bamf.redis.client.get_redis_client", lambda: redis_mock)
+
+    assert await _prune_once() == 0
+    redis_mock.set.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_prune_once_skips_when_lock_not_acquired(monkeypatch):
+    """A replica that loses the SET NX race does not prune."""
+    monkeypatch.setattr("bamf.config.settings.audit.retention_days", 90)
+    redis_mock = AsyncMock()
+    redis_mock.set = AsyncMock(return_value=None)  # lock held elsewhere
+    monkeypatch.setattr("bamf.redis.client.get_redis_client", lambda: redis_mock)
+
+    def _no_session():
+        raise AssertionError("prune must not run without the lock")
+
+    monkeypatch.setattr("bamf.db.session.async_session_factory", _no_session)
+
+    assert await _prune_once() == 0
+
+
+@pytest.mark.asyncio
+async def test_prune_once_prunes_when_lock_acquired(db_session: AsyncSession, monkeypatch):
+    """The lock winner runs the sweep and reports the count."""
+    await _add_entry(db_session, datetime.now(UTC) - timedelta(days=200))
+    await db_session.commit()
+
+    monkeypatch.setattr("bamf.config.settings.audit.retention_days", 90)
+    redis_mock = AsyncMock()
+    redis_mock.set = AsyncMock(return_value=True)  # lock won
+    monkeypatch.setattr("bamf.redis.client.get_redis_client", lambda: redis_mock)
+
+    @asynccontextmanager
+    async def _fake_factory():
+        yield db_session
+
+    monkeypatch.setattr("bamf.db.session.async_session_factory", _fake_factory)
+
+    assert await _prune_once() == 1
     assert await _count(db_session) == 0


### PR DESCRIPTION
Pre-release (v0.8.6) audit follow-ups from the adversarial review of `git diff v0.8.5..HEAD`. No behaviour change.

- **Test the prune loop body** — extracted the audit-prune loop's per-iteration logic into a testable `_prune_once()` and covered its three branches: disabled when `retention_days<=0` (never touches Redis/DB), skipped when the Redis `SET NX` lock is lost, and runs the sweep when the lock is won. Closes the Code↔Tests gap the review flagged on `prune_audit_logs_loop` (previously only the pure `prune_audit_logs` helper was tested).
- **Drop stale comment** — removed the `# --- CA public key ---` section header left dangling in `auth.py` after `GET /auth/ca/public` was removed in #206.

### Verification
- `gmake test-python` → 1049 pass (+3 `_prune_once` tests); `gmake lint-python` → clean