### PR TITLE
security: adopt a documented vulnerability-suppression process

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -254,9 +254,11 @@ since the previous tag (`git log vPREV..HEAD`) and audit:
 - **F. Live smoke for destructive / high-blast-radius surfaces** — anything
   that mutates infrastructure, issues certificates, or opens tunnels is smoke-
   tested end-to-end on the live Tilt stack, not only unit-tested.
-- **G. Ignored-vulnerability review** — sweep the scanner suppressions
-  (`pentest/trivy/`, pip-audit/govulncheck allowlists) and drop any that a
-  version bump now fixes.
+- **G. Ignored-vulnerability review** — sweep the committed scanner suppression
+  allowlists (`pentest/trivy/.trivyignore`, `pentest/pip-audit/ignore-vulns.txt`;
+  govulncheck has none) and drop any that a version bump now fixes. The
+  suppression policy — when an ignore is permitted and the required justification
+  + "drop when" format — is in `SECURITY.md`.
 - **H. AI-agent onboarding** — confirm a fresh, repo-only agent pointed at the
   clone can accurately summarise BAMF, enumerate features, and give correct
   getting-started guidance **without hallucinating endpoints or Helm values**.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -46,9 +46,33 @@ BAMF's security model is documented in detail:
 
 ### Dependency Security
 
-- `govulncheck` (Go) and `pip-audit` (Python) run in CI on every pull request.
+- `govulncheck` (Go), `pip-audit` (Python), and Trivy (container images) run in
+  CI on every pull request.
 - Dependencies are reviewed weekly.
 - No CGo — the Go attack surface is limited to pure Go code.
+
+### Vulnerability suppression policy
+
+The default is to **fix**, not suppress: bump the dependency or base image. A
+scanner finding may be suppressed **only when both** of the following hold:
+
+1. no fixed release can be taken yet — there is no fix upstream, or the fix is
+   blocked by a compatibility pin we can't move; **and**
+2. it is not exploitable in BAMF's configuration (transitive/unused dependency,
+   unreachable code path, base-image package we never invoke).
+
+Every suppression lives in a committed allowlist (used identically by local runs
+and CI) and **must** carry a justification block: what it is, why it is
+safe/unavoidable, and an explicit **"drop when …"** re-evaluation condition.
+
+| Scanner | Allowlist | Format |
+|---|---|---|
+| Trivy (images) | [`pentest/trivy/.trivyignore`](pentest/trivy/.trivyignore) | one CVE per line + justification comment |
+| pip-audit (Python) | [`pentest/pip-audit/ignore-vulns.txt`](pentest/pip-audit/ignore-vulns.txt) | one ID per line + justification comment (read by `scripts/security-scan.sh`) |
+| govulncheck (Go) | none — reports only reachable code, so a finding is fixed; a genuinely unfixable, unreachable case is documented here | — |
+
+Item G of the pre-release audit (see `AGENTS.md`) re-reviews every active
+suppression on each release and drops any a version bump now fixes.
 
 ## Security-Related Configuration
 

--- a/pentest/pip-audit/ignore-vulns.txt
+++ b/pentest/pip-audit/ignore-vulns.txt
@@ -1,0 +1,19 @@
+# pip-audit vulnerability suppression allowlist for BAMF (Python deps).
+# Read by scripts/security-scan.sh (local + the CI Python Security job), which
+# passes each active ID as `--ignore-vuln`, so local and CI agree.
+#
+# One vulnerability ID per line (PYSEC-…, GHSA-…, or CVE-…). Blank lines and
+# lines starting with # are ignored.
+#
+# Suppress ONLY when (see SECURITY.md → Vulnerability suppression policy) there
+# is no fixed release we can take (e.g. blocked by a compatibility pin) AND it
+# is not exploitable in BAMF's configuration. Every active entry MUST carry a
+# justification block above it: what it is, why it is safe/unavoidable, and an
+# explicit "drop when …" condition. Item G of the AGENTS.md release audit
+# re-reviews every entry each release.
+#
+# Example (commented — remove the leading # to activate):
+# # GHSA-xxxx-xxxx-xxxx — <lib> <CVE>: fixed only in a release FastAPI can't take
+# #   yet; the vulnerable path (<feature>) is not used in BAMF.
+# #   Drop when: FastAPI supports <lib> >= <fixed version>.
+# GHSA-xxxx-xxxx-xxxx

--- a/pentest/trivy/.trivyignore
+++ b/pentest/trivy/.trivyignore
@@ -1,6 +1,23 @@
-# Trivy CVE ignore list for BAMF container images.
-# Add accepted CVEs here with a comment explaining why.
-# Format: one CVE-ID per line.
+# Trivy CVE suppression allowlist for BAMF container images.
+# Consumed by both `scripts/pentest.sh` and the CI scan-images job
+# (trivy-action `trivyignores:`), so local and CI agree.
 #
