### PR TITLE
fix(tilt): raise node inotify limits so the web pod stops crashlooping

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -22,6 +22,20 @@ cfg = config.parse()
 # Local TLS Certificates (mkcert)
 # ─────────────────────────────────────────────────────────────────────────────
 
+# Next.js 16 dev (Turbopack) opens many inotify instances / file descriptors.
+# The k3s node default (fs.inotify.max_user_instances=128) is too low, so the
+# web pod exhausts FDs ("No file descriptors available", CrashLoopBackOff). Raise
+# the node limits via a one-off privileged pod. Idempotent; safe to re-run.
+local_resource(
+    'raise-inotify-limits',
+    cmd='''
+kubectl --context rancher-desktop run inotify-limits --rm --attach --restart=Never \
+  --image=busybox --quiet \
+  --overrides='{"spec":{"hostPID":true,"containers":[{"name":"x","image":"busybox","command":["nsenter","--target","1","--mount","--uts","--ipc","--net","--pid","--","sh","-c","sysctl -w fs.inotify.max_user_instances=8192 fs.inotify.max_user_watches=1048576 >/dev/null && echo raised"],"securityContext":{"privileged":true}}]}}'
+''',
+    labels=['setup'],
+)
+
 local_resource(
     'setup-certificates',
     cmd='''


### PR DESCRIPTION
The `bamf-web` dev pod (Next.js 16 / Turbopack) crashloops with **`No file descriptors available (os error 24)`** — the k3s node's default `fs.inotify.max_user_instances=128` is far too low for Turbopack's file watchers (the memory-noted "web crashloops on inotify" issue; the pod had **252 restarts**).

Adds a `raise-inotify-limits` `local_resource` that raises the node's limits (`max_user_instances=8192`, `max_user_watches=1048576`) via a one-off privileged pod on `tilt up`. Idempotent.

**Verified:** after raising the limit, a fresh `bamf-web` pod runs with **0 restarts** (was 252). Node-level sysctl, so all pods benefit. `tilt alpha tiltfile-result` parses clean.

Local-dev only (Tiltfile) — no effect on CI or the product.