### PR TITLE
docs: add production-checklist, runbooks, security-hardening + DR pages

### DIFF
--- a/docs/admin/security-hardening.md
+++ b/docs/admin/security-hardening.md
@@ -1,0 +1,91 @@
+# Security Hardening
+
+Operational hardening for a production BAMF deployment. This is the *how to lock
+it down* companion to the design-level [Security](../architecture/security.md)
+page and the [Production Checklist](../operations/production-checklist.md).
+
+## Transport security
+
+- **PostgreSQL**: require TLS — `core.postgresql.external.sslmode: require` (or
+  `verify-full` with a CA bundle).
+- **Redis**: use a TLS endpoint where your provider offers one; keep Redis on a
+  private subnet regardless.
+- **Ingress**: terminate public TLS at the ingress with a cert-manager-issued
+  wildcard (`tls.certManager`). Tunnel mTLS (CLI ↔ bridge ↔ agent) uses the
+  BAMF internal CA and is independent of the public cert.
+
+## Authentication hardening
+
+- **Disable local auth** (`core.auth.local.enabled: false`) so all access goes
+  through your IdP, where MFA is enforced. Keep at most one break-glass local
+  admin, and know its blast radius.
+- **Require SSO for privileged roles** — list `admin`, `k8s-access`, etc. under
+  `require_external_sso_for_roles` so they can never be reached via local
+  password.
+- **Short user certs** — `core.api.config.certificates.user_ttl_hours` (default
+  12). Lower it if your sessions should expire faster; users re-login via SSO.
+
+## Secrets
+
+- **Kubernetes Secrets only** — never place a password, client secret, or join
+  token in the API ConfigMap. The chart wires all of these via `secretKeyRef` /
+  `existingSecret`; CI's `helm-config-contract` fails a build that leaks one.
+- **ExternalSecrets Operator** (recommended) — sync DB/Redis/OIDC credentials
+  from AWS Secrets Manager / Vault / etc. rather than inline `password:` values,
+  so nothing sensitive lives in your GitOps repo.
+- **The CA key** is stored in the `bamf-ca` Secret and mirrored into PostgreSQL
+  for disaster recovery — protect database backups accordingly (see
+  [Disaster Recovery](../operations/disaster-recovery.md)).
+
+## Network policies
+
+The chart does not ship NetworkPolicies — author them for your cluster. Enforce:
+
+- Only **API pods** may reach PostgreSQL and Redis. Bridges, agents, the proxy,
+  and web UI must not.
+- Bridge tunnel ports accept traffic only from the ingress controller.
+- Default-deny egress where practical; allow agents only their targets + the API.
+
+## Pod security
+
+Set `podSecurityContext` (and container `securityContext`) per component to run
+as non-root, read-only root filesystem where possible, and drop all
+capabilities. The bridge needs `devpts` for web-terminal PTYs but still runs
+unprivileged. Align with the Kubernetes **Restricted** Pod Security Standard.
+
+## Rate limiting
+
+Two independent tiers, both worth enabling:
+
+- **Ingress** (`gateway.rateLimit`) — coarse per-IP limiting at the edge
+  (Traefik Middleware / Istio EnvoyFilter).
+- **API app tier** (`core.api.config.rate_limit`) — a Redis-backed sliding
+  window that distinguishes authenticated from anonymous traffic and applies a
+  strict per-IP limit to `/auth/*` for login brute-force defence. Tune
+  `trusted_proxy_hops` to the number of proxies in front of the API so client
+  IPs aren't spoofable.
+
+## Audit logging
+
+- **Retention** — `core.api.config.audit.retention_days` (default 90; `0`
+  disables pruning and keeps rows forever). A background sweep enforces it.
+- **API self-audit** — `core.api.config.audit.api_audit_enabled` records API
+  request/response exchanges (with redaction) for a full control-plane trail.
+- **SIEM export** — poll the audit API (`GET /api/v1/audit`, cursor-paginated)
+  from your SIEM. Sensitive headers/bodies are redacted before storage.
+
+## Database hardening
+
+- Dedicated database and least-privilege role for BAMF (no superuser).
+- Encryption at rest (default on managed providers) and in transit (above).
+- Restrict network access to the API's security group / subnet only.
+
+## Agent isolation
+
+- **Join tokens** are short-lived (default 24h) and can be usage-capped and
+  revoked. Delete a token once the agent has registered — the cert then carries
+  identity, and the token is no longer needed.
+- **Kubernetes access** is via impersonation: the agent's ServiceAccount holds
+  `impersonate` and BAMF roles decide which `kubernetes_groups` a user maps to.
+  Never grant a proxied app its own K8s RBAC — that bypasses BAMF entirely. Keep
+  the agent SA scoped to impersonation only.

