### PR TITLE
fix(web): unblock local /login behind Traefik, add Playwright E2E tier

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -207,6 +207,12 @@ k8s_yaml(helm(
         'core.web.image.tag=latest',
         'core.web.image.pullPolicy=Never',
         'core.web.standalone=true',
+        # next dev + Turbopack spikes past 1Gi compiling routes on the first
+        # requests (the startup probe hitting `/`), which OOMKills the pod into
+        # a crashloop. Give the local dev server headroom. Committed here (not
+        # in the gitignored values-local.yaml) so every `tilt up` gets it.
+        'core.web.resources.requests.memory=768Mi',
+        'core.web.resources.limits.memory=2Gi',
         'core.postgresql.bundled.enabled=true',
         'core.postgresql.external.enabled=false',
         'core.redis.bundled.enabled=true',

--- a/Tiltfile
+++ b/Tiltfile
@@ -93,17 +93,23 @@ if [ -f "$CAROOT/rootCA.pem" ]; then
         --dry-run=client -o yaml | kubectl apply -f -
 fi
 
-# Verify /etc/hosts entries
-MISSING=""
-for HOST in bamf.local; do
-    if ! grep -q "$HOST" /etc/hosts; then
-        MISSING="$MISSING $HOST"
-    fi
-done
-if [ -n "$MISSING" ]; then
+# Verify /etc/hosts entries. Both IPv4 AND IPv6 are required: bamf.local is a
+# .local name, so macOS resolves it via mDNS. With only the 127.0.0.1 line, the
+# AAAA (IPv6) lookup has no answer and mDNS times out ~5s on EVERY request —
+# which makes the app crawl and breaks the Next.js dev HMR websocket handshake
+# (the login page then hangs on its Suspense fallback forever). The `::1` line
+# answers AAAA instantly and eliminates the stall.
+if ! grep -qE "^127\\.0\\.0\\.1[[:space:]]+bamf\\.local([[:space:]]|$)" /etc/hosts; then
     echo ""
-    echo "WARNING: Missing /etc/hosts entries for:$MISSING"
+    echo "WARNING: Missing IPv4 /etc/hosts entry for bamf.local"
     echo "Run: sudo sh -c 'echo \"127.0.0.1 bamf.local\" >> /etc/hosts'"
+    echo ""
+fi
+if ! grep -qE "^::1[[:space:]]+bamf\\.local([[:space:]]|$)" /etc/hosts; then
+    echo ""
+    echo "WARNING: Missing IPv6 /etc/hosts entry for bamf.local (causes a ~5s"
+    echo "         DNS stall per request on macOS — see comment in Tiltfile)."
+    echo "Run: sudo sh -c 'echo \"::1 bamf.local\" >> /etc/hosts'"
     echo ""
 fi
 ''',

--- a/web/.gitignore
+++ b/web/.gitignore
@@ -1,0 +1,6 @@
+
+# playwright
+/test-results/
+/playwright-report/
+/blob-report/
+/playwright/.cache/

--- a/web/e2e/auth.spec.ts
+++ b/web/e2e/auth.spec.ts
@@ -1,0 +1,30 @@
+import { test, expect } from '@playwright/test'
+
+const ADMIN_EMAIL = process.env.BAMF_E2E_ADMIN_EMAIL || 'admin'
+const ADMIN_PASSWORD = process.env.BAMF_E2E_ADMIN_PASSWORD || 'admin'
+
+// The browser (web-UI) login is the SPA fetch form: inputs keyed by id
+// (#email / #password), submit button "Sign in". The name="email" variant is
+// only rendered in CLI mode (?cli_state=...), so target the ids here.
+test.describe('authentication', () => {
+  test('login page renders the local login form', async ({ page }) => {
+    await page.goto('/login')
+    await expect(page.locator('#email')).toBeVisible()
+    await expect(page.locator('#password')).toBeVisible()
+    await expect(page.getByRole('button', { name: /sign in/i })).toBeVisible()
+  })
+
+  test('unauthenticated access to a protected page redirects to login', async ({ page }) => {
+    await page.goto('/users')
+    await expect(page).toHaveURL(/\/login/)
+  })
+
+  test('admin can log in with local credentials', async ({ page }) => {
+    await page.goto('/login')
+    await page.locator('#email').fill(ADMIN_EMAIL)
+    await page.locator('#password').fill(ADMIN_PASSWORD)
+    await page.getByRole('button', { name: /sign in/i }).click()
+    // On success the SPA navigates off /login to the dashboard.
+    await expect(page).not.toHaveURL(/\/login/, { timeout: 15_000 })
+  })
+})

--- a/web/next.config.js
+++ b/web/next.config.js
@@ -1,6 +1,14 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: 'standalone',
+  // In local dev the Next dev server is reached via the ingress hostname
+  // (https://bamf.local through Traefik), which is cross-origin to the pod's
+  // dev server. Next 16 rejects cross-origin dev requests — including the HMR
+  // websocket and dev-client payloads — unless the origin is allowlisted here.
+  // Without this the client runtime never boots and client-only pages (e.g.
+  // /login, whose content is behind Suspense+useSearchParams) hang on their
+  // fallback. Prod builds ignore this field.
+  allowedDevOrigins: ['bamf.local'],
   async rewrites() {
     return [
       {

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -20,6 +20,7 @@
         "react-dom": "^19.2.1"
       },
       "devDependencies": {
+        "@playwright/test": "^1.61.1",
         "@tailwindcss/postcss": "^4.2.2",
         "@types/node": "^20",
         "@types/react": "^19.2.14",
@@ -1286,6 +1287,22 @@
       "license": "MIT",
       "engines": {
         "node": ">=12.4.0"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.61.1.tgz",
+      "integrity": "sha512-8nKv6+0RJSL9FE4jYOEGXnPeM/Hg12qZpmqzZjRh3qM0Y7c3z1mrOTfFLids72RDQYVh9WpLEfR5WdpNX4fkig==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@rtsao/scc": {
@@ -3832,6 +3849,20 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
@@ -5512,6 +5543,38 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.61.1.tgz",
+      "integrity": "sha512-DWnY5o3YbLWK4GovuAVwpqL+1VwGNdUGrRr++8j8PtQQzvAVZUIMjKQ90fY689sEJZJBbZVw1rXaOKSTitkzPQ==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.61.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.61.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.61.1.tgz",
+      "integrity": "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/web/package.json
+++ b/web/package.json
@@ -7,7 +7,8 @@
     "build": "next build",
     "start": "next start --port 3000",
     "lint": "eslint src/",
-    "type-check": "tsc --noEmit"
+    "type-check": "tsc --noEmit",
+    "e2e": "playwright test"
   },
   "dependencies": {
     "@xterm/addon-fit": "^0.11.0",
@@ -22,6 +23,7 @@
     "react-dom": "^19.2.1"
   },
   "devDependencies": {
+    "@playwright/test": "^1.61.1",
     "@tailwindcss/postcss": "^4.2.2",
     "@types/node": "^20",
     "@types/react": "^19.2.14",

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -1,0 +1,21 @@
+import { defineConfig, devices } from '@playwright/test'
+
+// E2E runs against a live BAMF stack (the Tilt dev stack by default). Point it
+// elsewhere with BAMF_E2E_BASE_URL. The local stack uses an mkcert cert that
+// isn't in the Node trust store, so HTTPS errors are ignored.
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : 'list',
+  use: {
+    baseURL: process.env.BAMF_E2E_BASE_URL || 'https://bamf.local',
+    ignoreHTTPSErrors: true,
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+  },
+  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+})


### PR DESCRIPTION
Closes #227.

## Problem

In the local Tilt stack, `https://bamf.local/login` hangs forever on its `Suspense` fallback, making the web UI unusable for local development and blocking a web E2E tier. `/login` is the only page whose visible content is entirely client-rendered (behind `Suspense`+`useSearchParams`), so it's the one that exposes an otherwise-invisible broken dev client. Root-caused to three compounding issues — **none in the IngressRoute**:

1. **`allowedDevOrigins` unset** — Next 16 rejects cross-origin dev-server requests (including the HMR websocket) from origins not allowlisted. Reached via `bamf.local` (cross-origin to the pod's dev server), the HMR ws returns 500, the dev client never boots, and the Suspense never resolves.
2. **web pod OOMKilled** — the 1Gi limit is too tight for `next dev` + Turbopack compiling routes under the startup probe, crashlooping the pod.
3. **Missing IPv6 `/etc/hosts` entry** — `bamf.local` is a `.local` name resolved via mDNS on macOS; with only the `127.0.0.1` line the AAAA lookup times out ~5s per request, slowing everything and breaking the HMR handshake.

## Fix

- `web/next.config.js`: `allowedDevOrigins: ['bamf.local']` (mirrors the working Terrapod setup).
- `Tiltfile`: pin the local web pod to a 2Gi memory limit via the committed `set=` block (the `values-local.yaml` overrides file is gitignored with no committed template, so the override must live in the Tiltfile to survive a fresh clone). Prod runs the lighter standalone build and is unaffected.
- `Tiltfile`: the `/etc/hosts` check now also warns when the `::1 bamf.local` entry is missing, with the reason.

## Tests

Adds the **Web E2E tier** with Playwright (`web/e2e/auth.spec.ts`, `web/playwright.config.ts`): login-form render, unauth→login redirect, and admin local login — all three green against the live Tilt stack.

```
3 passed (3.6s)
```