### PR TITLE
ci: DRY GHCR auth into a composite action + retry transient GHCR ops

### DIFF
--- a/.github/actions/ghcr-login/action.yml
+++ b/.github/actions/ghcr-login/action.yml
@@ -1,0 +1,47 @@
+name: GHCR login (with retry)
+description: |
+  Authenticate the Docker CLI (and optionally Helm) against ghcr.io with
+  exponential backoff so transient GHCR / Docker Hub blips don't fail an
+  otherwise-healthy build. Replaces docker/login-action, which has no retry
+  knob. Requires the repository to be checked out (uses .github/scripts).
+
+inputs:
+  token:
+    description: GHCR token (typically secrets.GITHUB_TOKEN)
+    required: true
+  username:
+    description: GHCR username (typically github.actor)
+    required: true
+  helm:
+    description: Also run `helm registry login` (set 'true' for jobs that push the Helm chart)
+    required: false
+    default: 'false'
+
+runs:
+  using: composite
+  steps:
+    - name: docker login ghcr.io (with retry)
+      shell: bash
+      env:
+        GHCR_TOKEN: ${{ inputs.token }}
+        GHCR_USER: ${{ inputs.username }}
+        ALSO_HELM: ${{ inputs.helm }}
+      run: |
+        set -u
+        # docker / helm don't accept stdin pipes cleanly when invoked via
+        # with-retry.sh's `"$@"`, so wrap each login in a shell function.
+        do_docker_login() {
+          echo "$GHCR_TOKEN" | docker login ghcr.io -u "$GHCR_USER" --password-stdin
+        }
+        do_helm_login() {
+          echo "$GHCR_TOKEN" | helm registry login ghcr.io --username "$GHCR_USER" --password-stdin
+        }
+        export -f do_docker_login do_helm_login
+
+        "$GITHUB_WORKSPACE/.github/scripts/with-retry.sh" "docker login" -- \
+          bash -c do_docker_login
+
+        if [ "$ALSO_HELM" = "true" ]; then
+          "$GITHUB_WORKSPACE/.github/scripts/with-retry.sh" "helm login" -- \
+            bash -c do_helm_login
+        fi

--- a/.github/scripts/with-retry.sh
+++ b/.github/scripts/with-retry.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+# Run a command with exponential-backoff retry for transient infrastructure
+# flakes (GHCR / Docker Hub blips).
+#
+# Usage:   .github/scripts/with-retry.sh "<label>" -- cmd args...
+#
+# Five attempts at 5s, 10s, 20s, 40s intervals (total cap ~75s). Emits GitHub
+# Actions `::warning::` lines between attempts and `::error::` on terminal
+# failure so flakes show up annotated in the run summary.
+#
+# Used for GHCR-touching ops the upstream action / CLI doesn't retry itself:
+# docker login is wrapped by .github/actions/ghcr-login; this also covers
+# `docker buildx imagetools create` and `helm push`.
+set -u
+
+if [ "$#" -lt 3 ] || [ "$2" != "--" ]; then
+  echo "usage: with-retry.sh '<label>' -- <command> [args...]" >&2
+  exit 2
+fi
+
+label="$1"
+shift 2 # drop label + '--'
+
+for i in 1 2 3 4 5; do
+  if "$@"; then
+    exit 0
+  fi
+  if [ "$i" -eq 5 ]; then
+    echo "::error::$label failed after 5 attempts"
+    exit 1
+  fi
+  wait=$((5 * (2 ** (i - 1))))
+  echo "::warning::$label attempt $i failed; retrying in ${wait}s"
+  sleep "$wait"
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,11 +60,10 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Check if images exist
         id: check
@@ -421,11 +420,10 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and push
         uses: docker/build-push-action@53b7df96c91f9c12dcc8a07bcb9ccacbed38856a # v7
@@ -461,11 +459,10 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
 
       - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Scan with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # 0.36.0
@@ -523,18 +520,22 @@ jobs:
       matrix:
         image: [bamf-api, bamf-bridge, bamf-agent, bamf-web, bamf-proxy]
     steps:
