### PR TITLE
ci: shard the Go cross-compile check by platform (330s → ~55s)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,14 +105,28 @@ jobs:
       - run: scripts/test.sh go
 
   go-build:
-    name: Go Build
+    name: Go Build (${{ matrix.platform }})
     needs: prepare
     if: needs.prepare.outputs.images_exist != 'true'
     runs-on: ubuntu-latest
-    timeout-minutes: 25
+    timeout-minutes: 15
+    # Sharded one runner per target platform. The single-job build cross-compiled
+    # all 6 platforms serially (~330s, the CI long pole); per-platform shards run
+    # in parallel (~55s each). This is a compile check only — the release job
+    # builds the shipped binaries (incl. the macOS universal fat binary) itself.
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - linux/amd64
+          - linux/arm64
+          - darwin/amd64
+          - darwin/arm64
+          - windows/amd64
+          - windows/arm64
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
-      - run: scripts/build.sh binaries
+      - run: scripts/build.sh binaries --platform=${{ matrix.platform }}
 
   go-security:
     name: Go Security (govulncheck)

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -7,11 +7,13 @@ set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 PUSH=false
+PLATFORM=""
 TARGETS=()
 
 for arg in "$@"; do
   case "$arg" in
     --push) PUSH=true ;;
+    --platform=*) PLATFORM="${arg#--platform=}" ;;
     *)      TARGETS+=("$arg") ;;
   esac
 done
@@ -41,25 +43,38 @@ build_binaries() {
       GOOS=$os GOARCH=$arch go build -buildvcs=false -ldflags="$LDFLAGS" -o "$out" "./cmd/$cmd"
     }
 
-    # CLI + Agent: all 6 platforms
-    for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
-      os="${platform%%/*}"
-      arch="${platform##*/}"
+    PLATFORM_FILTER="'"$PLATFORM"'"
+    if [[ -n "$PLATFORM_FILTER" ]]; then
+      # Single-platform compile check (CI shards one runner per platform).
+      # No macOS universal binary here — the fat step needs both darwin arches
+      # and is a release concern, not a compile check.
+      os="${PLATFORM_FILTER%%/*}"
+      arch="${PLATFORM_FILTER##*/}"
       build "$os" "$arch" bamf bamf
       build "$os" "$arch" bamf-agent bamf-agent
-    done
+      [[ "$os" == "linux" ]] && build "$os" "$arch" bamf-bridge bamf-bridge
+      echo "Single-platform compile check ($PLATFORM_FILTER) done."
+    else
+      # CLI + Agent: all 6 platforms
+      for platform in linux/amd64 linux/arm64 darwin/amd64 darwin/arm64 windows/amd64 windows/arm64; do
+        os="${platform%%/*}"
+        arch="${platform##*/}"
+        build "$os" "$arch" bamf bamf
+        build "$os" "$arch" bamf-agent bamf-agent
+      done
 
-    # Bridge: Linux only (container-only)
-    for arch in amd64 arm64; do
-      build linux "$arch" bamf-bridge bamf-bridge
-    done
+      # Bridge: Linux only (container-only)
+      for arch in amd64 arm64; do
+        build linux "$arch" bamf-bridge bamf-bridge
+      done
 
-    # Create macOS universal binary for CLI (replaces arch-specific binaries)
-    echo "  Creating universal binary: dist/bamf-darwin-universal..."
-    go run ./tools/makefat dist/bamf-darwin-universal dist/bamf-darwin-amd64 dist/bamf-darwin-arm64
-    rm dist/bamf-darwin-amd64 dist/bamf-darwin-arm64
+      # Create macOS universal binary for CLI (replaces arch-specific binaries)
+      echo "  Creating universal binary: dist/bamf-darwin-universal..."
+      go run ./tools/makefat dist/bamf-darwin-universal dist/bamf-darwin-amd64 dist/bamf-darwin-arm64
+      rm dist/bamf-darwin-amd64 dist/bamf-darwin-arm64
 
-    echo "Done."
+      echo "Done."
+    fi
   '
 
   success "Binaries written to dist/"


### PR DESCRIPTION
Refs #127 (CI hardening — Terrapod parallelism patterns). First of a few CI-speed PRs.

The `go-build` job cross-compiled all **six** target platforms serially in one runner (~330s) — the CI wall-clock long pole (next longest job is CodeQL-go at 245s). This shards it into a `strategy.matrix` over platforms so they compile in parallel (~55s each).

**Changes:**
- `scripts/build.sh` gains an optional `--platform=<os/arch>` filter — builds just that platform's binaries (`bamf`, `bamf-agent`, and `bamf-bridge` on linux) and skips the macOS universal fat step (needs both darwin arches; a release concern, not a compile check). **No arg = the existing full build**, so the release job and `make build` are untouched.
- `go-build` → 6-way matrix. It is only ever a **gate** — `ci-pass` and `create-manifests` consume its aggregate `result`, never its artifacts — so the matrix aggregate preserves the same gating semantics (`!contains(needs.*.result, 'failure')` still holds).

**Verification:**
- Ran the exact CI invocation locally: `scripts/build.sh binaries --platform=linux/amd64` → builds only the 3 linux/amd64 binaries, no universal, no other platforms.
- `actionlint` clean on the change; `python -c yaml.safe_load` valid.

This is the biggest single wall-clock win. Follow-ups in the same phase: shard `go-test` (121s) and `python-test` (77s, Terrapod-style unit/services-api xdist + integration serial), then composite actions + a helm-smoke gate.