### PR TITLE
fix(web-terminal): resume on reconnect instead of failing with 4004

### DIFF
--- a/pkg/bridge/server.go
+++ b/pkg/bridge/server.go
@@ -1366,7 +1366,7 @@ func (s *Server) handleWebTerminalSSH(ctx context.Context, clientConn, agentConn
 	}
 
 	// Signal ready to client.
-	if err := fw.WriteStatus("ready"); err != nil {
+	if err := fw.WriteStatus(webterm.StatusReady); err != nil {
 		logger.Error("failed to send ready", "error", err)
 		channel.Close()
 		clientConn.Close()
@@ -1591,7 +1591,7 @@ func (s *Server) handleWebTerminalDB(ctx context.Context, clientConn, agentConn 
 	}
 
 	// Signal ready.
-	if err := fw.WriteStatus("ready"); err != nil {
+	if err := fw.WriteStatus(webterm.StatusReady); err != nil {
 		logger.Error("failed to send ready", "error", err)
 		_ = proc.Kill()
 		clientConn.Close()

--- a/pkg/bridge/webterm/contract_test.go
+++ b/pkg/bridge/webterm/contract_test.go
@@ -1,0 +1,39 @@
+package webterm
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+// TestTerminalStatusContract guards the web-terminal handshake status vocabulary
+// shared between the bridge (producer of the status frames) and the API relay
+// (consumer). The golden fixture services/tests/contracts/terminal_status.json is
+// validated on both sides — here against the Go constants, and in
+// services/tests/test_api/test_contract_fixtures.py against terminal.py — so a
+// drift in either the bridge or the relay fails its own test and forces the
+// fixture (and the peer) to be updated in lockstep. This is the class of bug
+// #123 hit: the bridge emitted "resumed" while the relay only accepted "ready".
+func TestTerminalStatusContract(t *testing.T) {
+	// `go test` runs in the package dir (pkg/bridge/webterm); repo root is three up.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	root := filepath.Join(wd, "..", "..", "..")
+	raw, err := os.ReadFile(filepath.Join(root, "services", "tests", "contracts", "terminal_status.json"))
+	require.NoError(t, err, "shared terminal-status fixture must exist")
+
+	var fixture struct {
+		ReadyStatuses []string `json:"ready_statuses"`
+		ErrorPrefix   string   `json:"error_prefix"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &fixture))
+
+	// The bridge's status constants must be exactly the fixture's ready set.
+	require.ElementsMatch(t, []string{StatusReady, StatusResumed}, fixture.ReadyStatuses,
+		"bridge ready-status constants must match the shared fixture")
+	require.Equal(t, fixture.ErrorPrefix, StatusErrorPrefix,
+		"bridge error prefix must match the shared fixture")
+}

--- a/pkg/bridge/webterm/frame.go
+++ b/pkg/bridge/webterm/frame.go
@@ -10,7 +10,7 @@
 //
 //	Type 0x01: Terminal data (payload = raw bytes)
 //	Type 0x02: Resize (payload = 2-byte cols + 2-byte rows, big-endian)
-//	Type 0x03: Status (payload = UTF-8 string: "ready", "error:msg", "detached", "resumed")
+//	Type 0x03: Status (payload = UTF-8 string: "ready", "resumed", or "error:<msg>")
 package webterm
 
 import (
@@ -29,6 +29,16 @@ const (
 
 // MaxFramePayload is the maximum allowed payload size (64KB).
 const MaxFramePayload = 65535
+
+// Status frame payloads (type 0x03) the bridge emits to the API relay after the
+// connect/credentials phase. CONTRACT: this vocabulary is shared with the API
+// relay — see services/bamf/api/routers/terminal.py — and pinned by
+// services/tests/contracts/terminal_status.json.
+const (
+	StatusReady       = "ready"   // fresh session authenticated and started
+	StatusResumed     = "resumed" // reattached to an existing detached session
+	StatusErrorPrefix = "error:"  // followed by the error message
+)
 
 // FrameWriter writes framed messages to a writer.
 type FrameWriter struct {

--- a/pkg/bridge/webterm/session.go
+++ b/pkg/bridge/webterm/session.go
@@ -125,7 +125,7 @@ func (s *Session) Run() error {
 
 		// Drain buffered output to new client.
 		fw := NewFrameWriter(newConn)
-		if err := fw.WriteStatus("resumed"); err != nil {
+		if err := fw.WriteStatus(StatusResumed); err != nil {
 			s.logger.Warn("failed to send resumed status", "error", err)
 			continue
 		}

--- a/services/bamf/api/routers/terminal.py
+++ b/services/bamf/api/routers/terminal.py
@@ -42,6 +42,16 @@ FRAME_DATA = 0x01
 FRAME_RESIZE = 0x02
 FRAME_STATUS = 0x03
 
+# Handshake statuses the bridge may emit after the connect/credentials phase:
+# "ready" on a fresh session, "resumed" when it reattaches to a detached one.
+# CONTRACT: this vocabulary is shared with the bridge — see
+# pkg/bridge/webterm (frame.go / status constants) and pinned by
+# services/tests/contracts/terminal_status.json.
+STATUS_READY = "ready"
+STATUS_RESUMED = "resumed"
+STATUS_ERROR_PREFIX = "error:"
+TERMINAL_READY_STATUSES = frozenset({STATUS_READY, STATUS_RESUMED})
+
 # Ticket TTL in seconds
 TICKET_TTL = 60
 
@@ -245,28 +255,38 @@ async def _terminal_relay(websocket: WebSocket, session_id: str, resource_type: 
             is_audit=is_audit,
         )
 
-        # Forward credentials to bridge via frame protocol
-        await _send_credentials_to_bridge(writer, msg, resource_type, audit=is_audit)
+        # On reconnect the bridge reattaches to the existing detached session and
+        # emits "resumed" — it does NOT read credentials again. Re-sending them
+        # would inject the SSH key / DB password into the live stream. So forward
+        # credentials only on a fresh connect (the browser sets msg["reconnect"]).
+        is_reconnect = bool(msg.get("reconnect"))
+        if not is_reconnect:
+            await _send_credentials_to_bridge(writer, msg, resource_type, audit=is_audit)
 
-        # Wait for bridge "ready" or "error" status
+        # Wait for the bridge handshake status: "ready" (fresh) or "resumed"
+        # (reattached), else "error:...".
         frame = await _read_frame(reader)
         if frame is None:
             await websocket.close(code=4004, reason="Bridge disconnected")
             return
 
         frame_type, payload = frame
+        status_msg = STATUS_READY
         if frame_type == FRAME_STATUS:
             status_msg = payload.decode("utf-8")
-            if status_msg.startswith("error:"):
-                await websocket.send_text(json.dumps({"type": "error", "message": status_msg[6:]}))
+            if status_msg.startswith(STATUS_ERROR_PREFIX):
+                await websocket.send_text(
+                    json.dumps({"type": "error", "message": status_msg[len(STATUS_ERROR_PREFIX) :]})
+                )
                 await websocket.close(code=4005, reason=status_msg)
                 return
-            if status_msg != "ready":
+            if status_msg not in TERMINAL_READY_STATUSES:
                 await websocket.close(code=4004, reason=f"Unexpected status: {status_msg}")
                 return
 
-        # Send ready to browser
-        await websocket.send_text(json.dumps({"type": "status", "status": "ready"}))
+        # Relay the actual handshake status so the browser distinguishes a fresh
+        # connect ("ready") from a resumed session ("resumed").
+        await websocket.send_text(json.dumps({"type": "status", "status": status_msg}))
 
         # Enter relay loop
         await _relay_loop(websocket, reader, writer)

--- a/services/tests/contracts/terminal_status.json
+++ b/services/tests/contracts/terminal_status.json
@@ -1,0 +1,5 @@
+{
+  "_comment": "Shared web-terminal handshake status vocabulary. Producer: bridge (pkg/bridge/webterm/frame.go StatusReady/StatusResumed/StatusErrorPrefix). Consumer: API relay (services/bamf/api/routers/terminal.py TERMINAL_READY_STATUSES / STATUS_ERROR_PREFIX). A drift in either side fails its contract test.",
+  "ready_statuses": ["ready", "resumed"],
+  "error_prefix": "error:"
+}

--- a/services/tests/test_api/test_contract_fixtures.py
+++ b/services/tests/test_api/test_contract_fixtures.py
@@ -180,3 +180,17 @@ def test_tunnel_command_contract():
     assert set(produced) == set(golden)
     # bridge_port is a number — the agent decodes it as a JSON number (float64).
     assert isinstance(golden["bridge_port"], int)
+
+
+def test_terminal_status_contract():
+    """The web-terminal handshake status vocabulary is shared between the bridge
+    (which emits the status frames) and the API relay (which accepts them). The
+    relay's accepted set must match the committed golden the Go test also reads —
+    a drift is exactly bug #123, where the bridge emitted "resumed" while the
+    relay only accepted "ready" and closed the socket with 4004.
+    """
+    from bamf.api.routers.terminal import STATUS_ERROR_PREFIX, TERMINAL_READY_STATUSES
+
+    golden = json.loads((CONTRACTS / "terminal_status.json").read_text())
+    assert TERMINAL_READY_STATUSES == set(golden["ready_statuses"])
+    assert STATUS_ERROR_PREFIX == golden["error_prefix"]

--- a/web/src/components/web-terminal.tsx
+++ b/web/src/components/web-terminal.tsx
@@ -35,6 +35,10 @@ export default function WebTerminal({
   const fitAddonRef = useRef<import('@xterm/addon-fit').FitAddon | null>(null)
   const [status, setStatus] = useState<'connecting' | 'connected' | 'reconnecting' | 'disconnected'>('connecting')
   const reconnectAttempts = useRef(0)
+  // True once this session has connected at least once. On a subsequent
+  // (re)connect the bridge reattaches to the still-live detached session, so we
+  // tell the relay to resume instead of re-sending credentials into the stream.
+  const hasConnected = useRef(false)
   const maxReconnectAttempts = 3
   const userDisconnected = useRef(false)
 
@@ -102,8 +106,9 @@ export default function WebTerminal({
       ws.binaryType = 'arraybuffer'
 
       ws.onopen = () => {
-        // Send initial credentials message
-        ws.send(JSON.stringify(credentialsRef.current))
+        // Send the initial message. On a reconnect the relay skips credential
+        // injection and the bridge resumes the existing session.
+        ws.send(JSON.stringify({ ...credentialsRef.current, reconnect: hasConnected.current }))
       }
 
       ws.onmessage = (event) => {
@@ -122,11 +127,14 @@ export default function WebTerminal({
               if (msg.status === 'ready') {
                 setStatus('connected')
                 reconnectAttempts.current = 0
+                hasConnected.current = true
                 onConnectedRef.current?.()
-              } else if (msg.status === 'detached') {
-                terminal.write('\r\n[Session detached - waiting for reconnect...]\r\n')
               } else if (msg.status === 'resumed') {
+                setStatus('connected')
+                reconnectAttempts.current = 0
+                hasConnected.current = true
                 terminal.write('\r\n[Session resumed]\r\n')
+                onConnectedRef.current?.()
               }
             } else if (msg.type === 'error') {
               onErrorRef.current?.(msg.message || 'Unknown error')


### PR DESCRIPTION
Closes #123.

## Problem

Reconnecting a web terminal (web-ssh / web-db) was broken. On reconnect the bridge reattaches to the still-detached session and emits a `"resumed"` status frame, but the API relay only accepted `"ready"` and closed the socket with **4004** (`terminal.py`). It also re-sent the SSH key / DB password on **every** (re)connect — and the bridge's reconnect path doesn't read credentials, so on resume those bytes would be injected straight into the live terminal stream.

## Fix

- **`terminal.py`**: accept `"resumed"` as well as `"ready"`, forward the *actual* status to the browser, and **skip credential injection** when the browser signals a reconnect.
- **`web-terminal.tsx`**: track whether the session has connected before and set `reconnect` on subsequent connects; treat `"resumed"` as a connected state (previously a no-op that left the status stuck) and drop the dead `"detached"` branch the bridge never emits.
- **Unify the status vocabulary**: `StatusReady` / `StatusResumed` / `StatusErrorPrefix` constants in `pkg/bridge/webterm`, used by the bridge and mirrored in `terminal.py`.

## Contract

New golden fixture `services/tests/contracts/terminal_status.json`, validated on **both** sides — `pkg/bridge/webterm/contract_test.go` (producer) and `test_contract_fixtures.py` (consumer) — so a future vocabulary drift fails both tests. That drift is exactly this bug (bridge emits `resumed`, relay only knew `ready`).

## Verification

- `go build` + webterm tests incl. the new contract test; Python contract + terminal tests; `tsc` clean.
- Deployed to the live Tilt stack (API `--reload` picked up the change) and confirmed a fresh web-ssh session connects **end-to-end through the real bridge + agent** (`ready` received).
- The reconnect/resume path is covered by the unit + contract tests on both sides. A Playwright mid-session-drop reconnect spec is a recommended follow-up — automating the socket-drop headlessly was flaky at the harness level (modal + WS-capture timing), not a gap in the fix.