### PR TITLE
chore(review): address minor findings from the pre-release review

### DIFF
--- a/pkg/bridge/server.go
+++ b/pkg/bridge/server.go
@@ -1282,7 +1282,7 @@ func (s *Server) handleWebTerminalSSH(ctx context.Context, clientConn, agentConn
 	)
 
 	if username == "" {
-		_ = fw.WriteStatus("error:username required")
+		_ = fw.WriteStatus(webterm.StatusErrorPrefix + "username required")
 		clientConn.Close()
 		agentConn.Close()
 		return
@@ -1348,7 +1348,7 @@ func (s *Server) handleWebTerminalSSH(ctx context.Context, clientConn, agentConn
 		signer, err := ssh.ParsePrivateKey(pemBuf)
 		if err != nil {
 			logger.Error("failed to parse SSH key", "error", err)
-			_ = fw.WriteStatus("error:invalid SSH key: " + err.Error())
+			_ = fw.WriteStatus(webterm.StatusErrorPrefix + "invalid SSH key: " + err.Error())
 			// Zero the PEM buffer.
 			for i := range pemBuf {
 				pemBuf[i] = 0
@@ -1370,7 +1370,7 @@ func (s *Server) handleWebTerminalSSH(ctx context.Context, clientConn, agentConn
 	channel, recording, err := s.sshProxy.HandleDirect(agentConn, username, authMethods, int(cols), int(rows), auditSession, logger)
 	if err != nil {
 		logger.Error("SSH auth to target failed", "error", err)
-		_ = fw.WriteStatus("error:" + err.Error())
+		_ = fw.WriteStatus(webterm.StatusErrorPrefix + err.Error())
 		clientConn.Close()
 		agentConn.Close()
 		return
@@ -1508,7 +1508,7 @@ func (s *Server) handleWebTerminalDB(ctx context.Context, clientConn, agentConn 
 	localListener, err := net.Listen("tcp", "127.0.0.1:0")
 	if err != nil {
 		logger.Error("failed to bind local listener", "error", err)
-		_ = fw.WriteStatus("error:internal error")
+		_ = fw.WriteStatus(webterm.StatusErrorPrefix + "internal error")
 		clientConn.Close()
 		agentConn.Close()
 		return
@@ -1544,7 +1544,7 @@ func (s *Server) handleWebTerminalDB(ctx context.Context, clientConn, agentConn 
 	master, slave, err := webterm.OpenPTY()
 	if err != nil {
 		logger.Error("failed to open PTY", "error", err)
-		_ = fw.WriteStatus("error:" + err.Error())
+		_ = fw.WriteStatus(webterm.StatusErrorPrefix + err.Error())
 		clientConn.Close()
 		return
 	}
@@ -1594,7 +1594,7 @@ func (s *Server) handleWebTerminalDB(ctx context.Context, clientConn, agentConn 
 		// Disable SSL for same reason as PostgreSQL (see above).
 		cmd = append(cmd, "--ssl-mode=DISABLED")
 	default:
-		_ = fw.WriteStatus("error:unsupported db_type: " + dbType)
+		_ = fw.WriteStatus(webterm.StatusErrorPrefix + "unsupported db_type: " + dbType)
 		clientConn.Close()
 		return
 	}
@@ -1604,7 +1604,7 @@ func (s *Server) handleWebTerminalDB(ctx context.Context, clientConn, agentConn 
 	slave.Close() // Close slave in parent after passing to child.
 	if err != nil {
 		logger.Error("failed to spawn database client", "error", err, "cmd", cmd[0])
-		_ = fw.WriteStatus("error:failed to start " + cmd[0])
+		_ = fw.WriteStatus(webterm.StatusErrorPrefix + "failed to start " + cmd[0])
 		clientConn.Close()
 		return
 	}

--- a/pkg/bridge/webterm/contract_test.go
+++ b/pkg/bridge/webterm/contract_test.go
@@ -4,10 +4,19 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 )
+
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	// `go test` runs in the package dir (pkg/bridge/webterm); repo root is three up.
+	wd, err := os.Getwd()
+	require.NoError(t, err)
+	return filepath.Join(wd, "..", "..", "..")
+}
 
 // TestTerminalStatusContract guards the web-terminal handshake status vocabulary
 // shared between the bridge (producer of the status frames) and the API relay
@@ -18,11 +27,7 @@ import (
 // fixture (and the peer) to be updated in lockstep. This is the class of bug
 // #123 hit: the bridge emitted "resumed" while the relay only accepted "ready".
 func TestTerminalStatusContract(t *testing.T) {
-	// `go test` runs in the package dir (pkg/bridge/webterm); repo root is three up.
-	wd, err := os.Getwd()
-	require.NoError(t, err)
-	root := filepath.Join(wd, "..", "..", "..")
-	raw, err := os.ReadFile(filepath.Join(root, "services", "tests", "contracts", "terminal_status.json"))
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "services", "tests", "contracts", "terminal_status.json"))
 	require.NoError(t, err, "shared terminal-status fixture must exist")
 
 	var fixture struct {
@@ -39,4 +44,33 @@ func TestTerminalStatusContract(t *testing.T) {
 		"bridge ready-status constants must match the shared fixture")
 	require.Equal(t, fixture.ErrorPrefix, StatusErrorPrefix,
 		"bridge error prefix must match the shared fixture")
+}
+
+// TestTerminalStatusBrowserConsumer pins the third consumer of the status
+// vocabulary — the web UI — to the same golden fixture. The browser is the one
+// consumer covered by neither the Go nor the Python contract test above, so if
+// the ready-status vocabulary grows, the bridge/relay/fixture could be updated
+// in lockstep while the UI silently stops recognising a status (leaving the
+// terminal stuck "connecting"). This reads web-terminal.tsx and asserts it
+// handles exactly the fixture's ready statuses.
+func TestTerminalStatusBrowserConsumer(t *testing.T) {
+	root := repoRoot(t)
+	raw, err := os.ReadFile(filepath.Join(root, "services", "tests", "contracts", "terminal_status.json"))
+	require.NoError(t, err)
+	var fixture struct {
+		ReadyStatuses []string `json:"ready_statuses"`
+	}
+	require.NoError(t, json.Unmarshal(raw, &fixture))
+
+	tsx, err := os.ReadFile(filepath.Join(root, "web", "src", "components", "web-terminal.tsx"))
+	require.NoError(t, err, "web-terminal.tsx must exist")
+
+	// Extract every `msg.status === '<x>'` comparison the UI branches on.
+	re := regexp.MustCompile(`msg\.status === '([a-z-]+)'`)
+	var handled []string
+	for _, m := range re.FindAllStringSubmatch(string(tsx), -1) {
+		handled = append(handled, m[1])
+	}
+	require.ElementsMatch(t, fixture.ReadyStatuses, handled,
+		"web-terminal.tsx must handle exactly the fixture's ready statuses (update the UI when the vocabulary changes)")
 }

--- a/services/bamf/api/middleware.py
+++ b/services/bamf/api/middleware.py
@@ -37,6 +37,20 @@ def _is_excluded(path: str) -> bool:
     return any(path.startswith(prefix) for prefix in _EXCLUDED_PREFIXES)
 
 
+# Strong references to in-flight fire-and-forget audit tasks. Without them,
+# asyncio may garbage-collect a task before it finishes committing (CPython
+# only keeps a weak reference to running tasks). The done-callback drops the
+# reference once the task completes.
+_audit_tasks: set[asyncio.Task] = set()
+
+
+def _fire_audit(coro) -> None:
+    """Schedule an audit-store coroutine as a retained background task."""
+    task = asyncio.create_task(coro)
+    _audit_tasks.add(task)
+    task.add_done_callback(_audit_tasks.discard)
+
+
 async def api_audit_middleware(request: Request, call_next):
     """Middleware that records API request/response exchanges for audit.
 
@@ -84,8 +98,11 @@ async def api_audit_middleware(request: Request, call_next):
                 # disconnect / cancellation), so the audit captures exactly the
                 # bytes that were sent and the true end-to-end duration. Runs as
                 # a background task so we never block the ASGI send loop.
+                # (If the iterator is never started at all the audit is skipped —
+                # the response was never sent, so there is nothing to record;
+                # the early-disconnect case still fires here via GeneratorExit.)
                 elapsed_ms = round((time.monotonic() - t0) * 1000)
-                asyncio.create_task(
+                _fire_audit(
                     _store_api_audit(
                         request=request,
                         request_body=body,
@@ -104,7 +121,7 @@ async def api_audit_middleware(request: Request, call_next):
         resp_body = response.body
     elapsed_ms = round((time.monotonic() - t0) * 1000)
 
-    asyncio.create_task(
+    _fire_audit(
         _store_api_audit(
             request=request,
             request_body=body,


### PR DESCRIPTION
Follow-up to the adversarial pre-release review (the blocker was #234). Fixes the remaining **minor/non-blocking** findings before cutting v0.9.1.

- **Middleware — GC-able audit tasks.** `asyncio.create_task(...)` results weren't retained, so a running audit task could be garbage-collected before it committed (CPython keeps only a weak ref). Added `_fire_audit()` + a module-level retention set. Also documented that a never-*started* stream is intentionally not audited (nothing was sent); the early-*disconnect* case still fires via the iterator's `finally`.
- **Bridge — hollow error-prefix contract.** The bridge emitted bare `"error:"` string literals, so the shared `terminal_status.json` error-prefix pin didn't actually constrain the wire output. All seven web-terminal error emits now use `webterm.StatusErrorPrefix`.
- **Contract — third consumer unpinned.** The web UI (`web-terminal.tsx`) is a status-vocabulary consumer covered by neither the Go nor Python contract test — the bridge/relay/fixture could drift in lockstep while the UI silently stopped recognising a status. A new Go test reads the tsx and asserts it handles exactly the fixture's ready statuses.

The review's PEP 758 `except` note turned out to be intentional house style — ruff's formatter enforces the parenthesis-less form on 3.14 — so it's left as-is.

## Verification

`golangci-lint`, `gofmt`, `ruff check`/`ruff format --check`, `tsc` clean; Go (`-race`) webterm/bridge tests and the Python middleware/terminal/contract tests all pass.