+      # Checkout is required for the local ./.github/actions/ghcr-login composite
+      # action (and its with-retry.sh helper); this job otherwise needs no repo.
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+
       - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Create multi-arch manifest
         run: |
           sha_short="${{ needs.prepare.outputs.sha_short }}"
           echo "Creating manifest for ${{ matrix.image }}:sha-$sha_short"
-          docker buildx imagetools create -t "$REGISTRY/${{ matrix.image }}:sha-$sha_short" \
+          .github/scripts/with-retry.sh "imagetools create ${{ matrix.image }}" -- \
+            docker buildx imagetools create -t "$REGISTRY/${{ matrix.image }}:sha-$sha_short" \
             "$REGISTRY/${{ matrix.image }}:sha-${sha_short}-amd64" \
             "$REGISTRY/${{ matrix.image }}:sha-${sha_short}-arm64"
 
@@ -557,12 +558,12 @@ jobs:
         with:
           fetch-depth: 0
 
-      - name: Log in to GHCR
-        uses: docker/login-action@af1e73f918a031802d376d3c8bbc3fe56130a9b0 # v4
+      - name: Log in to GHCR (docker + helm)
+        uses: ./.github/actions/ghcr-login
         with:
-          registry: ghcr.io
+          token: ${{ secrets.GITHUB_TOKEN }}
           username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          helm: 'true'
 
       - name: Retag images with version
         run: |
@@ -571,7 +572,8 @@ jobs:
 
           for image in bamf-api bamf-bridge bamf-agent bamf-web bamf-proxy; do
             echo "Retagging $image:sha-$sha_short -> $version + latest"
-            docker buildx imagetools create \
+            .github/scripts/with-retry.sh "retag $image" -- \
+              docker buildx imagetools create \
               -t "$REGISTRY/$image:$version" \
               -t "$REGISTRY/$image:latest" \
               "$REGISTRY/$image:sha-$sha_short"
@@ -585,12 +587,12 @@ jobs:
           version="${{ needs.prepare.outputs.version }}"
           chart_version="${version#v}"
 
-          echo "${{ secrets.GITHUB_TOKEN }}" | helm registry login ghcr.io --username "${{ github.actor }}" --password-stdin
-
+          # helm registry login is handled by the ghcr-login step (helm: true).
           helm package helm/bamf --destination dist/ \
             --version "$chart_version" --app-version "$version"
 
-          helm push "dist/bamf-${chart_version}.tgz" "oci://$REGISTRY"
+          .github/scripts/with-retry.sh "helm push" -- \
+            helm push "dist/bamf-${chart_version}.tgz" "oci://$REGISTRY"
 
       - name: Build cross-platform Go binaries
         run: scripts/build.sh binaries


### PR DESCRIPTION
Refs #127 (the composite-action / GHCR-retry item). Ports Terrapod's `ghcr-login` pattern.

The five GHCR logins were inlined `docker/login-action@v4` blocks with **no retry**, so a transient GHCR/Docker Hub blip failed an otherwise-healthy build or release.

**What's added:**
- **`.github/actions/ghcr-login`** (composite) — wraps `docker login` (and, with `helm: true`, `helm registry login`) in exponential-backoff retry. Replaces all five inlined login blocks (DRY).
- **`.github/scripts/with-retry.sh`** — 5 attempts at 5/10/20/40s with `::warning::`/`::error::` annotations. Also wraps the GHCR-touching **release** ops the CLI doesn't retry itself: `docker buildx imagetools create` (sha manifest + version retag) and `helm push`.
- `create-manifests` gains a `checkout` (the local composite + helper need the repo); the `release` login uses `helm: true`, dropping its separate inline `helm registry login`.

**Risk & how it's de-risked** (touches release-path jobs that only run on main/tags):
- `with-retry.sh` unit-tested locally — success (no retry), usage error (exit 2), eventual success on attempt 3, terminal failure (exit 2→1).
- The composite is a verbatim port of Terrapod's production action (the `export -f` + `bash -c` login pattern).
- `actionlint` clean on `ci.yml` (only the two pre-existing style notes remain); all 5 login jobs check out before the login step.
- **Coverage:** `prepare`'s login runs on every PR (validated here); build/scan/manifest logins + `imagetools create` retry run on the **main** push after merge (I'll watch it); the release `helm login`/`helm push` path runs on the **next tag** (I'll watch that release).