### PR TITLE
fix(web-terminal): bridge-driven handshake to stop credential injection

### DIFF
--- a/pkg/bridge/server.go
+++ b/pkg/bridge/server.go
@@ -1247,6 +1247,17 @@ func (s *Server) handleWebTerminalSSH(ctx context.Context, clientConn, agentConn
 	fr := webterm.NewFrameReader(clientConn)
 	fw := webterm.NewFrameWriter(clientConn)
 
+	// Bridge speaks first on a fresh session: tell the relay to send its
+	// handshake + credentials. On a reattach the relay instead sees "resumed"
+	// (from the session's reconnect path) and sends nothing — so credentials
+	// are never forwarded into a live session (#233).
+	if err := fw.WriteStatus(webterm.StatusAuthRequired); err != nil {
+		logger.Error("failed to send auth-required", "error", err)
+		clientConn.Close()
+		agentConn.Close()
+		return
+	}
+
 	// First frame: status with session parameters.
 	typ, payload, err := fr.ReadFrame()
 	if err != nil || typ != webterm.FrameStatus {
@@ -1445,6 +1456,14 @@ func (s *Server) handleWebTerminalDB(ctx context.Context, clientConn, agentConn 
 	// Read initial handshake from client via frame protocol.
 	fr := webterm.NewFrameReader(clientConn)
 	fw := webterm.NewFrameWriter(clientConn)
+
+	// Bridge speaks first on a fresh session (see handleWebTerminalSSH / #233).
+	if err := fw.WriteStatus(webterm.StatusAuthRequired); err != nil {
+		logger.Error("failed to send auth-required", "error", err)
+		clientConn.Close()
+		agentConn.Close()
+		return
+	}
 
 	typ, payload, err := fr.ReadFrame()
 	if err != nil || typ != webterm.FrameStatus {

--- a/pkg/bridge/webterm/contract_test.go
+++ b/pkg/bridge/webterm/contract_test.go
@@ -26,12 +26,15 @@ func TestTerminalStatusContract(t *testing.T) {
 	require.NoError(t, err, "shared terminal-status fixture must exist")
 
 	var fixture struct {
+		AuthRequired  string   `json:"auth_required"`
 		ReadyStatuses []string `json:"ready_statuses"`
 		ErrorPrefix   string   `json:"error_prefix"`
 	}
 	require.NoError(t, json.Unmarshal(raw, &fixture))
 
-	// The bridge's status constants must be exactly the fixture's ready set.
+	// The bridge's status constants must match the shared fixture exactly.
+	require.Equal(t, fixture.AuthRequired, StatusAuthRequired,
+		"bridge auth-required constant must match the shared fixture")
 	require.ElementsMatch(t, []string{StatusReady, StatusResumed}, fixture.ReadyStatuses,
 		"bridge ready-status constants must match the shared fixture")
 	require.Equal(t, fixture.ErrorPrefix, StatusErrorPrefix,

--- a/pkg/bridge/webterm/frame.go
+++ b/pkg/bridge/webterm/frame.go
@@ -10,7 +10,13 @@
 //
 //	Type 0x01: Terminal data (payload = raw bytes)
 //	Type 0x02: Resize (payload = 2-byte cols + 2-byte rows, big-endian)
-//	Type 0x03: Status (payload = UTF-8 string: "ready", "resumed", or "error:<msg>")
+//	Type 0x03: Status (payload = UTF-8 string: "auth-required", "ready",
+//	           "resumed", or "error:<msg>")
+//
+// The bridge speaks first: on a fresh session it emits "auth-required" before
+// reading the client's handshake + credentials; on a reattach it emits
+// "resumed". The relay reads that status before sending anything, so it never
+// forwards credentials into a resumed session (see #233).
 package webterm
 
 import (
@@ -35,9 +41,10 @@ const MaxFramePayload = 65535
 // relay — see services/bamf/api/routers/terminal.py — and pinned by
 // services/tests/contracts/terminal_status.json.
 const (
-	StatusReady       = "ready"   // fresh session authenticated and started
-	StatusResumed     = "resumed" // reattached to an existing detached session
-	StatusErrorPrefix = "error:"  // followed by the error message
+	StatusAuthRequired = "auth-required" // fresh session: bridge awaits handshake + credentials
+	StatusReady        = "ready"         // fresh session authenticated and started
+	StatusResumed      = "resumed"       // reattached to an existing detached session
+	StatusErrorPrefix  = "error:"        // followed by the error message
 )
 
 // FrameWriter writes framed messages to a writer.

--- a/services/bamf/api/routers/terminal.py
+++ b/services/bamf/api/routers/terminal.py
@@ -42,14 +42,18 @@ FRAME_DATA = 0x01
 FRAME_RESIZE = 0x02
 FRAME_STATUS = 0x03
 
-# Handshake statuses the bridge may emit after the connect/credentials phase:
-# "ready" on a fresh session, "resumed" when it reattaches to a detached one.
-# CONTRACT: this vocabulary is shared with the bridge — see
-# pkg/bridge/webterm (frame.go / status constants) and pinned by
-# services/tests/contracts/terminal_status.json.
+# Web-terminal handshake status vocabulary. The bridge speaks first: it emits
+# "auth-required" on a fresh session (awaiting handshake + credentials) or
+# "resumed" when it reattaches to a detached one; after credentials it emits
+# "ready". The relay reads that status before sending anything, so credentials
+# are never forwarded into a resumed session (#233).
+# CONTRACT: shared with the bridge — see pkg/bridge/webterm (frame.go status
+# constants) and pinned by services/tests/contracts/terminal_status.json.
+STATUS_AUTH_REQUIRED = "auth-required"
 STATUS_READY = "ready"
 STATUS_RESUMED = "resumed"
 STATUS_ERROR_PREFIX = "error:"
+# Statuses that mean "the session is live" — forwarded to the browser as connected.
 TERMINAL_READY_STATUSES = frozenset({STATUS_READY, STATUS_RESUMED})
 
 # Ticket TTL in seconds
@@ -164,6 +168,70 @@ async def _read_frame(
     return frame_type, payload
 
 
+async def _terminal_handshake(
+    websocket: WebSocket,
+    reader: asyncio.StreamReader,
+    writer: asyncio.StreamWriter,
+    msg: dict,
+    resource_type: str,
+    *,
+    is_audit: bool,
+) -> str | None:
+    """Perform the bridge-first web-terminal handshake.
+
+    The bridge speaks first (#233): it emits ``auth-required`` on a fresh session
+    or ``resumed`` on a reattach. Credentials are forwarded to the bridge ONLY
+    after ``auth-required`` — never into a resumed session, regardless of what
+    the browser sent. This is the sole guard against injecting the SSH key / DB
+    password into a live session; the browser must not be trusted to decide it.
+
+    Returns the live status (``ready`` or ``resumed``) for the caller to relay to
+    the browser, or ``None`` if the websocket was already closed (error / EOF).
+    """
+
+    async def read_status() -> str | None:
+        frame = await _read_frame(reader)
+        if frame is None:
+            await websocket.close(code=4004, reason="Bridge disconnected")
+            return None
+        frame_type, payload = frame
+        if frame_type != FRAME_STATUS:
+            await websocket.close(code=4004, reason="Expected status frame")
+            return None
+        return payload.decode("utf-8")
+
+    async def forward_error(status: str) -> None:
+        await websocket.send_text(
+            json.dumps({"type": "error", "message": status[len(STATUS_ERROR_PREFIX) :]})
+        )
+        await websocket.close(code=4005, reason=status)
+
+    status_msg = await read_status()
+    if status_msg is None:
+        return None
+    if status_msg.startswith(STATUS_ERROR_PREFIX):
+        await forward_error(status_msg)
+        return None
+
+    if status_msg == STATUS_AUTH_REQUIRED:
+        # Fresh session — the bridge asked for the handshake + credentials.
+        await _send_credentials_to_bridge(writer, msg, resource_type, audit=is_audit)
+        status_msg = await read_status()
+        if status_msg is None:
+            return None
+        if status_msg.startswith(STATUS_ERROR_PREFIX):
+            await forward_error(status_msg)
+            return None
+        if status_msg != STATUS_READY:
+            await websocket.close(code=4004, reason=f"Unexpected status: {status_msg}")
+            return None
+    elif status_msg != STATUS_RESUMED:
+        await websocket.close(code=4004, reason=f"Unexpected status: {status_msg}")
+        return None
+
+    return status_msg
+
+
 @router.websocket("/ssh/{session_id}")
 async def terminal_ssh(websocket: WebSocket, session_id: str):
     """WebSocket relay for SSH web terminal sessions."""
@@ -255,37 +323,13 @@ async def _terminal_relay(websocket: WebSocket, session_id: str, resource_type: 
             is_audit=is_audit,
         )
 
-        # On reconnect the bridge reattaches to the existing detached session and
-        # emits "resumed" — it does NOT read credentials again. Re-sending them
-        # would inject the SSH key / DB password into the live stream. So forward
-        # credentials only on a fresh connect (the browser sets msg["reconnect"]).
-        is_reconnect = bool(msg.get("reconnect"))
-        if not is_reconnect:
-            await _send_credentials_to_bridge(writer, msg, resource_type, audit=is_audit)
-
-        # Wait for the bridge handshake status: "ready" (fresh) or "resumed"
-        # (reattached), else "error:...".
-        frame = await _read_frame(reader)
-        if frame is None:
-            await websocket.close(code=4004, reason="Bridge disconnected")
+        status_msg = await _terminal_handshake(
+            websocket, reader, writer, msg, resource_type, is_audit=is_audit
+        )
+        if status_msg is None:
             return
 
-        frame_type, payload = frame
-        status_msg = STATUS_READY
-        if frame_type == FRAME_STATUS:
-            status_msg = payload.decode("utf-8")
-            if status_msg.startswith(STATUS_ERROR_PREFIX):
-                await websocket.send_text(
-                    json.dumps({"type": "error", "message": status_msg[len(STATUS_ERROR_PREFIX) :]})
-                )
-                await websocket.close(code=4005, reason=status_msg)
-                return
-            if status_msg not in TERMINAL_READY_STATUSES:
-                await websocket.close(code=4004, reason=f"Unexpected status: {status_msg}")
-                return
-
-        # Relay the actual handshake status so the browser distinguishes a fresh
-        # connect ("ready") from a resumed session ("resumed").
+        # Tell the browser the session is live: "ready" (fresh) or "resumed".
         await websocket.send_text(json.dumps({"type": "status", "status": status_msg}))
 
         # Enter relay loop

--- a/services/tests/contracts/terminal_status.json
+++ b/services/tests/contracts/terminal_status.json
@@ -1,5 +1,6 @@
 {
-  "_comment": "Shared web-terminal handshake status vocabulary. Producer: bridge (pkg/bridge/webterm/frame.go StatusReady/StatusResumed/StatusErrorPrefix). Consumer: API relay (services/bamf/api/routers/terminal.py TERMINAL_READY_STATUSES / STATUS_ERROR_PREFIX). A drift in either side fails its contract test.",
+  "_comment": "Shared web-terminal handshake status vocabulary. Producer: bridge (pkg/bridge/webterm/frame.go StatusAuthRequired/StatusReady/StatusResumed/StatusErrorPrefix). Consumer: API relay (services/bamf/api/routers/terminal.py STATUS_AUTH_REQUIRED / TERMINAL_READY_STATUSES / STATUS_ERROR_PREFIX). The bridge speaks first: 'auth-required' on a fresh session (relay then sends credentials), 'resumed' on a reattach (relay sends nothing), 'ready' once the fresh session is live. A drift in either side fails its contract test.",
+  "auth_required": "auth-required",
   "ready_statuses": ["ready", "resumed"],
   "error_prefix": "error:"
 }

--- a/services/tests/test_api/test_contract_fixtures.py
+++ b/services/tests/test_api/test_contract_fixtures.py
@@ -189,8 +189,13 @@ def test_terminal_status_contract():
     a drift is exactly bug #123, where the bridge emitted "resumed" while the
     relay only accepted "ready" and closed the socket with 4004.
     """
-    from bamf.api.routers.terminal import STATUS_ERROR_PREFIX, TERMINAL_READY_STATUSES
+    from bamf.api.routers.terminal import (
+        STATUS_AUTH_REQUIRED,
+        STATUS_ERROR_PREFIX,
+        TERMINAL_READY_STATUSES,
+    )
 
     golden = json.loads((CONTRACTS / "terminal_status.json").read_text())
+    assert STATUS_AUTH_REQUIRED == golden["auth_required"]
     assert TERMINAL_READY_STATUSES == set(golden["ready_statuses"])
     assert STATUS_ERROR_PREFIX == golden["error_prefix"]

--- a/services/tests/test_api/test_terminal_handshake.py
+++ b/services/tests/test_api/test_terminal_handshake.py
@@ -1,0 +1,155 @@
+"""Tests for the bridge-first web-terminal handshake (issue #233).
+
+The security-critical property: credentials are forwarded to the bridge ONLY
+after it emits "auth-required" (a fresh session). On "resumed" (a reattach) no
+credentials are ever sent, so an SSH key / DB password can never be injected
+into a live session — regardless of what the browser sent.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import struct
+
+import pytest
+
+from bamf.api.routers import terminal
+from bamf.api.routers.terminal import (
+    FRAME_DATA,
+    FRAME_STATUS,
+    STATUS_AUTH_REQUIRED,
+    STATUS_READY,
+    STATUS_RESUMED,
+    _terminal_handshake,
+)
+
+
+def _frame(frame_type: int, payload: bytes) -> bytes:
+    return bytes([frame_type]) + struct.pack("!H", len(payload)) + payload
+
+
+def _status(s: str) -> bytes:
+    return _frame(FRAME_STATUS, s.encode())
+
+
+class FakeReader:
+    """Serves pre-encoded bridge frames to _read_frame's readexactly()."""
+
+    def __init__(self, data: bytes):
+        self._data = data
+        self._pos = 0
+
+    async def readexactly(self, n: int) -> bytes:
+        if self._pos + n > len(self._data):
+            raise asyncio.IncompleteReadError(self._data[self._pos :], n)
+        chunk = self._data[self._pos : self._pos + n]
+        self._pos += n
+        return chunk
+
+
+class FakeWS:
+    def __init__(self):
+        self.sent: list[str] = []
+        self.closed: tuple[int, str] | None = None
+
+    async def send_text(self, text: str) -> None:
+        self.sent.append(text)
+
+    async def close(self, code: int = 1000, reason: str = "") -> None:
+        self.closed = (code, reason)
+
+
+@pytest.fixture
+def creds_spy(monkeypatch):
+    """Record every _send_credentials_to_bridge call (and forward nothing)."""
+    calls: list[dict] = []
+
+    async def fake_send(writer, msg, resource_type, *, audit=False):
+        calls.append({"resource_type": resource_type, "audit": audit})
+
+    monkeypatch.setattr(terminal, "_send_credentials_to_bridge", fake_send)
+    return calls
+
+
+@pytest.mark.asyncio
+async def test_resumed_never_sends_credentials(creds_spy):
+    """#233 core guard: a 'resumed' session must NOT receive credentials."""
+    reader = FakeReader(_status(STATUS_RESUMED))
+    ws = FakeWS()
+
+    status = await _terminal_handshake(
+        ws,
+        reader,
+        writer=object(),
+        msg={"key": "SECRET-PEM"},
+        resource_type="web-ssh",
+        is_audit=False,
+    )
+
+    assert status == STATUS_RESUMED
+    assert creds_spy == [], "credentials must never be sent into a resumed session"
+    assert ws.closed is None
+
+
+@pytest.mark.asyncio
+async def test_auth_required_sends_credentials_then_ready(creds_spy):
+    """A fresh session: bridge asks (auth-required), relay sends creds, gets ready."""
+    reader = FakeReader(_status(STATUS_AUTH_REQUIRED) + _status(STATUS_READY))
+    ws = FakeWS()
+
+    status = await _terminal_handshake(
+        ws, reader, writer=object(), msg={"key": "SECRET"}, resource_type="web-ssh", is_audit=True
+    )
+
+    assert status == STATUS_READY
+    assert len(creds_spy) == 1, "credentials sent exactly once on a fresh session"
+    assert creds_spy[0]["audit"] is True
+    assert ws.closed is None
+
+
+@pytest.mark.asyncio
+async def test_error_first_forwards_and_closes_without_creds(creds_spy):
+    """An error before auth-required forwards to the browser and sends no creds."""
+    reader = FakeReader(_status("error:boom"))
+    ws = FakeWS()
+
+    status = await _terminal_handshake(
+        ws, reader, writer=object(), msg={"key": "S"}, resource_type="web-ssh", is_audit=False
+    )
+
+    assert status is None
+    assert creds_spy == []
+    assert json.loads(ws.sent[0]) == {"type": "error", "message": "boom"}
+    assert ws.closed[0] == 4005
+
+
+@pytest.mark.asyncio
+async def test_auth_required_then_auth_failure_forwards_error(creds_spy):
+    """Fresh session where the bridge rejects the credentials: error is forwarded."""
+    reader = FakeReader(_status(STATUS_AUTH_REQUIRED) + _status("error:auth failed"))
+    ws = FakeWS()
+
+    status = await _terminal_handshake(
+        ws, reader, writer=object(), msg={"key": "S"}, resource_type="web-ssh", is_audit=False
+    )
+
+    assert status is None
+    assert len(creds_spy) == 1  # creds were sent, then the bridge failed auth
+    assert json.loads(ws.sent[0]) == {"type": "error", "message": "auth failed"}
+    assert ws.closed[0] == 4005
+
+
+@pytest.mark.asyncio
+async def test_non_status_first_frame_closes(creds_spy):
+    """A non-status opening frame is a protocol violation → close, no creds."""
+    reader = FakeReader(_frame(FRAME_DATA, b"garbage"))
+    ws = FakeWS()
+
+    status = await _terminal_handshake(
+        ws, reader, writer=object(), msg={}, resource_type="web-ssh", is_audit=False
+    )
+
+    assert status is None
+    assert creds_spy == []
+    assert ws.closed[0] == 4004

--- a/web/src/components/web-terminal.tsx
+++ b/web/src/components/web-terminal.tsx
@@ -35,10 +35,6 @@ export default function WebTerminal({
   const fitAddonRef = useRef<import('@xterm/addon-fit').FitAddon | null>(null)
   const [status, setStatus] = useState<'connecting' | 'connected' | 'reconnecting' | 'disconnected'>('connecting')
   const reconnectAttempts = useRef(0)
-  // True once this session has connected at least once. On a subsequent
-  // (re)connect the bridge reattaches to the still-live detached session, so we
-  // tell the relay to resume instead of re-sending credentials into the stream.
-  const hasConnected = useRef(false)
   const maxReconnectAttempts = 3
   const userDisconnected = useRef(false)
 
@@ -106,9 +102,10 @@ export default function WebTerminal({
       ws.binaryType = 'arraybuffer'
 
       ws.onopen = () => {
-        // Send the initial message. On a reconnect the relay skips credential
-        // injection and the bridge resumes the existing session.
-        ws.send(JSON.stringify({ ...credentialsRef.current, reconnect: hasConnected.current }))
+        // Always send the credentials message. The bridge decides fresh-vs-resume
+        // and the relay only forwards these credentials on a fresh session
+        // ("auth-required"); on a reattach ("resumed") they're ignored (#233).
+        ws.send(JSON.stringify(credentialsRef.current))
       }
 
       ws.onmessage = (event) => {
@@ -127,12 +124,10 @@ export default function WebTerminal({
               if (msg.status === 'ready') {
                 setStatus('connected')
                 reconnectAttempts.current = 0
-                hasConnected.current = true
                 onConnectedRef.current?.()
               } else if (msg.status === 'resumed') {
                 setStatus('connected')
                 reconnectAttempts.current = 0
-                hasConnected.current = true
                 terminal.write('\r\n[Session resumed]\r\n')
                 onConnectedRef.current?.()
               }


### PR DESCRIPTION
Closes #233. Blocks the v0.9.1 release (surfaced by the pre-release adversarial review of the #123 fix).

## Problem

The reconnect handshake decided whether to (re-)send credentials from a **browser-supplied flag**, while the **bridge** decided fresh-vs-resume from its **own** session state. When they disagreed — e.g. the initial `ready` frame is lost before the browser processes it, so it reconnects with `reconnect:false` — the relay re-sent credentials, and the bridge (having resumed the live session) wrote those frames straight into the session input and the recording. An SSH key PEM / DB password could land in the user's **own** session recording via a connect-time race.

(Same-user only — the WS is gated by a one-time, session-bound, RBAC-re-checked ticket. Pre-existing; #123 improved but didn't close it.)

## Fix — the bridge is the sole source of truth

The bridge now **speaks first**:
- emits `auth-required` at the start of a fresh `web-ssh`/`web-db` handler (before reading the handshake + credentials);
- emits `resumed` on reattach (unchanged).

The relay reads that status **before sending anything** and forwards credentials **only** after `auth-required` — never into a resumed session. The browser `reconnect` flag is removed entirely.

- `pkg/bridge/webterm`: add `StatusAuthRequired`; both handlers emit it first.
- `terminal.py`: read-first handshake extracted into `_terminal_handshake()` so the "no credentials on resume" invariant is directly unit-testable.
- `web-terminal.tsx`: drop the `reconnect` flag / `hasConnected` ref.
- Extend the shared `terminal_status.json` contract with `auth-required`, pinned Go↔Python.

## Verification

- **`test_terminal_handshake.py`** (new): `resumed` never sends credentials; `auth-required` sends them exactly once; errors are forwarded without credentials; non-status opener closes.
- **Live**: a fresh `web-ssh` session connects end-to-end through the new handshake (`ready`, real SSH shell) on the Tilt stack.
- Full Go (`-race`) + Python suites green; `golangci-lint`, `gofmt`, `ruff`, `tsc` clean.