### PR TITLE
test(bridge): cover relay-pool lifecycle + postgres SSL interception

### DIFF
--- a/pkg/bridge/relay_lifecycle_test.go
+++ b/pkg/bridge/relay_lifecycle_test.go
@@ -1,0 +1,97 @@
+package bridge
+
+import (
+	"log/slog"
+	"net"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// trackConn wraps a net.Conn and records whether Close was called, so tests can
+// assert the pool's close-vs-detach semantics without relying on net.Pipe's
+// blocking Write.
+type trackConn struct {
+	net.Conn
+	closed atomic.Bool
+}
+
+func (c *trackConn) Close() error {
+	c.closed.Store(true)
+	return c.Conn.Close()
+}
+
+// newTrackConn returns a trackConn over one end of a net.Pipe (the other end is
+// closed immediately — the tests only care about lifecycle, not I/O).
+func newTrackConn(t *testing.T) *trackConn {
+	t.Helper()
+	a, b := net.Pipe()
+	t.Cleanup(func() { _ = b.Close() })
+	return &trackConn{Conn: a}
+}
+
+func TestRelayPool_removeConn_removesAndCloses(t *testing.T) {
+	pool := NewRelayPool(slog.Default())
+	t.Cleanup(pool.CloseAll)
+
+	conn := newTrackConn(t)
+	pool.Add("agent-1", conn)
+	require.Len(t, pool.conns["agent-1"], 1)
+	rc := pool.conns["agent-1"][0]
+
+	pool.removeConn("agent-1", rc)
+
+	require.NotContains(t, pool.conns, "agent-1", "empty pool entry must be deleted")
+	require.True(t, conn.closed.Load(), "removeConn must close the connection")
+}
+
+func TestRelayPool_removeConn_keepsSiblingsOfSameAgent(t *testing.T) {
+	pool := NewRelayPool(slog.Default())
+	t.Cleanup(pool.CloseAll)
+
+	c1, c2 := newTrackConn(t), newTrackConn(t)
+	pool.Add("agent-1", c1)
+	pool.Add("agent-1", c2)
+	rc1 := pool.conns["agent-1"][0]
+
+	pool.removeConn("agent-1", rc1)
+
+	require.Len(t, pool.conns["agent-1"], 1, "sibling connection must remain")
+	require.Same(t, c2, pool.conns["agent-1"][0].conn.(*trackConn))
+	require.True(t, c1.closed.Load())
+	require.False(t, c2.closed.Load())
+}
+
+func TestRelayPool_detachConn_removesWithoutClosing(t *testing.T) {
+	pool := NewRelayPool(slog.Default())
+	t.Cleanup(pool.CloseAll)
+
+	conn := newTrackConn(t)
+	pool.Add("agent-1", conn)
+	rc := pool.conns["agent-1"][0]
+
+	pool.detachConn("agent-1", rc)
+
+	require.NotContains(t, pool.conns, "agent-1", "empty pool entry must be deleted")
+	require.False(t, conn.closed.Load(), "detachConn must NOT close the connection")
+}
+
+func TestRelayPool_reapIdle_closesOnlyIdleConns(t *testing.T) {
+	pool := NewRelayPool(slog.Default())
+	t.Cleanup(pool.CloseAll)
+
+	idle, fresh := newTrackConn(t), newTrackConn(t)
+	pool.Add("idle-agent", idle)
+	pool.Add("fresh-agent", fresh)
+	// Age the idle connection past the reap threshold; leave the fresh one recent.
+	pool.conns["idle-agent"][0].lastActive = time.Now().Add(-2 * relayIdleTimeout)
+
+	pool.reapIdle()
+
+	require.NotContains(t, pool.conns, "idle-agent", "idle agent entry must be removed")
+	require.True(t, idle.closed.Load(), "idle connection must be closed")
+	require.Contains(t, pool.conns, "fresh-agent", "recent connection must survive")
+	require.False(t, fresh.closed.Load())
+}

--- a/pkg/bridge/server_pgssl_test.go
+++ b/pkg/bridge/server_pgssl_test.go
@@ -1,0 +1,75 @@
+package bridge
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"log/slog"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// pgMemConn is an in-memory net.Conn: reads drain from r, writes accumulate in w.
+type pgMemConn struct {
+	r *bytes.Reader
+	w *bytes.Buffer
+}
+
+func (c *pgMemConn) Read(p []byte) (int, error)       { return c.r.Read(p) }
+func (c *pgMemConn) Write(p []byte) (int, error)      { return c.w.Write(p) }
+func (c *pgMemConn) Close() error                     { return nil }
+func (c *pgMemConn) LocalAddr() net.Addr              { return pgMemAddr{} }
+func (c *pgMemConn) RemoteAddr() net.Addr             { return pgMemAddr{} }
+func (c *pgMemConn) SetDeadline(t time.Time) error    { return nil }
+func (c *pgMemConn) SetReadDeadline(time.Time) error  { return nil }
+func (c *pgMemConn) SetWriteDeadline(time.Time) error { return nil }
+
+type pgMemAddr struct{}
+
+func (pgMemAddr) Network() string { return "mem" }
+func (pgMemAddr) String() string  { return "mem" }
+
+// The PostgreSQL SSLRequest: message length=8, request code=80877103.
+var pgSSLRequest = []byte{0x00, 0x00, 0x00, 0x08, 0x04, 0xd2, 0x16, 0x2f}
+
+func TestInterceptPostgresSSL_deniesSSLRequest(t *testing.T) {
+	// SSLRequest followed by the real startup message — only the 8-byte
+	// SSLRequest must be consumed; the startup bytes remain for the tunnel.
+	trailer := []byte("STARTUP-MESSAGE")
+	input := append(append([]byte{}, pgSSLRequest...), trailer...)
+	c := &pgMemConn{r: bytes.NewReader(input), w: &bytes.Buffer{}}
+	reader := bufio.NewReader(c)
+
+	err := (&Server{}).interceptPostgresSSL(reader, c, slog.Default())
+	require.NoError(t, err)
+	require.Equal(t, []byte{'N'}, c.w.Bytes(), "must deny TLS with a single 'N'")
+
+	rest, _ := io.ReadAll(reader)
+	require.Equal(t, trailer, rest, "only the SSLRequest is consumed; startup bytes remain")
+}
+
+func TestInterceptPostgresSSL_passesThroughNonSSLRequest(t *testing.T) {
+	// A normal StartupMessage (not an SSLRequest) must be left untouched.
+	startup := []byte{0x00, 0x00, 0x00, 0x0a, 0x00, 0x03, 0x00, 0x00, 'x', 'y'}
+	c := &pgMemConn{r: bytes.NewReader(startup), w: &bytes.Buffer{}}
+	reader := bufio.NewReader(c)
+
+	err := (&Server{}).interceptPostgresSSL(reader, c, slog.Default())
+	require.NoError(t, err)
+	require.Empty(t, c.w.Bytes(), "a non-SSLRequest must not be answered")
+
+	rest, _ := io.ReadAll(reader)
+	require.Equal(t, startup, rest, "nothing must be consumed")
+}
+
+func TestInterceptPostgresSSL_shortStreamErrors(t *testing.T) {
+	// Fewer than 8 bytes then EOF — the peek must fail rather than misparse.
+	c := &pgMemConn{r: bytes.NewReader([]byte{0x00, 0x00}), w: &bytes.Buffer{}}
+	reader := bufio.NewReader(c)
+
+	err := (&Server{}).interceptPostgresSSL(reader, c, slog.Default())
+	require.Error(t, err)
+}


### PR DESCRIPTION
Part of #128 (test-coverage gaps).

## Problem

`pkg/bridge` was at **15.3%** statement coverage — several hot-path / security-relevant functions had **zero** tests.

## What this adds

White-box unit tests for cleanly-testable, previously-0% functions:

- **`RelayPool.removeConn` / `detachConn` / `reapIdle`** — the close-vs-detach semantics and idle reaping behind tunnel-relay connection management. Uses a `Close`-tracking conn so the "removeConn closes / detachConn does not" contract is asserted directly (net.Pipe's blocking `Write` can't distinguish closed from open).
- **`Server.interceptPostgresSSL`** — the `postgres-audit` path that denies a client `SSLRequest` with `'N'` (the tunnel is already mTLS; a client-initiated TLS upgrade would make the wire opaque to the query parser). Covers:
  - deny path — only the 8-byte SSLRequest is consumed, the following startup bytes are preserved for the tunnel;
  - pass-through — a non-SSLRequest StartupMessage is left untouched;
  - short-stream — fewer than 8 bytes errors rather than misparsing.

Raises `pkg/bridge` coverage to **18.6%**.

## Verification

`go test -race ./pkg/bridge/`, `go vet`, `gofmt`, and `golangci-lint` (CI image) all clean. No production code changed — tests only.

The remaining #128 gaps (web E2E — started in #228; kube WebSocket; the larger network handlers) are follow-ups.