### PR TITLE
ci: add async-safety Semgrep rules (AGENTS.md #10)

### DIFF
--- a/pentest/semgrep/.semgrep.yml
+++ b/pentest/semgrep/.semgrep.yml
@@ -71,3 +71,70 @@ rules:
       Possible hardcoded secret. Use environment variables or Kubernetes Secrets.
     languages: [python, go]
     severity: WARNING
+
+  # ── Async safety (AGENTS.md #10: no sync work in async handlers) ──────────
+  # A CPU-heavy or blocking call written directly in an `async def` body starves
+  # the uvicorn event loop for the whole worker. Wrap it in
+  # asyncio.to_thread(...) / run_in_executor(...), or move it into a plain `def`
+  # (FastAPI runs those in a threadpool, and BAMF's hash_password is exactly such
+  # a plain def called via to_thread — so `pattern-inside: async def` does not
+  # flag it).
+
+  - id: bamf-no-sync-pbkdf2-in-async
+    patterns:
+      - pattern: hashlib.pbkdf2_hmac(...)
+      - pattern-inside: |
+          async def $F(...):
+              ...
+    paths:
+      include:
+        - services/
+      exclude:
+        - "**/services/tests/"
+    message: >
+      hashlib.pbkdf2_hmac is CPU-blocking (BAMF runs it at 100k iterations).
+      Calling it directly in an async def starves the event loop (AGENTS.md #10).
+      Wrap it in asyncio.to_thread(...).
+    languages: [python]
+    severity: ERROR
+
+  - id: bamf-no-time-sleep-in-async
+    patterns:
+      - pattern: time.sleep(...)
+      - pattern-inside: |
+          async def $F(...):
+              ...
+    paths:
+      include:
+        - services/
+      exclude:
+        - "**/services/tests/"
+    message: >
+      time.sleep blocks the event loop inside an async def (AGENTS.md #10).
+      Use `await asyncio.sleep(...)`.
+    languages: [python]
+    severity: ERROR
+
+  - id: bamf-no-subprocess-in-async
+    patterns:
+      - patterns:
+          - pattern-either:
+              - pattern: subprocess.run(...)
+              - pattern: subprocess.call(...)
+              - pattern: subprocess.check_call(...)
+              - pattern: subprocess.check_output(...)
+              - pattern: subprocess.Popen(...)
+      - pattern-inside: |
+          async def $F(...):
+              ...
+    paths:
+      include:
+        - services/
+      exclude:
+        - "**/services/tests/"
+    message: >
+      Blocking subprocess call inside an async def starves the event loop
+      (AGENTS.md #10). Use asyncio.create_subprocess_exec(...) or wrap in
+      asyncio.to_thread(...).
+    languages: [python]
+    severity: ERROR


### PR DESCRIPTION
Refs #137 (executable invariants — the async-safety Semgrep item). Completes the #137 set.

The Semgrep config had **zero** rules enforcing AGENTS.md #10 ("no sync work in async handlers") — a real risk for BAMF, which runs PBKDF2 at 100k iterations (a textbook event-loop starver). Adds three ERROR rules that fire when a blocking call sits directly in an `async def` body:

- `hashlib.pbkdf2_hmac(...)`
- `time.sleep(...)`
- `subprocess.run/call/check_call/check_output/Popen(...)`

**Precision:** `pattern-inside: async def` alone is correct here — BAMF's blocking work lives in plain `def`s invoked via `asyncio.to_thread` (`hash_password`/`verify_password`), which the rule does not flag. I initially copied the `pattern-not-inside: def` idiom but testing showed Semgrep also matches the *enclosing* `async def`, which silently made all three rules no-ops; dropped it.

**Verified with Semgrep:** 0 findings on the current tree; all three fire (3 findings) on an injected violation. The `SAST (Semgrep)` CI job already runs this config, so they're enforced on every PR.

This closes the #137 executable-invariants set alongside the content-hygiene gate (#215) and dependency-pins (#216).