--- a/docs/operations/backup-restore.md
+++ b/docs/operations/backup-restore.md
@@ -53,40 +53,15 @@ velero restore create --from-backup bamf-backup
 
 ## Disaster Recovery
 
-### Full Recovery from Database Backup
+The full break-glass procedure — restoring PostgreSQL, letting the API recover
+the CA from the database, and bringing components back online — lives on its own
+page: [Disaster Recovery](disaster-recovery.md).
 
-1. Provision new PostgreSQL instance
-2. Restore backup: `pg_restore -d bamf bamf-backup.dump`
-3. Deploy BAMF with `ca.provider: bootstrap-from-db`
-4. API extracts CA from database, creates K8s Secret
-5. Verify: agents reconnect, users can log in
-
-### CA Key Recovery
-
-If the K8s Secret containing the CA is deleted but PostgreSQL is intact:
-
-```zsh
-# API auto-recovers on startup: detects missing Secret, reads CA from DB
-kubectl -n bamf rollout restart deployment/bamf-api
-```
-
-Or manually extract:
-```zsh
-bamf admin ca export --output ca.crt --key ca.key
-kubectl -n bamf create secret generic bamf-ca \
-  --from-file=ca.crt --from-file=ca.key
-```
-
-### Partial Recovery
-
-If only Redis is lost (restart, eviction):
-- No action needed — all components reconnect and re-register
-- Active tunnel sessions will disconnect; users reconnect
-
-If only individual pods are lost:
-- Kubernetes restarts them automatically
-- Bridges re-register; agents reconnect
-- Active tunnels migrate via reliable stream protocol
+In brief: PostgreSQL is the only thing you must restore (it holds users, roles,
+the audit log, and the CA). If the `bamf-ca` Secret is gone but the database is
+intact, the API recreates it from the database on the next start
+(`kubectl -n bamf rollout restart deployment/bamf-api`). If only Redis is lost,
+do nothing — bridges re-register, agents reconnect, and users re-login.
 
 ## Testing Restores
 

--- a/docs/operations/disaster-recovery.md
+++ b/docs/operations/disaster-recovery.md
@@ -1,0 +1,68 @@
+# Disaster Recovery
+
+Break-glass recovery of a BAMF control plane after losing the cluster, the
+database, or both. The single source of truth you must protect is **PostgreSQL**
+— it holds users, roles, role assignments, the audit log, and the internal CA
+(cert + key). A PostgreSQL backup is therefore a complete recovery point.
+Redis is disposable: its state rebuilds itself.
+
+See [Backup & Restore](backup-restore.md) for how to *take* the backups this
+procedure restores from.
+
+## What survives what
+
+| Loss | Impact | Recovery |
+|---|---|---|
+| Redis only | New tunnels/sessions fail transiently | Restart Redis; bridges re-register, agents reconnect, users re-login. No restore needed. |
+| API pods / cluster (DB intact) | Control plane down | Redeploy the chart against the same PostgreSQL; the CA and all identity come back from the DB. |
+| PostgreSQL | Users, roles, audit, and CA lost | Restore PostgreSQL from backup (below), then redeploy. |
+
+## Full recovery from a database backup
+
+### 1. Restore PostgreSQL
+
+Restore your latest backup into a reachable PostgreSQL instance (see
+[Backup & Restore](backup-restore.md) for `pg_dump`/snapshot specifics). This
+brings back users, roles, role assignments, the audit log, and the CA keypair.
+
+### 2. Redeploy BAMF against the restored database
+
+```sh
+helm upgrade --install bamf oci://ghcr.io/mattrobinsonsre/bamf \
+  --namespace bamf --create-namespace \
+  --values production-values.yaml \
+  --set core.postgresql.external.host=<restored-db-host>
+```
+
+### 3. The CA recovers automatically
+
+On startup the API reads the CA from the `bamf-ca` Kubernetes Secret. If that
+Secret is missing (a fresh cluster) but the CA exists in the restored database,
+the API **recreates the Secret from the database**. No manual CA import is
+needed — protecting the database protects the CA.
+
+### 4. Bring components back and let clients reconnect
+
+- Bridges register in Redis on startup and become available.
+- Agents reconnect over HTTPS; if their certificates are still within their
+  1-year validity they resume without re-registration and re-publish resources.
+- Users run `bamf login` again to get fresh short-lived certs.
+
+## Verification
+
+- `/ready` on the API returns 200 (DB + Redis reachable).
+- `bamf login` issues a certificate through your IdP.
+- Existing agents show **online** and their resources appear in `bamf ls`.
+- A `bamf ssh <resource>` session succeeds and lands in the audit log.
+- Spot-check the audit log for pre-incident entries (confirms the DB restore
+  captured history).
+
+## Notes
+
+- **Rehearse this.** A restore you have never tested is a hope, not a plan. Run
+  it against a scratch database on a schedule.
+- **CA rotation window**: a database backup taken *before* a CA rotation is your
+  rollback for a bad rotation — keep enough retention to cover your rotation
+  cadence.
+- **Redis-only restores are unnecessary** — never try to "restore" Redis; let it
+  rebuild from live heartbeats and logins.