-# Example:
-# CVE-2024-12345  # accepted: not exploitable in our configuration
+# Suppress a CVE ONLY when both hold (see SECURITY.md → Vulnerability
+# suppression policy):
+#   1. no fixed version exists yet, OR the fix is blocked by a compatibility
+#      pin we can't move; AND
+#   2. it is not exploitable in BAMF's configuration.
+#
+# Every active entry MUST have a justification block directly above it:
+#   - what it is (package + CVE),
+#   - why it is safe/unavoidable (transitive dep, unreachable path, no-fix-yet,
+#     base-image),
+#   - an explicit "drop when …" re-evaluation condition.
+# Keep removed entries as comments explaining why (e.g. "fixed in v1.2.3").
+# Item G of the AGENTS.md release audit re-reviews every entry each release.
+#
+# Example (commented — remove the leading # to activate):
+# # CVE-2024-12345 — libfoo in the base image. Not exploitable: the vulnerable
+# #   codec is never invoked (we only decode JSON). No fixed base image yet.
+# #   Drop when: the debian:bookworm-slim base ships libfoo >= 2.3.
+# CVE-2024-12345

--- a/scripts/security-scan.sh
+++ b/scripts/security-scan.sh
@@ -7,16 +7,31 @@ set -euo pipefail
 source "$(dirname "$0")/lib.sh"
 
 scan_go() {
+  # govulncheck reports only vulnerabilities in reachable code, so there is no
+  # suppression file: a finding is fixed (bump the dep) rather than ignored. A
+  # genuinely unfixable, unreachable case is documented in SECURITY.md instead.
   info "Running govulncheck (Go vulnerability scanner)..."
   docker_go govulncheck ./...
   success "govulncheck passed — no known vulnerabilities"
 }
 
+# Read a suppression allowlist file into `--ignore-vuln <ID>` args (comments and
+# blank lines stripped). Local and CI read the same committed file.
+_pip_audit_ignores() {
+  local f="$REPO_ROOT/pentest/pip-audit/ignore-vulns.txt"
+  [ -f "$f" ] || return 0
+  # `grep -v` exits 1 when the file is all-comments (no lines selected); that is
+  # the normal "no suppressions" case, not an error, so swallow it.
+  grep -vE '^[[:space:]]*(#|$)' "$f" 2>/dev/null | sed 's/^/--ignore-vuln /' | tr '\n' ' ' || true
+}
+
 scan_python() {
   info "Running pip-audit (Python vulnerability scanner)..."
   ensure_test_image
+  local ignores
+  ignores="$(_pip_audit_ignores)"
   docker compose -f "$REPO_ROOT/docker-compose.test.yml" run --rm \
-    --entrypoint sh test -c "pip install --quiet pip-audit && pip-audit"
+    --entrypoint sh test -c "pip install --quiet pip-audit && pip-audit ${ignores}"
   success "pip-audit passed — no known vulnerabilities"
 }
 


### PR DESCRIPTION
Refs #132. Ports Terrapod's disciplined suppression process so a scanner finding that can't be fixed yet (no upstream fix, or blocked by a compatibility pin) is accepted **only deliberately**, with a justification + re-evaluation condition — not an ad-hoc inline flag. There are **no active suppressions today**; this establishes the format + criteria *before* one is needed (the Starlette-1.x case in #116 is the intended first consumer).

- **`pentest/trivy/.trivyignore`** — replaced the bare "one CVE per line" note with the mandatory justification format (what / why-safe / explicit **"drop when …"**). CI already reads this via the trivy-action, so local ≡ CI.
- **`pentest/pip-audit/ignore-vulns.txt`** (new) — a structured allowlist read by `scripts/security-scan.sh`, which passes each active ID as `--ignore-vuln`; the pip-audit ignore is now a reviewable committed file, not an inline shell flag, and local ≡ CI. *(Caught + fixed a `set -e`/`pipefail` trap: `grep -v` exits 1 when the file is all-comments, which would have failed the whole Python Security job — verified locally before pushing.)*
- **govulncheck** — documented it has no allowlist (reports only reachable code, so a finding is fixed; a genuine unfixable/unreachable case is recorded in SECURITY.md).
- **SECURITY.md** — new "Vulnerability suppression policy": the two-part criteria (no-fix-available **AND** not-exploitable), the allowlist table, and the required justification + "drop when" format.
- **AGENTS.md item G** now names the consolidated files and points at the policy.

**Verified:** `scripts/security-scan.sh python` → exit 0, "No known vulnerabilities found" (empty allowlist path works); parsing yields `--ignore-vuln <ID>` for an active entry; `docs-xref` + `content-hygiene` + `shellcheck` clean.