### PR TITLE
fix(audit): capture streaming response bodies on completion, not a 0.1s timer

### DIFF
--- a/services/bamf/api/middleware.py
+++ b/services/bamf/api/middleware.py
@@ -63,43 +63,43 @@ async def api_audit_middleware(request: Request, call_next):
 
     response = await call_next(request)
 
-    # Capture response body — StreamingResponse needs wrapping
-    resp_body = b""
+    # Capture response body. A StreamingResponse's body isn't materialized yet,
+    # so wrap its iterator and fire the audit when iteration actually finishes
+    # (or the client disconnects) — never on a fixed timer. A timed guess
+    # (`sleep(0.1)`) truncates bodies that stream for longer than the timeout
+    # (large payloads, slow downstreams, SSE) and needlessly delays fast ones.
     if isinstance(response, StreamingResponse):
         chunks: list[bytes] = []
+        upstream = response.body_iterator
 
         async def body_iterator():
-            async for chunk in response.body_iterator:
-                if isinstance(chunk, str):
-                    chunk = chunk.encode("utf-8")
-                chunks.append(chunk)
-                yield chunk
+            try:
+                async for chunk in upstream:
+                    if isinstance(chunk, str):
+                        chunk = chunk.encode("utf-8")
+                    chunks.append(chunk)
+                    yield chunk
+            finally:
+                # Fires on normal completion AND on GeneratorExit (client
+                # disconnect / cancellation), so the audit captures exactly the
+                # bytes that were sent and the true end-to-end duration. Runs as
+                # a background task so we never block the ASGI send loop.
+                elapsed_ms = round((time.monotonic() - t0) * 1000)
+                asyncio.create_task(
+                    _store_api_audit(
+                        request=request,
+                        request_body=body,
+                        response=response,
+                        response_body=b"".join(chunks),
+                        elapsed_ms=elapsed_ms,
+                    )
+                )
 
         response.body_iterator = body_iterator()
-        # We need to actually consume the iterator to capture the body.
-        # The response will be sent to the client as it streams; we
-        # capture chunks in the iterator wrapper above. However, the
-        # middleware return sends the response before we can read chunks.
-        # Instead, schedule the audit as a background task that fires
-        # after the response is fully sent.
-        elapsed_ms = round((time.monotonic() - t0) * 1000)
-
-        async def _audit_after_stream():
-            # Wait briefly for the stream to complete
-            await asyncio.sleep(0.1)
-            resp_bytes = b"".join(chunks)
-            await _store_api_audit(
-                request=request,
-                request_body=body,
-                response=response,
-                response_body=resp_bytes,
-                elapsed_ms=elapsed_ms,
-            )
-
-        asyncio.create_task(_audit_after_stream())
         return response
 
     # Non-streaming response — body is available directly
+    resp_body = b""
     if hasattr(response, "body"):
         resp_body = response.body
     elapsed_ms = round((time.monotonic() - t0) * 1000)