--- a/docs/operations/production-checklist.md
+++ b/docs/operations/production-checklist.md
@@ -1,0 +1,100 @@
+# Production Readiness Checklist
+
+Work through this before putting a BAMF deployment in front of real users. Each
+item links to the page with the detail. Treat unchecked items as blockers, not
+nice-to-haves.
+
+## Infrastructure
+
+- [ ] **Kubernetes 1.27+** with a **Traefik v3** or **Istio** ingress that can do
+      **SNI-based TLS passthrough** (standard `Ingress` cannot route tunnel
+      traffic to individual bridge pods). See
+      [Deployment → Ingress Requirements](../admin/deployment.md).
+- [ ] **External PostgreSQL** (`core.postgresql.external.enabled: true`) — RDS,
+      Aurora, Cloud SQL, etc. — with Multi-AZ/HA and automated backups. The
+      bundled subchart is dev/staging only.
+- [ ] **External Redis** (`core.redis.external.enabled: true`) — ElastiCache,
+      Memorystore, etc. Redis holds live tunnel/session state; losing it is
+      recoverable (agents re-register, users re-login) but disruptive.
+- [ ] **Wildcard DNS** for `*.tunnel.<domain>` and `*.bridge.tunnel.<domain>`
+      pointing at the ingress LoadBalancer.
+
+## Certificates & the internal CA
+
+- [ ] **Public TLS** via cert-manager — a wildcard cert for `*.tunnel.<domain>`
+      (DNS-01) referenced through `tls.certManager.issuerRef`, plus the
+      API/Web host cert.
+- [ ] **Internal CA** — issued and owned by the API, backed up inside PostgreSQL
+      (so a database backup is a complete CA backup). No separate CA key to
+      manage. See [Certificates](../admin/certificates.md).
+- [ ] **Certificate lifetimes** reviewed (`core.api.config.certificates`):
+      user 12h, agent 8760h (1 year), bridge 24h. Shorten user certs if your
+      threat model calls for it.
+
+## Authentication & access control
+
+- [ ] **SSO configured** (OIDC/SAML) as the default provider; Auth0 or your IdP.
+      See [SSO](../admin/sso.md).
+- [ ] **Local auth disabled** for production (`core.auth.local.enabled: false`)
+      unless you have a deliberate break-glass local admin.
+- [ ] **`require_external_sso_for_roles`** set so privileged roles (admin,
+      k8s-access) can't be obtained via local password.
+- [ ] **RBAC reviewed** — roles, allow/deny by label and name, and
+      `kubernetes_groups` mappings. Deny wins; admin bypasses everything. See
+      [RBAC](../admin/rbac.md).
+
+## Secrets
+
+- [ ] **No secrets in ConfigMaps** — database/Redis passwords, OIDC client
+      secrets, and join tokens flow via `secretKeyRef` / `existingSecret` /
+      ExternalSecrets, never the API ConfigMap. CI enforces this
+      (`helm-config-contract`), but confirm your overrides follow it.
+- [ ] **ExternalSecrets** (recommended) syncing DB/Redis/OIDC credentials from
+      your secret store rather than inline `password:` values.
+
+## Networking & isolation
+
+- [ ] **NetworkPolicy** applied so only API pods reach PostgreSQL/Redis (the
+      chart does not ship one — author it for your cluster). Bridges, agents,
+      and the proxy must never connect to the data stores directly.
+- [ ] **Rate limiting** enabled at both tiers: ingress (`gateway.rateLimit`) and
+      the API's per-IP sliding window (`core.api.config.rate_limit`, which
+      applies a stricter limit to `/auth/*`).
+- [ ] **`podSecurityContext`** set per component (run as non-root, drop
+      capabilities) — see [Security Hardening](../admin/security-hardening.md).
+
+## Backups & recovery
+
+- [ ] **PostgreSQL backups** automated (daily minimum, hourly for prod) — this
+      captures users, roles, audit log, and the CA. See
+      [Backup & Restore](backup-restore.md).
+- [ ] **Restores tested** on a schedule, not assumed. Rehearse the
+      [Disaster Recovery](disaster-recovery.md) break-glass path at least once.
+
+## Monitoring & observability
+
+- [ ] **Bridge metrics** scraped (`bamf_bridge_*`, the only Prometheus surface).
+      See [Monitoring](monitoring.md).
+- [ ] **Structured logs** shipped to your aggregator (JSON, stdout).
+- [ ] **Audit log retention** set (`core.api.config.audit.retention_days`,
+      default 90; `0` keeps forever) and, if required, exported to a SIEM via
+      the audit API.
+
+## Scaling & availability
+
+- [ ] **API replicas ≥ 2** with an HPA and a PodDisruptionBudget (`pdb`).
+- [ ] **Bridge HPA** and per-pod Services/TLSRoutes pre-created up to
+      `maxReplicas`. See [Scaling](scaling.md).
+- [ ] **Spot/termination handling** — `terminationGracePeriodSeconds` and
+      preStop drains are set so tunnels migrate or reconnect cleanly.
+
+## Pre-go-live validation
+
+Smoke-test the real stack, not just unit tests:
+
+- [ ] `bamf login` through your production IdP issues a certificate.
+- [ ] `bamf ssh <resource>` opens a session and it appears in the audit log.
+- [ ] A web app resource loads through `https://<app>.tunnel.<domain>`.
+- [ ] `kubectl --context bamf-<cluster> get pods` works via the proxy.
+- [ ] An access-denied case is actually denied (negative test).
+- [ ] Kill a bridge pod mid-session and confirm the reliable stream reconnects.

