### PR TITLE
test: guard the Helm-values → API-config channel against drift

### DIFF
--- a/docker/Dockerfile.test
+++ b/docker/Dockerfile.test
@@ -22,6 +22,9 @@ RUN poetry config virtualenvs.create false \
 COPY services/bamf ./bamf
 COPY services/tests ./tests
 COPY alembic ./alembic
+# values.yaml is needed by tests/test_config_channel.py, which asserts the
+# Helm core.api.config block maps onto real Settings fields.
+COPY helm/bamf/values.yaml ./helm/bamf/values.yaml
 
 # CA data directory for tests
 RUN mkdir -p /var/lib/bamf/ca

--- a/services/tests/test_config_channel.py
+++ b/services/tests/test_config_channel.py
@@ -1,0 +1,69 @@
+"""Guard the Helm-values → API-config channel.
+
+The chart renders ``core.api.config`` (in ``helm/bamf/values.yaml``) into the
+API's ``config.yaml``; ``Settings`` loads it with ``extra="ignore"``, so a key
+that no model field consumes — a rename, or a knob wired to nothing (the #196
+class) — is silently dropped rather than rejected. This is exactly the
+camelCase-values ↔ snake_case-config boundary BAMF has repeatedly gotten wrong.
+
+This walks the real ``values.yaml`` config block against the Settings model tree
+(class-level introspection, no instantiation, no env reads) and fails on any key
+that isn't a real field.
+"""
+
+from __future__ import annotations
+
+import pathlib
+import typing
+
+import yaml
+from pydantic import BaseModel
+
+from bamf.config import Settings
+
+
+def _values_path() -> pathlib.Path:
+    # Repo layout puts values.yaml at <root>/helm/bamf/ (parents[2] locally);
+    # the test image copies it to /app/helm/bamf/ (parents[1]). Try both.
+    here = pathlib.Path(__file__).resolve()
+    for up in (2, 1, 3):
+        cand = here.parents[up] / "helm" / "bamf" / "values.yaml"
+        if cand.exists():
+            return cand
+    raise FileNotFoundError("helm/bamf/values.yaml not found from " + str(here))
+
+
+def _config_block() -> dict:
+    return yaml.safe_load(_values_path().read_text())["core"]["api"]["config"]
+
+
+def _model_of(annotation: object) -> type[BaseModel] | None:
+    """Return the BaseModel subclass an annotation refers to (unwrapping
+    Optional[...] / unions), else None for scalar/leaf fields."""
+    if isinstance(annotation, type) and issubclass(annotation, BaseModel):
+        return annotation
+    for arg in typing.get_args(annotation):
+        if isinstance(arg, type) and issubclass(arg, BaseModel):
+            return arg
+    return None
+
+
+def _check(cfg: dict, model: type[BaseModel], path: str = "") -> list[str]:
+    errors: list[str] = []
+    fields = model.model_fields
+    for key, val in cfg.items():
+        where = f"{path}.{key}" if path else key
+        if key not in fields:
+            errors.append(f"{where} — not a field of {model.__name__}")
+            continue
+        submodel = _model_of(fields[key].annotation)
+        if isinstance(val, dict) and submodel is not None:
+            errors.extend(_check(val, submodel, where))
+    return errors
+
+
+def test_values_config_keys_are_real_settings_fields():
+    """Every key under core.api.config in values.yaml must map onto a real
+    Settings field — otherwise the chart renders a config knob the API ignores."""
+    errors = _check(_config_block(), Settings)
+    assert not errors, "values.yaml core.api.config → Settings drift:\n" + "\n".join(errors)


### PR DESCRIPTION
Refs #137 (executable invariants — the Helm config-channel item).

The chart renders `core.api.config` (`helm/bamf/values.yaml`) into the API's `config.yaml`, and `Settings` loads it with **`extra="ignore"`** — so a key that no model field consumes (a rename, or a knob wired to nothing) is **silently dropped**, not rejected. This is the camelCase-values ↔ snake_case-config boundary BAMF has repeatedly gotten wrong (#196, #200).

`tests/test_config_channel.py` walks the real `values.yaml` config block against the `Settings` model tree — class-level introspection, **no instantiation, no env reads** — and fails on any key that isn't a real field, recursing into the nested config models (`certificates`/`audit`/`rate_limit`/`cors`).

**Rigor:** verified it catches an injected *nested* drift — `certificates.bogus_ttl — not a field of CertificateConfig` — so the recursion genuinely validates (a passing run alone wouldn't prove that).

`docker/Dockerfile.test` now copies `helm/bamf/values.yaml` into the test image (it lives outside `services/`, like `alembic/` which is already copied); the test resolves the path in both the local repo and the container.

**Verified:** `gmake test-python` → 1053 pass (+1); `gmake lint-python` clean.

This completes the #137 executable-invariants set (content-hygiene #215, dependency-pins #216, async-semgrep #217, and this). The remaining API↔apiclient full-introspection idea is largely covered by the golden-fixture contract guards from #198.