### PR TITLE
docs: add mkdocs site + a strict docs-build CI gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -193,6 +193,18 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/docs-xref.sh
 
+  # Builds the mkdocs site with --strict: a broken internal link or an
+  # orphaned/missing nav page fails CI instead of silently 404-ing on the site.
+  docs-build:
+    name: Docs Build
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - run: scripts/docs.sh build
+
   # ── Web ─────────────────────────────────────────────────
   web-lint:
     name: Web Lint
@@ -490,6 +502,7 @@ jobs:
       - python-security
       - web-lint
       - docs-xref
+      - docs-build
       - helm-lint
       - sast
       - secret-scan
@@ -703,6 +716,7 @@ jobs:
       - migration-check
       - python-security
       - docs-xref
+      - docs-build
       - web-lint
       - web-build
       - web-audit
@@ -734,6 +748,7 @@ jobs:
             "${{ needs.web-build.result }}"
             "${{ needs.web-audit.result }}"
             "${{ needs.docs-xref.result }}"
+            "${{ needs.docs-build.result }}"
             "${{ needs.helm-lint.result }}"
             "${{ needs.sast.result }}"
             "${{ needs.secret-scan.result }}"

--- a/.gitignore
+++ b/.gitignore
@@ -98,3 +98,4 @@ helm/bamf/values-local.yaml
 
 # Pen test reports
 reports/
+site/

--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,7 @@
 	clean clean-cache test-down \
 	db-migrate db-rollback db-reset \
 	migration-check docs-xref helm-config-contract \
+	docs docs-serve \
 	help
 
 # ── Variables (for build-local only) ─────────────────────
@@ -55,6 +56,12 @@ migration-check:    ## Alembic upgrade→downgrade→upgrade round-trip (Docker)
 
 docs-xref:          ## Fail if a docs/ or AGENTS.md file reference is stale
 	scripts/docs-xref.sh
+
+docs:               ## Build the docs site with strict validation (broken links/nav gaps fail)
+	scripts/docs.sh build
+
+docs-serve:         ## Live-preview the docs site at http://localhost:8000
+	scripts/docs.sh serve
 
 helm-config-contract: ## Assert no secrets land in a rendered ConfigMap
 	scripts/helm-config-contract.sh

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,9 @@ BAMF (Bridge Access Management Fabric) — secure, audited infrastructure access
 with short-lived certificates, session recording, and zero-trust tunnels. An
 open-source (MPL-2.0) alternative to Teleport.
 
