### PR TITLE
chore(cli): drop the dead --debug flag and vestigial ~/.bamf/keys dir

### DIFF
--- a/cmd/bamf/cmd/root.go
+++ b/cmd/bamf/cmd/root.go
@@ -14,7 +14,6 @@ var (
 	// Global flags
 	cfgFile    string
 	apiURL     string
-	debug      bool
 	jsonOutput bool
 
 	// Version info (set at build time)
@@ -44,7 +43,6 @@ func init() {
 
 	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is ~/.bamf/config.yaml)")
 	rootCmd.PersistentFlags().StringVar(&apiURL, "api", "", "BAMF API server URL")
-	rootCmd.PersistentFlags().BoolVar(&debug, "debug", false, "enable debug logging")
 	rootCmd.PersistentFlags().BoolVar(&jsonOutput, "json", false, "output in JSON format")
 }
 
@@ -81,12 +79,6 @@ func ensureBamfDir() (string, error) {
 
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return "", fmt.Errorf("cannot create .bamf directory: %w", err)
-	}
-
-	// Also create keys subdirectory
-	keysDir := filepath.Join(dir, "keys")
-	if err := os.MkdirAll(keysDir, 0700); err != nil {
-		return "", fmt.Errorf("cannot create keys directory: %w", err)
 	}
 
 	return dir, nil

--- a/cmd/bamf/cmd/ssh_test.go
+++ b/cmd/bamf/cmd/ssh_test.go
@@ -67,13 +67,6 @@ func TestEnsureBamfDir_CreatesDirectories(t *testing.T) {
 	require.NoError(t, err)
 	require.True(t, info.IsDir())
 	require.Equal(t, os.FileMode(0700), info.Mode().Perm())
-
-	// Verify keys subdirectory was created
-	keysDir := filepath.Join(dir, "keys")
-	info, err = os.Stat(keysDir)
-	require.NoError(t, err)
-	require.True(t, info.IsDir())
-	require.Equal(t, os.FileMode(0700), info.Mode().Perm())
 }
 
 func TestEnsureBamfDir_Idempotent(t *testing.T) {


### PR DESCRIPTION
Refs #126, #199. Two inert CLI artifacts flagged by the docs-drift audit and the #199 pre-release review:

- **`--debug` flag** set a `debug` bool that **nothing ever read** (confirmed zero readers, no tests). Removed the flag + variable.
- **`~/.bamf/keys/` dir** — `ensureBamfDir` created it, but certs are fetched per-connection and held in memory (`credentials.json` holds only the session token); nothing writes there. Stop creating it. `bamf logout` still clears a *legacy* `keys/` if present (its `ReadDir` already tolerates a missing dir via `!os.IsNotExist`), so upgrades that had the old dir are still cleaned up. Dropped the now-moot "keys subdirectory was created" assertion.

This makes cli.md's credential-storage description (`credentials.json` + `known_hosts`, no `keys/`, no `--debug` — corrected in #202/#205) match the binary **exactly**, closing the code side of that drift.

**Verified:** `go build`/`go test ./cmd/bamf/...` pass; `gmake lint-go` → 0 issues; no doc references `--debug`/`keys/`.