### PR TITLE
docs: fix Helm values drift (bridge maxReplicas key + resource defaults)

### DIFF
--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -102,7 +102,7 @@ core:
   api:
     replicas: 2
     resources:
-      requests: { cpu: 250m, memory: 512Mi }
+      requests: { cpu: 500m, memory: 1Gi }
       limits: { cpu: "1", memory: 1Gi }
     autoscaling:
       enabled: true
@@ -124,9 +124,8 @@ core:
 outpost:
   bridge:
     replicas: 2
-    maxReplicas: 20
     resources:
-      requests: { cpu: 250m, memory: 256Mi }
+      requests: { cpu: "1", memory: 1Gi }
       limits: { cpu: "2", memory: 1Gi }
     autoscaling:
       enabled: true
@@ -135,7 +134,8 @@ outpost:
 ```
 
 The bridge is deployed as a StatefulSet with per-pod Services for SNI routing.
-`maxReplicas` controls how many Services and TLSRoutes are pre-created.
+`outpost.bridge.autoscaling.maxReplicas` controls how many Services and
+TLSRoutes are pre-created.
 
 ### Web UI
 

--- a/docs/operations/scaling.md
+++ b/docs/operations/scaling.md
@@ -31,7 +31,6 @@ Bridges are stateful — they hold persistent mTLS relay/tunnel connections to a
 outpost:
   bridge:
     replicas: 2
-    maxReplicas: 20
     autoscaling:
       enabled: true
       minReplicas: 2
@@ -39,9 +38,9 @@ outpost:
       targetCPUUtilizationPercentage: 70
 ```
 
-**Important:** `outpost.bridge.maxReplicas` controls how many per-pod Services
-and TLSRoutes are pre-created. Scaling beyond `maxReplicas` requires a Helm
-upgrade.
+**Important:** `outpost.bridge.autoscaling.maxReplicas` controls how many per-pod
+Services and TLSRoutes are pre-created. Scaling beyond `maxReplicas` requires a
+Helm upgrade.
 
 Bridge scaling creates new StatefulSet pods. Each pod gets a pre-created Service
 and TLSRoute, so routing works immediately on scale-up.

--- a/docs/reference/helm-values.md
+++ b/docs/reference/helm-values.md
@@ -100,7 +100,6 @@ load balancer sits in front of the ingress.
 outpost:
   bridge:
     replicas: 2                      # Initial replicas
-    maxReplicas: 20                  # HPA max; controls pre-created Services/TLSRoutes
     image:
       repository: ghcr.io/mattrobinsonsre/bamf-bridge
       tag: ""
@@ -111,7 +110,7 @@ outpost:
     autoscaling:
       enabled: true
       minReplicas: 2
-      maxReplicas: 20
+      maxReplicas: 20                # HPA max; also pre-creates Services/TLSRoutes
       targetCPUUtilizationPercentage: 70
       targetTunnelsPerPod: 50          # Custom metric scaling (requires prometheus-adapter)
       nonMigratableOversubscribeFactor: 1.5  # Oversubscription for ssh-audit sessions


### PR DESCRIPTION
Part of #126 (docs-vs-code drift audit). Verified against the current `values.yaml` and chart templates.

## Fixes

- **Flat `outpost.bridge.maxReplicas` doesn't exist.** The per-pod Services / TLSRoutes loop and the bridge HPA both read `outpost.bridge.autoscaling.maxReplicas` (`service-bridge-pods.yaml`, `hpa-bridge.yaml`, `tlsroute-bridges.yaml`, `ingressroutetcp-bridges.yaml`). The docs showed a flat `bridge.maxReplicas` that the chart silently ignores. Removed it from `deployment.md`, `helm-values.md`, and `scaling.md`, and pointed the "controls Services/TLSRoutes" note at the real `autoscaling.maxReplicas` key.
- **deployment.md resource defaults were understated.** `core.api` requests are `500m/1Gi` (not `250m/512Mi`) and `outpost.bridge` requests are `1 CPU / 1Gi` (not `250m/256Mi`), matching `values.yaml`.

## Note

Most of #126's P1 list was already resolved by #220 (bcrypt→PBKDF2, the fictional `ca.provider` block, `credentials.json` contents, the removed `/kube` endpoint). This closes the remaining values-structure drift. The larger P2/P3 items (missing API-reference routers, the standalone-proxy reconciliation) remain as follow-ups.

`mkdocs build --strict` passes — no broken links or nav gaps.