-New to the project? Read the [README](../README.md) first, then
+New to the project? Read the [README](https://github.com/mattrobinsonsre/bamf/blob/main/README.md) first, then
 [Getting started](getting-started.md). Building or contributing? See
-[AGENTS.md](../AGENTS.md) and [CONTRIBUTING.md](../CONTRIBUTING.md).
+[AGENTS.md](https://github.com/mattrobinsonsre/bamf/blob/main/AGENTS.md) and [CONTRIBUTING.md](https://github.com/mattrobinsonsre/bamf/blob/main/CONTRIBUTING.md).
 
 ## Getting started
 

--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -5,7 +5,7 @@ Releases are **fully automated via GitHub Actions**: pushing a semver tag
 attaches the Go binaries + SBOMs, and creates the GitHub Release. This page is
 the mechanical how-to; the **quality gates** that must pass *before* you tag —
 the pre-release audit and the independent third-party review — live in
-[`AGENTS.md` → Release discipline](../AGENTS.md#release-discipline). Do those
+[`AGENTS.md` → Release discipline](https://github.com/mattrobinsonsre/bamf/blob/main/AGENTS.md#release-discipline). Do those
 first; then follow the steps here.
 
 ## Before tagging
@@ -13,7 +13,7 @@ first; then follow the steps here.
 1. **All intended PRs are merged with green CI.** Don't tag a release with
    unmerged work that was meant for it.
 2. **Run the pre-release audit (A–H) and the third-party review** described in
-   [`AGENTS.md`](../AGENTS.md#release-discipline), and land any fixes as a
+   [`AGENTS.md`](https://github.com/mattrobinsonsre/bamf/blob/main/AGENTS.md#release-discipline), and land any fixes as a
    dedicated `docs:`/`chore:` PR. Minor/major releases require the full audit;
    patch releases still run the content-hygiene (D) and live-smoke (F) gates and
    the third-party review (which scales with the diff).
@@ -56,9 +56,9 @@ patch (`vX.Y.Z+1`). The criterion is "did the pipeline succeed and publish?" —
 if `cleanup.yml` deleted the tag, the version is free to reuse; otherwise it is
 frozen.
 
-All release logic is in [`.github/workflows/ci.yml`](../.github/workflows/ci.yml);
+All release logic is in [`.github/workflows/ci.yml`](https://github.com/mattrobinsonsre/bamf/blob/main/.github/workflows/ci.yml);
 GHCR retention cleanup is in
-[`.github/workflows/cleanup.yml`](../.github/workflows/cleanup.yml).
+[`.github/workflows/cleanup.yml`](https://github.com/mattrobinsonsre/bamf/blob/main/.github/workflows/cleanup.yml).
 
 ## Published artifacts
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,0 +1,86 @@
+site_name: BAMF
+site_description: Bridge Access Management Fabric — open-source secure infrastructure access
+site_url: https://mattrobinsonsre.github.io/bamf
+repo_url: https://github.com/mattrobinsonsre/bamf
+repo_name: mattrobinsonsre/bamf
+docs_dir: docs
+
+theme:
+  name: material
+  palette:
+    - scheme: slate
+      primary: teal
+      accent: cyan
+      toggle:
+        icon: material/brightness-4
+        name: Switch to light mode
+    - scheme: default
+      primary: teal
+      accent: cyan
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+  features:
+    - navigation.sections
+    - navigation.top
+    - search.highlight
+    - search.share
+    - content.code.copy
+  icon:
+    repo: fontawesome/brands/github
+
+plugins:
+  - search
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+  - pymdownx.inlinehilite
+  - tables
+  - attr_list
+  - md_in_html
+  - toc:
+      permalink: true
+
+nav:
+  - Home: index.md
+  - Getting Started: getting-started.md
+  - Guides:
+      - SSH & SCP: guides/ssh.md
+      - Databases: guides/databases.md
+      - Kubernetes: guides/kubernetes.md
+      - Web Applications: guides/web-apps.md
+      - Web Terminal: guides/web-terminal.md
+      - File Shares: guides/file-shares.md
+      - Agents: guides/agents.md
+  - Administration:
+      - Deployment: admin/deployment.md
+      - RBAC: admin/rbac.md
+      - SSO: admin/sso.md
+      - Users: admin/users.md
+      - Certificates: admin/certificates.md
+  - Architecture:
+      - Overview: architecture/overview.md
+      - Authentication: architecture/authentication.md
+      - Tunnels: architecture/tunnels.md
+      - Security: architecture/security.md
+      - Outpost Deployments: architecture/outpost-deployments.md
+  - Operations:
+      - Monitoring: operations/monitoring.md
+      - Scaling: operations/scaling.md
+      - Backup & Restore: operations/backup-restore.md
+      - Upgrading: operations/upgrading.md
+  - Reference:
+      - CLI: reference/cli.md
+      - REST API: reference/api.md
+      - Helm Values: reference/helm-values.md
+      - Agent Config: reference/agent-config.md
+  - Project:
+      - Comparison: comparison.md
+      - Development: development.md
+      - Releasing: releasing.md

--- a/scripts/docs.sh
+++ b/scripts/docs.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Build (or serve) the documentation site.
+# Usage: scripts/docs.sh [build|serve]
+# Default: build
+#
+# `build` runs `mkdocs build --strict` — broken internal links and orphaned or
+# missing nav pages fail the build. This is the docs-drift gate: a renamed page
+# or a mistyped cross-link fails CI instead of silently 404-ing on the site.
+# `serve` runs a live-reload preview on http://localhost:8000.
+#
+# Runs in the pinned mkdocs-material container, so no local Python/mkdocs
+# install is required — only Docker.
+set -euo pipefail
+source "$(dirname "$0")/lib.sh"
+
+# Pinned by digest (mkdocs-material, mkdocs 1.6.1) for reproducible builds.
+DOCS_IMAGE="squidfunk/mkdocs-material@sha256:868ad4d39fb5865b72d00173ade00f4eae2b38dde7ff790a011cc44ce4a8ff8e"
+
+target="${1:-build}"
+case "$target" in
+  build)
+    info "Building docs site (mkdocs --strict)..."
+    docker run --rm -v "$REPO_ROOT":/docs "$DOCS_IMAGE" build --strict
+    success "Docs built (strict): no broken links or nav gaps"
+    ;;
+  serve)
+    info "Serving docs at http://localhost:8000 (ctrl-c to stop)..."
+    docker run --rm -it -p 8000:8000 -v "$REPO_ROOT":/docs "$DOCS_IMAGE" serve --dev-addr 0.0.0.0:8000
+    ;;
+  *)
+    error "Unknown target: $target"
+    echo "Usage: $0 [build|serve]"
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
Refs #138. Delivers the docs-site + strict-gate half — the mistake-prevention piece.

BAMF had `docs/` markdown but **no docs site and no CI validation of it**, so a renamed page or mistyped cross-link merged green and 404'd later (exactly the doc-drift class fixed by hand across #200/#202). This adds a docs site and a `--strict` gate.

**What's added:**
- **`mkdocs.yml`** — Material theme + search, nav mirroring the `docs/{guides,admin,architecture,operations,reference}/` tree plus top-level pages. All **30** `docs/` pages are in the nav, so `--strict` flags any orphan.
- **`scripts/docs.sh (build|serve)`** — runs mkdocs in the pinned `mkdocs-material` container (by digest), no local Python needed. Exposed as `make docs` / `make docs-serve`.
- **CI `docs-build` job** — runs `scripts/docs.sh build`, wired into the `ci-pass` gate **and** the `create-manifests` release gate alongside `docs-xref`. A broken internal link or nav gap now fails CI.
- **Fixed the 7 links `--strict` caught** — docs pages pointing at repo-root files outside the site (README, AGENTS, CONTRIBUTING, the two workflow YAMLs) now use absolute `github.com/…/blob/main` URLs, which resolve both on the site and in GitHub's markdown view. `docs-xref` only checks `docs/…` refs, so it's unaffected.
- `.gitignore` the mkdocs `site/` output.

**Verification:**
- `scripts/docs.sh build` → "Documentation built" with **zero** warnings under `--strict`.
- `actionlint` clean on the `docs-build` job; `shellcheck` clean on `docs.sh` (only benign SC1091); YAML valid.

**Follow-ups on #138** (content, not infra): the missing ops pages (production-checklist, runbooks, security-hardening, DR split out of backup-restore) and the `llms.txt` enabling-features table.