### PR TITLE
test(bridge): cover the remaining pure server.go helpers

### DIFF
--- a/pkg/bridge/server_test.go
+++ b/pkg/bridge/server_test.go
@@ -127,3 +127,66 @@ func TestCleanupPendingIdempotent(t *testing.T) {
 	s.cleanupPending("sess")
 	require.Empty(t, s.pendingConns)
 }
+
+func TestParseHandshakeParams(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want map[string]string
+	}{
+		{"empty", "", map[string]string{}},
+		{"single", "a=b", map[string]string{"a": "b"}},
+		{"multi line", "a=b\nc=d", map[string]string{"a": "b", "c": "d"}},
+		{"whitespace trimmed", "  a=b  \n c=d ", map[string]string{"a": "b", "c": "d"}},
+		{"line without = is skipped", "a=b\nnoeq\nc=d", map[string]string{"a": "b", "c": "d"}},
+		{"only first = splits", "a=b=c", map[string]string{"a": "b=c"}},
+		{"empty value", "a=", map[string]string{"a": ""}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, parseHandshakeParams(tt.in))
+		})
+	}
+}
+
+func TestParseUint16(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		def  uint16
+		want uint16
+	}{
+		{"empty falls back to default", "", 8443, 8443},
+		{"valid", "443", 8443, 443},
+		{"max uint16", "65535", 1, 65535},
+		{"overflow by one falls back", "65536", 1, 1},
+		{"large overflow falls back", "99999", 1, 1},
+		{"non-numeric falls back", "abc", 1, 1},
+		{"trailing non-digit falls back", "44a3", 1, 1},
+		{"zero is valid", "0", 8443, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.want, parseUint16(tt.in, tt.def))
+		})
+	}
+}
+
+// extractSessionInfo must ignore SAN URIs that aren't ours: non-bamf schemes,
+// unknown bamf hosts, and empty-path entries (a client can't smuggle routing
+// state past the CA-set SANs). The last valid value for a host wins.
+func TestExtractSessionInfo_IgnoresNonBamfAndUnknown(t *testing.T) {
+	cert := &x509.Certificate{URIs: []*url.URL{
+		mustURL("https://example.com/foo"), // non-bamf scheme → ignored
+		mustURL("bamf://session/sess-1"),
+		mustURL("bamf://unknown/xyz"), // unknown host → ignored
+		mustURL("bamf://resource/"),   // empty path → skipped
+		mustURL("bamf://resource/web-01"),
+	}}
+
+	info, err := extractSessionInfo(cert)
+	require.NoError(t, err)
+	require.Equal(t, "sess-1", info.SessionID)
+	require.Equal(t, "web-01", info.Resource)
+	require.Empty(t, info.BridgeID)
+}


### PR DESCRIPTION
Refs #128. `server.go`'s cert-matching + dispatch logic (`extractSessionInfo`, `bridgePinMatches`, `resolveResourceType`) is **already** unit-tested — so #128's server.go acceptance was largely met. This closes the last untested pure helpers on the tunnel-setup path:

- **`parseHandshakeParams`** — multi-line `k=v`, whitespace trimming, lines without `=` skipped, only-first-`=` split, empty values.
- **`parseUint16`** — default fallback on empty/non-numeric/trailing-non-digit/overflow (>65535), the 65535 boundary, and zero.
- **`extractSessionInfo` edge cases** — non-bamf schemes, unknown bamf hosts, and empty-path SANs are all ignored (a client can't smuggle routing state past the CA-set SANs), last-valid-value-wins.

Table-driven, `testify/require`. `gmake lint-go` → 0 issues; all pass locally.

The larger #128 items (web E2E/Playwright tier, TCP splice/dial path, kube-WS exec) remain — they're bigger undertakings (full-stack CI wiring) better suited to a dedicated effort.