### PR TITLE
ci: enforce the content-hygiene hard gate in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,6 +204,19 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
       - run: scripts/docs.sh build
 
+  # Automates the AGENTS.md content-hygiene HARD gate: fails if a tracked file
+  # leaks a company name / internal hostname / private tailnet host into this
+  # public repo. Was a manual pre-release step.
+  content-hygiene:
+    name: Content Hygiene
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - run: scripts/content-hygiene.sh
+
   # ── Web ─────────────────────────────────────────────────
   web-lint:
     name: Web Lint
@@ -500,6 +513,7 @@ jobs:
       - web-lint
       - docs-xref
       - docs-build
+      - content-hygiene
       - helm-lint
       - sast
       - secret-scan
@@ -719,6 +733,7 @@ jobs:
       - python-security
       - docs-xref
       - docs-build
+      - content-hygiene
       - web-lint
       - web-build
       - web-audit
@@ -751,6 +766,7 @@ jobs:
             "${{ needs.web-audit.result }}"
             "${{ needs.docs-xref.result }}"
             "${{ needs.docs-build.result }}"
+            "${{ needs.content-hygiene.result }}"
             "${{ needs.helm-lint.result }}"
             "${{ needs.sast.result }}"
             "${{ needs.secret-scan.result }}"

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@
 	clean clean-cache test-down \
 	db-migrate db-rollback db-reset \
 	migration-check docs-xref helm-config-contract \
-	docs docs-serve \
+	docs docs-serve content-hygiene \
 	help
 
 # ── Variables (for build-local only) ─────────────────────
@@ -65,6 +65,9 @@ docs-serve:         ## Live-preview the docs site at http://localhost:8000
 
 helm-config-contract: ## Assert no secrets land in a rendered ConfigMap
 	scripts/helm-config-contract.sh
+
+content-hygiene:    ## Fail if a tracked file leaks an internal identifier (public repo)
+	scripts/content-hygiene.sh
 
 # ── Build ─────────────────────────────────────────────────
 build:              ## Cross-compile Go binaries for all platforms (Docker)

--- a/scripts/content-hygiene.sh
+++ b/scripts/content-hygiene.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+# content-hygiene: fail if any tracked file contains a forbidden internal
+# identifier. Automates the AGENTS.md content-hygiene HARD gate — this is a
+# public repository, so a leaked company name, internal hostname, or private
+# tailnet host in source/docs is world-readable forever.
+#
+# Scans `git ls-files` (so gitignored files like the local CLAUDE.md are never
+# looked at) and greps each text file. Runs on the CI runner where git + the
+# full worktree are present.
+#
+# Usage: scripts/content-hygiene.sh   (exit 1 on the first offending file)
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+# Forbidden internal identifiers. `[.]` keeps the dots literal.
+patterns='acrolinx|markup[.]ai|markupai|acrolinx-cloud[.]net|[.]ts[.]net|grafana[.]net'
+
+# Files where these terms are legitimately present: AGENTS.md defines the policy
+# by naming them, and this script lists them as the patterns to search for.
+allow='^(AGENTS\.md|scripts/content-hygiene\.sh)$'
+
+hits=""
+while IFS= read -r f; do
+  case "$f" in
+    "") continue ;;
+  esac
+  # Skip binary files (grep -I treats them as non-matching / empty).
+  if grep -Iq . "$f" 2>/dev/null; then
+    match=$(grep -inE "$patterns" "$f" 2>/dev/null | sed "s#^#$f:#" || true)
+    [ -n "$match" ] && hits="${hits}${match}"$'\n'
+  fi
+done < <(git ls-files | grep -vE "$allow")
+
+if [ -n "$hits" ]; then
+  echo "content-hygiene: forbidden internal identifier(s) in tracked files:"
+  printf '%s' "$hits"
+  echo "Scrub the reference (anonymise the deployment) before pushing."
+  exit 1
+fi
+echo "content-hygiene: clean"


### PR DESCRIPTION
Refs #137 (executable-invariants — the highest-value one). AGENTS.md declares content-hygiene a **HARD gate** (no company name / internal hostname / private tailnet host in this public repo), but it was only a manual pre-release step + my discipline. This automates it.

- **`scripts/content-hygiene.sh`** scans `git ls-files` (so the gitignored local `CLAUDE.md` is never read) and greps each text file for the forbidden set (`acrolinx` / `markup.ai` / `markupai` / `acrolinx-cloud.net` / `*.ts.net` / `grafana.net`). `AGENTS.md` (which names them to *define* the policy) and the script itself are allowlisted. Exits 1 with `file:line` on any hit.
- New **`content-hygiene` CI job** wired into `ci-pass` and the `create-manifests` release gate; `make content-hygiene` target.

**Verified locally:** clean on the current tree; catches an injected `*.ts.net` leak (exit 1) then clean again after removal; `shellcheck` clean; `actionlint` clean on `ci.yml` (only the 2 pre-existing style notes).

This converts a manual gate I run by hand every release into an always-on guard — exactly the "make declared invariants executable" intent of #137.