### PR TITLE
ci: content-hygiene also catches the hyphenated markup-ai form

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -288,8 +288,9 @@ world-readable forever.
 - **No internal references** — commit messages, PR text, **and source comments
   / docstrings** must never reference any company, internal hostname, internal
   repo/project name, internal cluster name, or specific customer/deployment
-  (this includes `acrolinx`, `acrolinx-cloud.net`, `markup.ai`, `markupai`, and
-  anything under a private tailnet). When describing an issue motivated by a
+  (this includes `acrolinx`, `acrolinx-cloud.net`, `markup.ai`, `markupai`,
+  `markup-ai` — e.g. `markup-ai.atlassian.net` — and anything under a private
+  tailnet). When describing an issue motivated by a
   real deployment, anonymise it ("a multi-cluster estate", "an internal CI
   cluster"), never name the source. If you catch a leak in your own draft,
   scrub it before pushing.

--- a/scripts/content-hygiene.sh
+++ b/scripts/content-hygiene.sh
@@ -12,8 +12,10 @@
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
-# Forbidden internal identifiers. `[.]` keeps the dots literal.
-patterns='acrolinx|markup[.]ai|markupai|acrolinx-cloud[.]net|[.]ts[.]net|grafana[.]net'
+# Forbidden internal identifiers. `[.]` keeps the dots literal; `markup[.-]?ai`
+# covers markupai / markup.ai / markup-ai (the org's hyphenated form appears in
+# real hostnames like markup-ai.atlassian.net).
+patterns='acrolinx|markup[.-]?ai|acrolinx-cloud[.]net|[.]ts[.]net|grafana[.]net'
 
 # Files where these terms are legitimately present: AGENTS.md defines the policy
 # by naming them, and this script lists them as the patterns to search for.


### PR DESCRIPTION
Pre-release (v0.8.7) audit follow-up. The adversarial review of `git diff v0.8.6..HEAD` found the content-hygiene gate (#215) missed the **hyphenated `markup-ai`** form — only `markup.ai` / `markupai` were in the pattern — so a real internal host like `markup-ai.atlassian.net` would have evaded the gate on this public repo.

Broadened the pattern to `markup[.-]?ai` (covers `markupai` / `markup.ai` / `markup-ai`) and added the form to the AGENTS.md forbidden list.

**Verified:** the gate now fails (exit 1) on an injected `markup-ai.atlassian.net` and stays clean on the current tree; `docs-xref` resolves.

The review returned **no other blockers** for v0.8.7 across the 16-PR diff (CLI users/roles feature + the CI/security hardening); remaining findings are non-blocking follow-ups (CLI list pagination, producer-side nested-key contract depth).