--- a/services/tests/test_api/test_api_audit_middleware.py
+++ b/services/tests/test_api/test_api_audit_middleware.py
@@ -1,0 +1,138 @@
+"""Tests for the API self-audit middleware's response-body capture.
+
+Regression coverage for #172: the streaming-response audit must capture the
+FULL body on actual stream completion (or the exact bytes sent on client
+disconnect), never a prefix truncated by a fixed `sleep(0.1)` timer.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from starlette.requests import Request
+from starlette.responses import StreamingResponse
+
+from bamf.api import middleware
+
+
+def _scope(
+    method: str = "GET", path: str = "/api/v1/users", host: str = "bamf.example.com"
+) -> dict:
+    """Minimal ASGI http scope for a Starlette Request the middleware accepts."""
+    return {
+        "type": "http",
+        "method": method,
+        "path": path,
+        "query_string": b"",
+        "server": ("bamf.example.com", 443),
+        "client": ("10.0.0.1", 12345),
+        "headers": [(b"host", host.encode()), (b"user-agent", b"pytest")],
+    }
+
+
+def _capture_store(captured: dict):
+    """Patch replacement for _store_api_audit that records the captured body."""
+
+    async def fake_store(*, request, request_body, response, response_body, elapsed_ms):
+        captured["response_body"] = response_body
+        captured["elapsed_ms"] = elapsed_ms
+
+    return fake_store
+
+
+@pytest.mark.asyncio
+async def test_streaming_audit_captures_full_body_after_slow_stream(monkeypatch):
+    """#172: a response that streams for >100ms must be audited in full.
+
+    An asyncio.Event holds the stream open past the old 0.1s timer. The buggy
+    timer-based audit fired mid-stream with only the first chunk; the fixed
+    iterator-completion audit fires once the stream truly finishes, with all of
+    it.
+    """
+    captured: dict = {}
+    monkeypatch.setattr(middleware, "_store_api_audit", _capture_store(captured))
+
+    release = asyncio.Event()
+
+    async def slow_stream():
+        yield b"chunk-0"
+        await release.wait()
+        yield b"chunk-1"
+        yield b"chunk-2"
+
+    async def call_next(_request):
+        return StreamingResponse(slow_stream(), status_code=200)
+
+    request = Request(scope=_scope())
+    request._body = b""
+
+    response = await middleware.api_audit_middleware(request, call_next)
+
+    # Consume the wrapped iterator the way the ASGI server would.
+    consumed: list[bytes] = []
+
+    async def consume():
+        async for chunk in response.body_iterator:
+            consumed.append(chunk)
+
+    task = asyncio.create_task(consume())
+
+    # Exceed the old 0.1s timer while the stream is still blocked at chunk-0.
+    # The buggy audit would have fired here with a truncated body.
+    await asyncio.sleep(0.15)
+    assert "response_body" not in captured, "audit fired mid-stream (timer bug)"
+
+    release.set()
+    await task
+    await asyncio.sleep(0)  # let the audit background task run
+
+    assert b"".join(consumed) == b"chunk-0chunk-1chunk-2"
+    assert captured["response_body"] == b"chunk-0chunk-1chunk-2"
+
+
+@pytest.mark.asyncio
+async def test_streaming_audit_captures_exact_bytes_on_client_disconnect(monkeypatch):
+    """On disconnect (GeneratorExit) the audit records exactly the bytes sent."""
+    captured: dict = {}
+    monkeypatch.setattr(middleware, "_store_api_audit", _capture_store(captured))
+
+    async def stream():
+        yield b"partial"
+        yield b"never-sent"
+
+    async def call_next(_request):
+        return StreamingResponse(stream(), status_code=200)
+
+    request = Request(scope=_scope())
+    request._body = b""
+
+    response = await middleware.api_audit_middleware(request, call_next)
+
+    agen = response.body_iterator
+    first = await agen.__anext__()
+    assert first == b"partial"
+    await agen.aclose()  # simulate the client going away mid-stream
+    await asyncio.sleep(0.01)  # let the audit task run
+
+    assert captured["response_body"] == b"partial"
+
+
+@pytest.mark.asyncio
+async def test_non_streaming_audit_captures_body(monkeypatch):
+    """Plain (non-streaming) responses are audited with their full body."""
+    from starlette.responses import Response
+
+    captured: dict = {}
+    monkeypatch.setattr(middleware, "_store_api_audit", _capture_store(captured))
+
+    async def call_next(_request):
+        return Response(content=b'{"ok": true}', status_code=200, media_type="application/json")
+
+    request = Request(scope=_scope())
+    request._body = b""
+
+    await middleware.api_audit_middleware(request, call_next)
+    await asyncio.sleep(0)  # let the audit background task run
+
+    assert captured["response_body"] == b'{"ok": true}'


### PR DESCRIPTION
Closes #172.

## Problem

The API self-audit middleware (`services/bamf/api/middleware.py`) captured a `StreamingResponse` body by scheduling a background task that did `await asyncio.sleep(0.1)` and then read the accumulated chunks. If the response streamed for longer than 100ms (large payloads, slow downstreams, SSE) the audit recorded a **truncated or empty** body; if it finished faster, the task still waited the full 100ms. The recorded `duration_ms` was also measured *before* the stream ran.

## Fix

Wrap the `body_iterator` and fire the audit from its `finally` block, so it runs on **actual stream completion** — or on `GeneratorExit` when the client disconnects — capturing exactly the bytes that were sent and the true end-to-end duration. It's still scheduled with `asyncio.create_task`, so the ASGI send loop is never blocked.

## Tests

New `services/tests/test_api/test_api_audit_middleware.py`:
- **`test_streaming_audit_captures_full_body_after_slow_stream`** — an `asyncio.Event` holds the stream open past the old 0.1s timer; asserts nothing fires mid-stream and the full body is captured. This fails against the old timer-based code.
- **`test_streaming_audit_captures_exact_bytes_on_client_disconnect`** — `aclose()` mid-stream records exactly the bytes sent.
- **`test_non_streaming_audit_captures_body`** — plain-response sanity.

Full Python suite green locally: `1058 passed`.