### PR TITLE
docs: explain why "never tag a red main" is discipline, not CI-enforced

### DIFF
--- a/docs/releasing.md
+++ b/docs/releasing.md
@@ -19,7 +19,13 @@ first; then follow the steps here.
    the third-party review (which scales with the diff).
 3. **`main` CI is green** on the commit you're about to tag. **Never tag a red
    main.** (`gh run watch` the main-branch run to exit 0 first — "it'll probably
-   pass" is not sufficient.)
+   pass" is not sufficient.) This is enforced by discipline, not by CI: image
+   builds gate only on `prepare`, so a commit whose lint/test failed can still
+   have images in GHCR. A tag on that commit sees `images_exist=true`, **skips**
+   re-validation, and the release gate accepts the skip — so a red commit *can*
+   be released via a tag. (Terrapod's pipeline has the same shape; closing this
+   would mean gating image builds on the full validation set and slowing every
+   main-push publish.)
 
 ## Cutting the release
 


### PR DESCRIPTION
Refs #127. Resolves the release-gate finding from the #127 CI-hardening assessment.

Most of #127 turned out to be **already implemented** in bamf (per-job timeouts, the 4-topology helm-smoke render, the real `alembic upgrade→downgrade→upgrade` check, the no-secrets-in-ConfigMap contract, `npm run build`). The one substantive item was the "skip-counts-as-pass" release-gate hole.

**Finding:** `build-images` gates only on `prepare`, so a commit whose lint/test failed can still have images pushed to GHCR; a tag on it sees `images_exist=true`, **skips** re-validation, and the release gate accepts the skip → a red commit can be released via a tag. **Terrapod's pipeline has the exact same shape** — its release gate uses the identical `(success || skipped)` pattern and `build-images` needs only `prepare`. So bamf is already at Terrapod parity here; closing the hole would mean diverging *beyond* Terrapod and gating every main-push image publish on the full validation set (~+250s on the CodeQL long pole).

Given the north star is Terrapod convergence, the aligned resolution is to **make the shared limitation explicit** rather than diverge. `docs/releasing.md` already said "never tag a red main"; this adds the *why*, so the rule reads as a real constraint. No pipeline change.