--- a/docs/operations/runbooks.md
+++ b/docs/operations/runbooks.md
@@ -1,0 +1,182 @@
+# Operational Runbooks
+
+Per-condition response playbooks. Each follows **Symptoms → Diagnosis →
+Resolution → Verification**. Commands assume `kubectl` is pointed at the BAMF
+cluster and the release is named `bamf` in namespace `bamf`.
+
+For historical logs of pods that have already restarted or been evicted, query
+your log aggregator rather than `kubectl logs` — pod logs are ephemeral.
+
+## Bridge pod OOM-killed or restarting
+
+### Symptoms
+Active tunnels stall for 1–2s then recover; `kubectl get pods` shows a
+`bamf-bridge-N` with a recent restart or `OOMKilled` last state.
+
+### Diagnosis
+```sh
+kubectl -n bamf describe pod bamf-bridge-0 | grep -A3 "Last State"
+kubectl -n bamf top pod -l app.kubernetes.io/component=bridge
+```
+`ssh-audit` sessions hold SSH state in the bridge and cannot survive a crash;
+plain `ssh`/DB tunnels use the reliable stream and reconnect automatically.
+
+### Resolution
+Raise `outpost.bridge.resources.limits.memory` and roll the StatefulSet. If OOM
+is driven by session count, lower `targetTunnelsPerPod` (or
+`nonMigratableOversubscribeFactor` for `ssh-audit`-heavy fleets) so the HPA
+scales out sooner.
+
+### Verification
+`bamf_bridge_*` memory metrics settle below the limit; no further `OOMKilled`
+events; a test tunnel survives a `kubectl delete pod bamf-bridge-0`.
+
+## Bridge draining for scale-in / maintenance
+
+### Symptoms
+A bridge is being removed (scale-in, node drain, spot warning) and you want
+zero-disruption handoff.
+
+### Diagnosis
+```sh
+kubectl -n bamf get pods -l app.kubernetes.io/component=bridge
+```
+
+### Resolution
+On SIGTERM the bridge notifies the API to drain and migrates active tunnels to
+other bridges before exiting (within `terminationGracePeriodSeconds`). Don't
+`--force` delete — that skips the drain. If a drain hangs, confirm other
+bridges have capacity (HPA `minReplicas` > 1) before the grace period expires.
+
+### Verification
+Sessions on the drained bridge migrated (no client disconnects); the pod exited
+0; `bridges:available` in Redis no longer lists it.
+
+## Agent shows offline
+
+### Symptoms
+A resource disappears from `bamf ls`; the Agents page shows the agent offline.
+
+### Diagnosis
+An agent is marked offline after 3 missed 60s heartbeats. Check:
+```sh
+kubectl -n <agent-ns> logs deploy/bamf-agent --tail=100
+```
+Look for API-connectivity errors (agent → API over HTTPS) or an expired agent
+certificate.
+
+### Resolution
+- **Network**: confirm the agent can reach `platformUrl` (public HTTPS). Agent
+  SSE reconnect uses exponential backoff (1s → 5m).
+- **Cert expired**: agent certs last 1 year and auto-renew before expiry; if it
+  lapsed, re-deploy with a valid join token so it re-registers. The cert is
+  stored in a K8s Secret (or the data dir on VMs) and survives pod restarts.
+
+### Verification
+Agent status flips online; its resources reappear in `bamf ls`; a tunnel to one
+of them succeeds.
+
+## Certificate authority expiry approaching
+
+### Symptoms
+Monitoring flags the internal CA nearing expiry, or newly issued identity/session
+certs fail validation at the bridge.
+
+### Diagnosis
+The CA is owned by the API and mirrored into PostgreSQL. Inspect the CA cert via
+`GET /api/v1/certificates/ca` (or the `bamf-ca` Secret).
+
+### Resolution
+CA rotation is an admin operation — plan it in a maintenance window. After
+rotation, agents and CLIs fetch the new CA public cert at their next bootstrap
+(inline in join/login responses); long-lived agent certs remain valid until
+their own expiry. Because the CA lives in PostgreSQL, a DB backup taken before
+rotation is your rollback.
+
+### Verification
+New `bamf login` / `bamf ssh` sessions validate against the bridge; existing
+agents reconnect without re-registration.
+
+## Redis unavailable
+
+### Symptoms
+New tunnel setup fails; the resource catalog empties; browser proxy sessions
+fail. Existing spliced tunnels keep flowing (the bridge holds no Redis
+dependency mid-tunnel).
+
+### Diagnosis
+```sh
+kubectl -n bamf logs deploy/bamf-api --tail=100 | grep -i redis
+```
+
+### Resolution
+Restore Redis connectivity. All Redis state is recoverable: bridges re-register
+on heartbeat, agents reconnect and re-publish resources, sessions time out and
+users reconnect. No data is lost from Redis loss alone — durable identity and
+audit live in PostgreSQL.
+
+### Verification
+`bamf ls` repopulates; a new `bamf ssh` succeeds; the Agents/Bridges views
+refill.
+
+## API pod CrashLoopBackOff
+
+### Symptoms
+`bamf-api` pods restart repeatedly; the platform is unreachable.
+
+### Diagnosis
+Investigate before deleting — do not hope a restart fixes it.
+```sh
+kubectl -n bamf logs deploy/bamf-api --previous --tail=200
+kubectl -n bamf describe pod -l app.kubernetes.io/component=api
+```
+Common causes: bad `DATABASE_URL`/credentials, unreachable PostgreSQL, or a
+pending migration.
+
+### Resolution
+- **DB connectivity/creds**: fix the Secret/`externalSecret` and roll.
+- **Migration mismatch**: ensure the migration job ran `alembic upgrade head`
+  for this release (see below).
+
+### Verification
+Pods reach `Ready`; `/ready` returns 200 (it checks DB + Redis).
+
+## Migration job failed
+
+### Symptoms
+Helm upgrade hangs or the API won't start after a version bump; the migration
+job/hook is in `Error`.
+
+### Diagnosis
+```sh
+kubectl -n bamf logs job/bamf-migrations
+```
+
+### Resolution
+Fix the underlying DB issue (permissions, connectivity, a conflicting manual
+change) and re-run the upgrade. For external PostgreSQL the migration runs as a
+pre-install/upgrade hook and must complete before the deployment proceeds. Never
+edit `alembic_version` by hand unless you understand exactly which revision the
+schema is at.
+
+### Verification
+The job completes; `alembic upgrade head` is a no-op on re-run; the API starts
+and `/ready` is green.
+
+## Tunnel setup times out
+
+### Symptoms
+`bamf ssh <resource>` errors after ~30s with a setup timeout.
+
+### Diagnosis
+Tunnel setup fails if the agent doesn't dial the assigned bridge within 30s.
+Check the agent is online (`bamf ls`), reachable, and that the SNI hostname
+`N.bridge.tunnel.<domain>` resolves and routes to the bridge pod.
+
+### Resolution
+- Agent offline → see [Agent shows offline](#agent-shows-offline).
+- SNI routing broken → verify the per-pod Service + TLSRoute/IngressRouteTCP for
+  that bridge ordinal exist (pre-created up to `maxReplicas`).
+
+### Verification
+`bamf ssh` connects; the session start appears in the audit log.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - SSO: admin/sso.md
       - Users: admin/users.md
       - Certificates: admin/certificates.md
+      - Security Hardening: admin/security-hardening.md
   - Architecture:
       - Overview: architecture/overview.md
       - Authentication: architecture/authentication.md
@@ -71,9 +72,12 @@ nav:
       - Security: architecture/security.md
       - Outpost Deployments: architecture/outpost-deployments.md
   - Operations:
+      - Production Checklist: operations/production-checklist.md
+      - Runbooks: operations/runbooks.md
       - Monitoring: operations/monitoring.md
       - Scaling: operations/scaling.md
       - Backup & Restore: operations/backup-restore.md
+      - Disaster Recovery: operations/disaster-recovery.md
       - Upgrading: operations/upgrading.md
   - Reference:
       - CLI: reference/cli.md


### PR DESCRIPTION
Refs #138. Fills the operational-docs gap — the page types a real operator needs, now validated by the strict mkdocs gate (in-nav, all links resolve).

| Page | What it covers |
|---|---|
| `operations/production-checklist.md` | Go-live gate: external PG/Redis, SNI ingress, CA/cert-manager, SSO + disable-local + `require_external_sso_for_roles`, no-secrets-in-ConfigMaps, NetworkPolicy, both rate-limit tiers, backups, HPA/PDB, pre-go-live smoke list. |
| `operations/runbooks.md` | Symptoms → Diagnosis → Resolution → Verification for bridge OOM/drain, agent-offline, CA-expiry, Redis-down, API CrashLoop, migration-job failure, tunnel setup timeout. |
| `admin/security-hardening.md` | Ops hardening (TLS, disable local auth, cert TTLs, K8s Secrets/ExternalSecrets, NetworkPolicy, pod security, rate limiting, audit retention/SIEM, DB hardening, agent isolation) — distinct from design-level `architecture/security.md`. |
| `operations/disaster-recovery.md` | Break-glass: restore PostgreSQL (holds users/roles/audit/CA), the API recreates the `bamf-ca` Secret from the DB on start, components reconnect. |

**Also:** slimmed the duplicate DR section in `backup-restore.md` to a pointer, dropping its **fictional** `ca.provider: bootstrap-from-db` and `bamf admin ca export` steps (the CA is API-generated + DB-backed; there's no such Helm key or command).

**Accuracy:** every Helm key cited was checked against `values.yaml` / `values.schema.json` / `config.py` (e.g. `core.auth.local.enabled`, `require_external_sso_for_roles`, `gateway.rateLimit` + `core.api.config.rate_limit`, `outpost.bridge.*`) — no reintroduced drift. `mkdocs build --strict` passes; `docs-xref` resolves; content-hygiene clean.