### PR TITLE
feat(networking): split-horizon M2M ingress for edges vs humans

### DIFF
--- a/docs/admin/deployment.md
+++ b/docs/admin/deployment.md
@@ -411,6 +411,50 @@ The chart creates:
 - HTTPRoute for web app proxy (`*.tunnel.bamf.example.com`)
 - TLSRoute per bridge pod for tunnel traffic (SNI passthrough)
 
+### Split-horizon (M2M) ingress
+
+By default every consumer — humans and the CLI, plus agents/edges and bridges —
+reaches BAMF through the single `gateway.hostname` / `gateway.tunnelDomain`
+above (agents can also use in-cluster Service DNS; see the agent
+[`zone`](../reference/agent-config.md)). When there is a separate **internal
+network** (e.g. a transit-gateway / VPC fabric), you can put machine-to-machine
+traffic on its own internal ingress while humans stay on the public one — enable
+the optional `gateway.m2m` binding:
+
+```yaml
+gateway:
+  hostname: bamf.example.com            # public — humans + CLI (Cloudflare / Tailscale)
+  tunnelDomain: tunnel.bamf.example.com
+  m2m:
+    enabled: true
+    hostname: bamf.internal             # internal — agents/edges + bridges
+    tunnelDomain: tunnel.bamf.internal
+    tls:
+      existingSecret: bamf-public-tls   # a TRACEABLE cert (see note)
+```
+
+When enabled the chart adds, on the internal binding, a second API route (agent /
+bridge / internal endpoints) and a second SNI-passthrough route set for the
+bridge tunnels — both to the same backends. The API then hands each requester the
+bridge dial host for **its** vantage:
+
+| Agent `zone` | Bridge dial host |
+|---|---|
+| `in-cluster` | K8s Service DNS |
+| `internal` | `*.bridge.{m2m.tunnelDomain}` |
+| `public` (default) | `*.bridge.{tunnelDomain}` |
+
+The CLI and browsers always use the public binding. Set an edge's vantage with
+`agent.zone` (or the agent's `zone:` config); `clusterInternal: true` remains a
+back-compat alias for `in-cluster`.
+
+!!! warning "The internal API cert must be traceable"
+    The internal binding's API HTTPS must present a cert from a **trusted
+    issuer** (commonly the same public cert duplicated via `existingSecret`),
+    never the BAMF internal CA — an edge validates that cert to bootstrap trust
+    *before* it has the BAMF CA. The bridge tunnel routes stay SNI-passthrough
+    (the bridge presents its BAMF-CA cert), so this applies only to the API route.
+
 ## TLS Hardening
 
 BAMF enforces TLS 1.3 by default on both the public ingress and internal

--- a/docs/reference/helm-values.md
+++ b/docs/reference/helm-values.md
@@ -21,6 +21,27 @@ When `provider: traefik`, the chart creates Traefik IngressRoute and
 IngressRouteTCP CRDs. When `provider: istio`, it creates Gateway API resources
 (Gateway, HTTPRoute, TLSRoute) for the Istio controller.
 
+### Split-horizon (M2M) ingress
+
+Optional second, internal ingress for agent/edge + bridge traffic, separate from
+the public `hostname`/`tunnelDomain`. See
+[Split-horizon ingress](../admin/deployment.md#split-horizon-m2m-ingress).
+
+```yaml
+gateway:
+  m2m:
+    enabled: false               # off = everything uses the public binding (default)
+    hostname: bamf.internal       # internal API hostname
+    tunnelDomain: tunnel.bamf.internal  # internal bridge tunnel domain
+    className: ""                 # Istio gatewayClass override (defaults to gateway.className)
+    traefik:
+      entryPoint: ""              # defaults to gateway.traefik.entryPoint
+    tls:
+      existingSecret: ""          # a TRACEABLE cert (often the public cert duplicated)
+      certManager:
+        enabled: false            # or let cert-manager issue for the internal hostname
+```
+
 ### Rate Limiting
 
 ```yaml
@@ -155,7 +176,8 @@ agent:
     resources: []                  # Resource definitions (list)
   platformUrl: ""                  # BAMF API URL
   joinToken: ""                    # Join token for registration
-  clusterInternal: false           # Use in-cluster API URL
+  clusterInternal: false           # Use in-cluster API URL (alias for zone: in-cluster)
+  zone: ""                         # Split-horizon vantage: in-cluster | internal | public (empty = fall back to clusterInternal then public)
   kubernetes:
     impersonation:
       enabled: false               # Create K8s impersonation RBAC

--- a/helm/bamf/templates/_helpers.tpl
+++ b/helm/bamf/templates/_helpers.tpl
@@ -275,6 +275,19 @@ Usage: {{ include "bamf.bridge.sniHostname" (dict "root" . "ordinal" 0) }}
 {{- end }}
 
 {{/*
+Internal (M2M) bridge SNI hostname — same shape as bamf.bridge.sniHostname but
+built from gateway.m2m.tunnelDomain. Used for the internal bridge-SNI route set
+that agents/edges on the internal network dial.
+*/}}
+{{- define "bamf.bridge.m2mSniHostname" -}}
+{{- if .root.Values.outpost.name -}}
+{{ .ordinal }}.bridge.{{ .root.Values.outpost.name }}.{{ .root.Values.gateway.m2m.tunnelDomain }}
+{{- else -}}
+{{ .ordinal }}.bridge.{{ .root.Values.gateway.m2m.tunnelDomain }}
+{{- end -}}
+{{- end }}
+
+{{/*
 Outpost tunnel domain — the base domain for this outpost's proxy.
 gateway.tunnelDomain already includes "tunnel." (e.g., "tunnel.bamf.example.com").
 When outpost.name is set: {outpost}.{tunnelDomain}
@@ -285,6 +298,18 @@ Otherwise: {tunnelDomain} (unchanged)
 {{ .Values.outpost.name }}.{{ .Values.gateway.tunnelDomain }}
 {{- else -}}
 {{ .Values.gateway.tunnelDomain }}
+{{- end -}}
+{{- end }}
+
+{{/*
+Internal (M2M) outpost tunnel domain — mirror of bamf.outpost.tunnelDomain built
+from gateway.m2m.tunnelDomain, for the Istio internal passthrough listener.
+*/}}
+{{- define "bamf.outpost.m2mTunnelDomain" -}}
+{{- if .Values.outpost.name -}}
+{{ .Values.outpost.name }}.{{ .Values.gateway.m2m.tunnelDomain }}
+{{- else -}}
+{{ .Values.gateway.m2m.tunnelDomain }}
 {{- end -}}
 {{- end }}
 

--- a/helm/bamf/templates/configmap-agent.yaml
+++ b/helm/bamf/templates/configmap-agent.yaml
@@ -28,6 +28,11 @@ data:
     cluster_internal: true
     {{- end }}
 
+    # Network zone for split-horizon bridge routing (#167): in-cluster | internal | public
+    {{- if .Values.agent.zone }}
+    zone: {{ .Values.agent.zone | quote }}
+    {{- end }}
+
     # Labels for RBAC matching
     {{- if .Values.agent.config.labels }}
     labels:

--- a/helm/bamf/templates/configmap-api.yaml
+++ b/helm/bamf/templates/configmap-api.yaml
@@ -46,6 +46,12 @@ data:
     tunnel_domain: {{ .Values.gateway.tunnelDomain | quote }}
     {{- end }}
 
+    {{- if and .Values.gateway.m2m.enabled .Values.gateway.m2m.tunnelDomain }}
+    # Internal (M2M) tunnel domain — agents/edges in the "internal" zone are
+    # handed bridge SNI hostnames on this domain (split-horizon ingress, #167).
+    m2m_tunnel_domain: {{ .Values.gateway.m2m.tunnelDomain | quote }}
+    {{- end }}
+
     # Bridge headless service for internal relay communication
     bridge_headless_service: {{ printf "%s-bridge-headless" (include "bamf.fullname" .) | quote }}
 

--- a/helm/bamf/templates/gateway.yaml
+++ b/helm/bamf/templates/gateway.yaml
@@ -47,4 +47,35 @@ spec:
         kinds:
           - kind: TLSRoute
     {{- end }}
+
+    {{- if .Values.gateway.m2m.enabled }}
+    # ── Internal (M2M) split-horizon listeners (#167) ─────────────────────────
+    # Internal HTTPS for agent/edge + bridge API bootstrap. A distinct hostname
+    # lets SNI pick the (traceable) internal cert vs the public one.
+    - name: https-m2m
+      port: {{ .Values.gateway.ports.https | default 443 }}
+      protocol: HTTPS
+      hostname: {{ required "gateway.m2m.hostname is required when gateway.m2m.enabled" .Values.gateway.m2m.hostname | quote }}
+      tls:
+        mode: Terminate
+        certificateRefs:
+          - name: {{ .Values.gateway.m2m.tls.existingSecret | default (printf "%s-m2m-tls" (include "bamf.fullname" .)) }}
+      allowedRoutes:
+        namespaces:
+          from: Same
+    {{- if .Values.gateway.m2m.tunnelDomain }}
+    # Internal TLS-passthrough for the bridge tunnels on the m2m domain.
+    - name: tunnel-m2m
+      port: {{ .Values.gateway.ports.https | default 443 }}
+      protocol: TLS
+      hostname: "*.bridge.{{ include "bamf.outpost.m2mTunnelDomain" . }}"
+      tls:
+        mode: Passthrough
+      allowedRoutes:
+        namespaces:
+          from: Same
+        kinds:
+          - kind: TLSRoute
+    {{- end }}
+    {{- end }}
 {{- end }}

--- a/helm/bamf/templates/httproute-api.yaml
+++ b/helm/bamf/templates/httproute-api.yaml
@@ -54,4 +54,36 @@ spec:
         - name: {{ include "bamf.fullname" . }}-api
           port: 8000
     {{- end }}
+{{- if .Values.gateway.m2m.enabled }}
+---
+# Internal (M2M) HTTPRoute — the same API Service on the internal hostname for
+# agents/edges + bridges. Humans/CLI stay on the public route above (#167).
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ include "bamf.fullname" . }}-api-m2m
+  labels:
+    {{- include "bamf.labels" . | nindent 4 }}
+    app.kubernetes.io/component: m2m
+spec:
+  parentRefs:
+    - name: {{ include "bamf.fullname" . }}
+      sectionName: https-m2m
+  hostnames:
+    - {{ required "gateway.m2m.hostname is required when gateway.m2m.enabled" .Values.gateway.m2m.hostname | quote }}
+  rules:
+    - matches:
+        - path:
+            type: PathPrefix
+            value: /api
+        - path:
+            type: PathPrefix
+            value: /health
+        - path:
+            type: PathPrefix
+            value: /ready
+      backendRefs:
+        - name: {{ include "bamf.fullname" . }}-api
+          port: 8000
+{{- end }}
 {{- end }}

--- a/helm/bamf/templates/ingressroute-api.yaml
+++ b/helm/bamf/templates/ingressroute-api.yaml
@@ -59,4 +59,43 @@ spec:
     options:
       name: {{ $fullName }}-hardened
       namespace: {{ .Release.Namespace }}
+{{- if .Values.gateway.m2m.enabled }}
+{{- $m2mEntryPoint := .Values.gateway.m2m.traefik.entryPoint | default $entryPoint }}
+{{- $m2mSecret := .Values.gateway.m2m.tls.existingSecret | default (printf "%s-m2m-tls" $fullName) }}
+---
+# Internal (M2M) IngressRoute — the same API Service on the internal hostname
+# for agents/edges and bridges. Humans + CLI stay on the public route above.
+# Auth is per-endpoint (cert for agent/bridge/internal routes), so exposing the
+# API here is safe. TLS must be a traceable cert (see gateway.m2m in values).
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $fullName }}-api-m2m
+  labels:
+    {{- include "bamf.labels" . | nindent 4 }}
+    app.kubernetes.io/component: m2m
+  {{- with .Values.gateway.m2m.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  entryPoints:
+    - {{ $m2mEntryPoint }}
+  routes:
+    - match: Host(`{{ required "gateway.m2m.hostname is required when gateway.m2m.enabled" .Values.gateway.m2m.hostname }}`) && (PathPrefix(`/api`) || PathPrefix(`/health`) || PathPrefix(`/ready`))
+      kind: Rule
+      {{- if .Values.gateway.rateLimit.enabled }}
+      middlewares:
+        - name: {{ $fullName }}-rate-limit
+          namespace: {{ .Release.Namespace }}
+      {{- end }}
+      services:
+        - name: {{ $fullName }}-api
+          port: 8000
+  tls:
+    secretName: {{ $m2mSecret }}
+    options:
+      name: {{ $fullName }}-hardened
+      namespace: {{ .Release.Namespace }}
+{{- end }}
 {{- end }}

--- a/helm/bamf/templates/ingressroutetcp-bridges.yaml
+++ b/helm/bamf/templates/ingressroutetcp-bridges.yaml
@@ -13,6 +13,8 @@
 # else gets TLS termination.
 # SNI hostname format: {ordinal}.bridge.{tunnelDomain}
 
+{{- $m2mEnabled := and $.Values.gateway.m2m.enabled $.Values.gateway.m2m.tunnelDomain -}}
+{{- $m2mEntryPoint := $.Values.gateway.m2m.traefik.entryPoint | default $entryPoint -}}
 {{- range $i := until $maxReplicas }}
 ---
 apiVersion: traefik.io/v1alpha1
@@ -33,5 +35,30 @@ spec:
           port: {{ $tunnelPort }}
   tls:
     passthrough: true
+{{- if $m2mEnabled }}
+---
+# Internal (M2M) SNI route to the SAME bridge pod — agents/edges on the internal
+# network dial this hostname; the CLI/humans use the public one above. Both are
+# TLS-passthrough (the bridge presents its BAMF-CA cert).
+apiVersion: traefik.io/v1alpha1
+kind: IngressRouteTCP
+metadata:
+  name: {{ $fullName }}-bridge-m2m-{{ $i }}
+  labels:
+    {{- $labels | nindent 4 }}
+    app.kubernetes.io/component: bridge
+    bamf.io/bridge-ordinal: "{{ $i }}"
+    bamf.io/binding: m2m
+spec:
+  entryPoints:
+    - {{ $m2mEntryPoint }}
+  routes:
+    - match: HostSNI(`{{ include "bamf.bridge.m2mSniHostname" (dict "root" $ "ordinal" $i) }}`)
+      services:
+        - name: {{ $fullName }}-bridge-{{ $i }}
+          port: {{ $tunnelPort }}
+  tls:
+    passthrough: true
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/bamf/templates/tlsroute-bridges.yaml
+++ b/helm/bamf/templates/tlsroute-bridges.yaml
@@ -12,6 +12,7 @@
 # The "bridge." subdomain separates bridge SNI from web app hostnames
 # (which live directly under *.{tunnelDomain}).
 
+{{- $m2mEnabled := and $.Values.gateway.m2m.enabled $.Values.gateway.m2m.tunnelDomain -}}
 {{- range $i := until $maxReplicas }}
 ---
 apiVersion: gateway.networking.k8s.io/v1alpha2
@@ -32,5 +33,28 @@ spec:
     - backendRefs:
         - name: {{ $fullName }}-bridge-{{ $i }}
           port: {{ $tunnelPort }}
+{{- if $m2mEnabled }}
+---
+# Internal (M2M) TLSRoute to the SAME bridge pod on the internal tunnel domain.
+apiVersion: gateway.networking.k8s.io/v1alpha2
+kind: TLSRoute
+metadata:
+  name: {{ $fullName }}-bridge-m2m-{{ $i }}
+  labels:
+    {{- $labels | nindent 4 }}
+    app.kubernetes.io/component: bridge
+    bamf.io/bridge-ordinal: "{{ $i }}"
+    bamf.io/binding: m2m
+spec:
+  parentRefs:
+    - name: {{ $fullName }}
+      sectionName: tunnel-m2m
+  hostnames:
+    - {{ include "bamf.bridge.m2mSniHostname" (dict "root" $ "ordinal" $i) | quote }}
+  rules:
+    - backendRefs:
+        - name: {{ $fullName }}-bridge-{{ $i }}
+          port: {{ $tunnelPort }}
+{{- end }}
 {{- end }}
 {{- end }}

--- a/helm/bamf/values.schema.json
+++ b/helm/bamf/values.schema.json
@@ -580,6 +580,7 @@
         "joinTokenKey": { "type": "string" },
         "platformUrl": { "type": "string" },
         "clusterInternal": { "type": "boolean" },
+        "zone": { "type": "string", "enum": ["", "in-cluster", "internal", "public"] },
         "kubernetes": {
           "type": "object",
           "additionalProperties": false,
@@ -637,6 +638,39 @@
           "additionalProperties": false,
           "properties": {
             "entryPoint": { "type": "string" }
+          }
+        },
+        "m2m": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "Optional internal (machine-to-machine) ingress for agents/edges + bridge tunnels.",
+          "properties": {
+            "enabled": { "type": "boolean" },
+            "hostname": { "type": "string" },
+            "tunnelDomain": { "type": "string" },
+            "className": { "type": "string" },
+            "annotations": { "type": "object" },
+            "traefik": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "entryPoint": { "type": "string" }
+              }
+            },
+            "tls": {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "existingSecret": { "type": "string" },
+                "certManager": {
+                  "type": "object",
+                  "additionalProperties": false,
+                  "properties": {
+                    "enabled": { "type": "boolean" }
+                  }
+                }
+              }
+            }
           }
         },
         "rateLimit": {

--- a/helm/bamf/values.yaml
+++ b/helm/bamf/values.yaml
@@ -535,6 +535,13 @@ agent:
   # deployed within the same Kubernetes cluster as the platform.
   clusterInternal: false
 
+  # Network zone for split-horizon bridge routing (#167): "in-cluster",
+  # "internal", or "public". "internal" makes the API hand this agent bridge
+  # hostnames on the gateway.m2m tunnel domain (for edges on a private/TGW
+  # network). Empty falls back to clusterInternal (true → in-cluster) then
+  # "public", so existing deployments are unchanged.
+  zone: ""
+
   # Kubernetes impersonation — enable when agent provides K8s cluster access
   kubernetes:
     impersonation:
@@ -594,6 +601,39 @@ gateway:
     https: 443
   traefik:
     entryPoint: websecure  # Traefik entrypoint name for HTTPS
+
+  # ── Split-horizon M2M ingress (optional) ────────────────────────────────────
+  # A SECOND, internal ingress for machine-to-machine traffic (agents/edges and
+  # bridges reaching the API + the bridge tunnels), separate from the public
+  # `hostname`/`tunnelDomain` above that humans and the CLI use. Enable this when
+  # there is an internal network (e.g. a transit-gateway/VPC fabric) whose edges
+  # must reach BAMF over a private name rather than the public ingress.
+  #
+  # Disabled by default: edges then use the public `hostname` or the in-cluster
+  # Service DNS (see the agent's `zone`), exactly as today — nothing changes.
+  #
+  # The API HTTPS on this binding MUST present a cert from a trusted issuer (the
+  # public cert is commonly duplicated here via `tls.existingSecret`) — an edge
+  # validates it to bootstrap trust *before* it has the BAMF CA, so an
+  # internal-CA cert would break the chain. The bridge tunnel routes stay
+  # SNI-passthrough (the bridge presents its BAMF-CA cert), so the traceable-cert
+  # requirement applies only to the API/HTTP route on this binding.
+  m2m:
+    enabled: false
+    hostname: ""        # Internal API hostname, e.g. bamf.internal
+    tunnelDomain: ""    # Internal tunnel base domain, e.g. tunnel.bamf.internal
+    className: ""       # Istio gatewayClassName override (defaults to gateway.className)
+    annotations: {}
+    traefik:
+      entryPoint: ""    # Traefik entrypoint for the internal binding (defaults to gateway.traefik.entryPoint)
+    tls:
+      # Traceable cert for the internal API HTTPS. Point this at an existing
+      # secret (often the same public cert duplicated onto the internal LB).
+      existingSecret: ""
+      # Or let cert-manager issue for the internal hostname (needs resolvable DNS
+      # + a reachable ACME/issuer). Uses tls.certManager.issuerRef unless overridden.
+      certManager:
+        enabled: false
 
   # HTTP rate limiting — applied at the ingress layer (Traefik Middleware or
   # Istio EnvoyFilter). Protects API, web UI, and web app proxy routes from

--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -301,7 +301,7 @@ func (a *Agent) loadCertificates(ctx context.Context) error {
 // sendHeartbeat sends a single heartbeat with current resources, labels, and
 // active tunnel count (for self-correcting Redis tunnel counts on drift).
 func (a *Agent) sendHeartbeat(ctx context.Context) error {
-	return a.apiClient.Heartbeat(ctx, a.agentID, a.cfg.Resources, a.cfg.Labels, a.cfg.ClusterInternal, a.instanceID, a.ActiveTunnelCount())
+	return a.apiClient.Heartbeat(ctx, a.agentID, a.cfg.Resources, a.cfg.Labels, a.cfg.ClusterInternal, a.cfg.Zone, a.instanceID, a.ActiveTunnelCount())
 }
 
 // checkAndRenewCertificate checks if the certificate is past its halfway point and renews it.

--- a/pkg/agent/api_client.go
+++ b/pkg/agent/api_client.go
@@ -83,6 +83,7 @@ type heartbeatRequest struct {
 	Resources       []heartbeatResource `json:"resources"`
 	Labels          map[string]string   `json:"labels"`
 	ClusterInternal bool                `json:"cluster_internal"`
+	Zone            string              `json:"zone,omitempty"`
 	InstanceID      string              `json:"instance_id,omitempty"`
 	ActiveTunnels   int                 `json:"active_tunnels"`
 }
@@ -91,7 +92,7 @@ type heartbeatRequest struct {
 // resources, labels, cluster_internal flag, instance identifier, and
 // active tunnel count (for self-correcting Redis tunnel counts).
 // Calls: POST /api/v1/agents/{id}/heartbeat
-func (c *APIClient) Heartbeat(ctx context.Context, agentID string, resources []ResourceConfig, labels map[string]string, clusterInternal bool, instanceID string, activeTunnels int) error {
+func (c *APIClient) Heartbeat(ctx context.Context, agentID string, resources []ResourceConfig, labels map[string]string, clusterInternal bool, zone string, instanceID string, activeTunnels int) error {
 	hbResources := make([]heartbeatResource, len(resources))
 	for i, r := range resources {
 		hbResources[i] = heartbeatResource{
@@ -111,6 +112,7 @@ func (c *APIClient) Heartbeat(ctx context.Context, agentID string, resources []R
 		Resources:       hbResources,
 		Labels:          labels,
 		ClusterInternal: clusterInternal,
+		Zone:            zone,
 		InstanceID:      instanceID,
 		ActiveTunnels:   activeTunnels,
 	}

--- a/pkg/agent/api_client_test.go
+++ b/pkg/agent/api_client_test.go
@@ -90,7 +90,7 @@ func TestAPIClient_Heartbeat(t *testing.T) {
 			Labels:       map[string]string{"env": "prod"},
 		},
 	}
-	err := c.Heartbeat(context.Background(), "agent-123", resources, map[string]string{"env": "prod"}, true, "inst-1", 3)
+	err := c.Heartbeat(context.Background(), "agent-123", resources, map[string]string{"env": "prod"}, true, "internal", "inst-1", 3)
 	require.NoError(t, err)
 }
 
@@ -188,6 +188,6 @@ func TestAPIClient_Heartbeat_WithWebhooks(t *testing.T) {
 			},
 		},
 	}
-	err := c.Heartbeat(context.Background(), "agent-1", resources, nil, false, "inst-1", 0)
+	err := c.Heartbeat(context.Background(), "agent-1", resources, nil, false, "", "inst-1", 0)
 	require.NoError(t, err)
 }

--- a/pkg/agent/config.go
+++ b/pkg/agent/config.go
@@ -40,6 +40,12 @@ type Config struct {
 	// hostnames for bridge connections instead of external DNS names.
 	ClusterInternal bool
 
+	// Zone is this agent's network vantage for split-horizon bridge routing
+	// (#167): "in-cluster" | "internal" | "public". Empty lets the API fall
+	// back to ClusterInternal (true → in-cluster) then "public". "internal"
+	// selects the gateway.m2m tunnel domain.
+	Zone string
+
 	// Connection settings
 	HeartbeatInterval    time.Duration
 	ReconnectBaseDelay   time.Duration
@@ -85,6 +91,7 @@ type yamlConfig struct {
 	AgentName       string            `yaml:"agent_name"`
 	DataDir         string            `yaml:"data_dir"`
 	ClusterInternal *bool             `yaml:"cluster_internal"`
+	Zone            string            `yaml:"zone"`
 	Labels          map[string]string `yaml:"labels"`
 	// Resources is parsed manually in loadYAML to support both list and map formats.
 	Resources yaml.Node `yaml:"resources"`
@@ -227,6 +234,10 @@ func (cfg *Config) loadYAML() error {
 		cfg.ClusterInternal = *yc.ClusterInternal
 	}
 
+	if yc.Zone != "" {
+		cfg.Zone = yc.Zone
+	}
+
 	// Merge labels (YAML labels are base; env vars can override later)
 	for k, v := range yc.Labels {
 		cfg.Labels[k] = v
@@ -356,6 +367,10 @@ func (cfg *Config) applyEnvOverrides() {
 
 	if v := os.Getenv("BAMF_CLUSTER_INTERNAL"); v != "" {
 		cfg.ClusterInternal = v == "true" || v == "1"
+	}
+
+	if v := os.Getenv("BAMF_ZONE"); v != "" {
+		cfg.Zone = v
 	}
 
 	// Merge env labels into existing labels (env overrides YAML per-key)

--- a/pkg/agent/config_extra_test.go
+++ b/pkg/agent/config_extra_test.go
@@ -300,6 +300,43 @@ func TestFindYAMLFile_NoEnvVar(t *testing.T) {
 	_ = result
 }
 
+// ── Tests: LoadConfig with zone (split-horizon, #167) ────────────────
+
+func TestLoadConfig_Zone_YAML(t *testing.T) {
+	clearEnvs(t,
+		"BAMF_CONFIG_FILE", "BAMF_PLATFORM_URL", "BAMF_API_URL",
+		"BAMF_JOIN_TOKEN", "BAMF_AGENT_NAME", "BAMF_DATA_DIR",
+		"BAMF_LABELS", "BAMF_RESOURCES", "BAMF_CLUSTER_INTERNAL", "BAMF_ZONE",
+	)
+
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "agent.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte("agent_name: edge\nzone: internal\n"), 0644))
+	setEnv(t, "BAMF_CONFIG_FILE", configFile)
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Equal(t, "internal", cfg.Zone)
+}
+
+func TestLoadConfig_Zone_EnvOverride(t *testing.T) {
+	clearEnvs(t,
+		"BAMF_CONFIG_FILE", "BAMF_PLATFORM_URL", "BAMF_API_URL",
+		"BAMF_JOIN_TOKEN", "BAMF_AGENT_NAME", "BAMF_DATA_DIR",
+		"BAMF_LABELS", "BAMF_RESOURCES", "BAMF_CLUSTER_INTERNAL", "BAMF_ZONE",
+	)
+
+	dir := t.TempDir()
+	configFile := filepath.Join(dir, "agent.yaml")
+	require.NoError(t, os.WriteFile(configFile, []byte("agent_name: edge\nzone: public\n"), 0644))
+	setEnv(t, "BAMF_CONFIG_FILE", configFile)
+	setEnv(t, "BAMF_ZONE", "internal")
+
+	cfg, err := LoadConfig()
+	require.NoError(t, err)
+	require.Equal(t, "internal", cfg.Zone)
+}
+
 // ── Tests: LoadConfig with cluster_internal ──────────────────────────
 
 func TestLoadConfig_ClusterInternal_YAML(t *testing.T) {

--- a/services/bamf/api/bridge_relay.py
+++ b/services/bamf/api/bridge_relay.py
@@ -19,6 +19,7 @@ from bamf.api.agent_commands import enqueue_agent_command
 from bamf.auth.ca import get_ca
 from bamf.config import settings
 from bamf.logging_config import get_logger
+from bamf.services.bridge_routing import resolve_agent_bridge_endpoint
 
 logger = get_logger(__name__)
 
@@ -89,16 +90,11 @@ async def send_relay_connect(r, agent_id: str, bridge_id: str) -> None:
         logger.warning("No live agent instances for relay_connect", agent_id=agent_id)
         return
 
-    agent_cluster_internal = await r.get(f"agent:{agent_id}:cluster_internal")
     bridge_info = await r.hgetall(f"bridge:{bridge_id}")
     bridge_hostname = bridge_info.get("hostname", bridge_id)
-
-    if agent_cluster_internal:
-        bridge_host = f"{bridge_id}.{settings.namespace}.svc.cluster.local"
-        bridge_port = settings.bridge_internal_tunnel_port
-    else:
-        bridge_host = bridge_hostname
-        bridge_port = settings.bridge_tunnel_port
+    bridge_host, bridge_port = await resolve_agent_bridge_endpoint(
+        r, agent_id, bridge_id, bridge_hostname
+    )
 
     # Include CA cert so the agent can verify the bridge's certificate.
     # The agent may have joined with a previous CA — always send the current one.

--- a/services/bamf/api/routers/agents.py
+++ b/services/bamf/api/routers/agents.py
@@ -59,6 +59,7 @@ from bamf.db.session import get_db, get_db_read
 from bamf.logging_config import get_logger
 from bamf.redis.client import get_redis
 from bamf.services.audit_service import log_audit_event
+from bamf.services.bridge_routing import VALID_ZONES
 from bamf.services.resource_catalog import (
     ResourceInfo,
     get_agent_labels,
@@ -162,6 +163,10 @@ class AgentHeartbeatRequest(BAMFBaseModel):
     resources: list[HeartbeatResource] = Field(default_factory=list)
     labels: dict[str, str] = Field(default_factory=dict)
     cluster_internal: bool = False
+    # Network vantage for split-horizon bridge routing (#167): one of
+    # "in-cluster" | "internal" | "public". Empty falls back to cluster_internal
+    # (true → in-cluster) then "public", so older agents keep working.
+    zone: str | None = None
     instance_id: str | None = None
     active_tunnels: int = 0
 
@@ -388,6 +393,12 @@ async def agent_heartbeat(
         else:
             await r.delete(f"agent:{agent_id_str}:cluster_internal")
 
+        # Store the network zone for split-horizon bridge routing (#167).
+        if body.zone and body.zone in VALID_ZONES:
+            await r.setex(f"agent:{agent_id_str}:zone", AGENT_TTL_SECONDS, body.zone)
+        else:
+            await r.delete(f"agent:{agent_id_str}:zone")
+
     return SuccessResponse(message="OK")
 
 
@@ -609,6 +620,7 @@ async def delete_agent(
         f"agent:{agent_id_str}:instances",
         f"agent:{agent_id_str}:name",
         f"agent:{agent_id_str}:cluster_internal",
+        f"agent:{agent_id_str}:zone",
         f"agent:{agent_id_str}:relay_bridge",
     ]
     for key in keys_to_delete:

--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -61,6 +61,7 @@ from bamf.logging_config import get_logger
 from bamf.redis.client import get_redis
 from bamf.redis_keys import tunnel_session_creds_key, tunnel_session_key
 from bamf.services.audit_service import log_audit_event
+from bamf.services.bridge_routing import resolve_agent_bridge_endpoint
 from bamf.services.rbac_service import check_access
 from bamf.services.resource_catalog import get_resource
 
@@ -520,13 +521,9 @@ async def _issue_session(
         ),
     )
 
-    agent_cluster_internal = await r.get(f"agent:{agent_id}:cluster_internal")
-    if agent_cluster_internal:
-        agent_bridge_host = f"{bridge_id}.{settings.namespace}.svc.cluster.local"
-        agent_bridge_port = settings.bridge_internal_tunnel_port
-    else:
-        agent_bridge_host = bridge_hostname
-        agent_bridge_port = bridge_port
+    agent_bridge_host, agent_bridge_port = await resolve_agent_bridge_endpoint(
+        r, agent_id, bridge_id, bridge_hostname
+    )
 
     # Enqueue the command on the selected instance's reliable delivery queue so
     # it survives a brief agent SSE reconnect (see agent_commands).

--- a/services/bamf/config.py
+++ b/services/bamf/config.py
@@ -285,6 +285,14 @@ class Settings(BaseSettings):
         description="Base domain for tunnel hostnames (e.g., 'tunnel.bamf.local').",
     )
 
+    # Optional internal (M2M) tunnel domain for the split-horizon ingress (#167).
+    # When set, agents/edges whose zone is "internal" are handed bridge SNI
+    # hostnames on this domain instead of the public tunnel_domain.
+    m2m_tunnel_domain: str = Field(
+        default="",
+        description="Internal tunnel base domain for the M2M ingress (empty = no split horizon).",
+    )
+
     # Bridge headless service name — used to construct internal FQDNs for
     # relay communication (pod-name.headless-svc.namespace.svc.cluster.local).
     bridge_headless_service: str = Field(

--- a/services/bamf/services/bridge_routing.py
+++ b/services/bamf/services/bridge_routing.py
@@ -1,0 +1,71 @@
+"""Resolve which bridge endpoint an agent should dial, per its network zone.
+
+Split-horizon / multi-vantage routing (#167). The hub (API) and the bridge are
+reachable from up to three vantages, and an agent/edge is handed the bridge dial
+host that matches the one it lives in:
+
+- ``in-cluster`` — K8s Service DNS (co-located edges).
+- ``internal``   — the internal-ingress SNI hostname (the ``gateway.m2m``
+  binding's tunnel domain), for edges on a private/TGW network.
+- ``public``     — the bridge's registered public SNI hostname (external edges;
+  also the CLI/human path).
+
+The zone comes from ``agent:{id}:zone`` in Redis (reported by the agent). For
+back-compat, the older ``agent:{id}:cluster_internal`` boolean maps to
+``in-cluster``; absence of both means ``public`` (today's default).
+"""
+
+from __future__ import annotations
+
+from bamf.config import settings
+
+ZONE_IN_CLUSTER = "in-cluster"
+ZONE_INTERNAL = "internal"
+ZONE_PUBLIC = "public"
+VALID_ZONES = frozenset({ZONE_IN_CLUSTER, ZONE_INTERNAL, ZONE_PUBLIC})
+
+
+async def resolve_agent_zone(r, agent_id: str) -> str:
+    """Return the agent's network zone (in-cluster | internal | public)."""
+    zone = await r.get(f"agent:{agent_id}:zone")
+    if zone in VALID_ZONES:
+        return zone
+    # Back-compat: the boolean cluster_internal flag predates zones.
+    if await r.get(f"agent:{agent_id}:cluster_internal"):
+        return ZONE_IN_CLUSTER
+    return ZONE_PUBLIC
+
+
+def internal_bridge_host(public_hostname: str) -> str:
+    """Map a bridge's public SNI hostname to its internal-ingress equivalent.
+
+    The two hostnames share the same ``{ordinal}.bridge[.{outpost}]`` prefix and
+    differ only in the trailing tunnel domain, so we swap the public
+    ``tunnel_domain`` suffix for the ``m2m_tunnel_domain``. If no m2m domain is
+    configured (or the hostname doesn't carry the public domain), fall back to
+    the public hostname — never invent an unreachable name.
+    """
+    public_td = settings.tunnel_domain
+    m2m_td = settings.m2m_tunnel_domain
+    if m2m_td and public_td and public_hostname.endswith(public_td):
+        return public_hostname[: -len(public_td)] + m2m_td
+    return public_hostname
+
+
+async def resolve_agent_bridge_endpoint(
+    r, agent_id: str, bridge_id: str, public_hostname: str
+) -> tuple[str, int]:
+    """Resolve the (host, port) the agent should dial for this bridge.
+
+    ``public_hostname`` is the bridge's registered public SNI hostname
+    (``bridge:{id}`` → ``hostname``).
+    """
+    zone = await resolve_agent_zone(r, agent_id)
+    if zone == ZONE_IN_CLUSTER:
+        return (
+            f"{bridge_id}.{settings.namespace}.svc.cluster.local",
+            settings.bridge_internal_tunnel_port,
+        )
+    if zone == ZONE_INTERNAL:
+        return internal_bridge_host(public_hostname), settings.bridge_tunnel_port
+    return public_hostname, settings.bridge_tunnel_port

--- a/services/tests/test_services/test_bridge_routing.py
+++ b/services/tests/test_services/test_bridge_routing.py
@@ -1,0 +1,95 @@
+"""Tests for split-horizon bridge-host resolution (#167)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from bamf.services import bridge_routing
+
+PUBLIC = "0.bridge.default.tunnel.bamf.example.com"
+
+
+class FakeRedis:
+    def __init__(self, data: dict | None = None):
+        self._d = data or {}
+
+    async def get(self, key: str):
+        return self._d.get(key)
+
+
+def _settings(monkeypatch, *, m2m="tunnel.bamf.internal"):
+    monkeypatch.setattr(
+        bridge_routing,
+        "settings",
+        SimpleNamespace(
+            tunnel_domain="tunnel.bamf.example.com",
+            m2m_tunnel_domain=m2m,
+            namespace="bamf",
+            bridge_tunnel_port=443,
+            bridge_internal_tunnel_port=8443,
+        ),
+    )
+
+
+@pytest.fixture
+def domains(monkeypatch):
+    _settings(monkeypatch)
+
+
+@pytest.mark.asyncio
+async def test_zone_in_cluster_uses_service_dns(domains):
+    r = FakeRedis({"agent:a:zone": "in-cluster"})
+    host, port = await bridge_routing.resolve_agent_bridge_endpoint(r, "a", "bamf-bridge-0", PUBLIC)
+    assert host == "bamf-bridge-0.bamf.svc.cluster.local"
+    assert port == 8443
+
+
+@pytest.mark.asyncio
+async def test_zone_internal_swaps_tunnel_domain(domains):
+    r = FakeRedis({"agent:a:zone": "internal"})
+    host, port = await bridge_routing.resolve_agent_bridge_endpoint(r, "a", "bamf-bridge-0", PUBLIC)
+    assert host == "0.bridge.default.tunnel.bamf.internal"
+    assert port == 443
+
+
+@pytest.mark.asyncio
+async def test_zone_public_uses_registered_hostname(domains):
+    r = FakeRedis({"agent:a:zone": "public"})
+    host, port = await bridge_routing.resolve_agent_bridge_endpoint(r, "a", "bamf-bridge-0", PUBLIC)
+    assert host == PUBLIC
+    assert port == 443
+
+
+@pytest.mark.asyncio
+async def test_backcompat_cluster_internal_maps_to_in_cluster(domains):
+    r = FakeRedis({"agent:a:cluster_internal": "1"})
+    host, _ = await bridge_routing.resolve_agent_bridge_endpoint(r, "a", "bamf-bridge-0", PUBLIC)
+    assert host == "bamf-bridge-0.bamf.svc.cluster.local"
+
+
+@pytest.mark.asyncio
+async def test_default_zone_is_public(domains):
+    r = FakeRedis({})
+    host, _ = await bridge_routing.resolve_agent_bridge_endpoint(r, "a", "bamf-bridge-0", PUBLIC)
+    assert host == PUBLIC
+
+
+@pytest.mark.asyncio
+async def test_internal_falls_back_to_public_when_no_m2m(monkeypatch):
+    _settings(monkeypatch, m2m="")  # not configured
+    r = FakeRedis({"agent:a:zone": "internal"})
+    host, _ = await bridge_routing.resolve_agent_bridge_endpoint(r, "a", "bamf-bridge-0", PUBLIC)
+    assert host == PUBLIC
+
+
+def test_internal_bridge_host_swaps_suffix(monkeypatch):
+    _settings(monkeypatch)
+    assert bridge_routing.internal_bridge_host(PUBLIC) == "0.bridge.default.tunnel.bamf.internal"
+
+
+def test_internal_bridge_host_fallback_on_mismatch(monkeypatch):
+    _settings(monkeypatch)
+    # Hostname doesn't carry the public tunnel domain → return unchanged.
+    assert bridge_routing.internal_bridge_host("weird.host") == "weird.host"


### PR DESCRIPTION
Closes #167. Designed with @-you in the issue thread (patterned on Terrapod's internal-ingress split, minus the webhook ingress BAMF doesn't need).

## What & why

Adds an **optional internal ingress** so machine-to-machine traffic (agents/edges + the bridge tunnels) can live on a separate internal network (e.g. a transit-gateway fabric) from the public human/CLI ingress. **Off by default** — everything uses the public binding, exactly as today.

The hub (API) and bridge are reachable from **three vantages**, and each requester is handed the bridge dial host for the one it lives in:

| Agent `zone` | Bridge dial host |
|---|---|
| `in-cluster` | K8s Service DNS (existing `clusterInternal`, kept) |
| `internal` | `*.bridge.{gateway.m2m.tunnelDomain}` (**new**) |
| `public` (default) | the registered public SNI hostname |

The CLI and browsers always use the public binding.

## Changes

- **Chart** — `gateway.m2m` optional binding (hostname, tunnelDomain, entryPoint/className, TLS), rendered for **both** Traefik (IngressRoute + IngressRouteTCP) and Istio (Gateway listeners + HTTPRoute + TLSRoutes). Its API HTTPS requires a **traceable** cert (an edge validates it to bootstrap trust *before* it has the BAMF CA — internal-CA would break the chain; the public cert is commonly duplicated via `existingSecret`); the bridge tunnel routes stay SNI-passthrough. `agent.zone` added (`clusterInternal` stays a back-compat alias). Schema + configmap wiring (`m2m_tunnel_domain` → API, `zone` → agent).
- **API** — `bridge_routing.py` resolves `(host, port)` per the agent's zone (Redis `agent:{id}:zone`, falling back to `cluster_internal` then public); wired into `connect.py` + `bridge_relay.py`, replacing the 2-way branch.
- **Agent (Go)** — `Zone` config field (`zone:` / `BAMF_ZONE`), reported in the heartbeat.

## Verification

- **Python** — full suite `1072 passed` incl. 8 new resolver tests (in-cluster / internal / public / back-compat / no-m2m fallback).
- **Go** — build, `gofmt`, `golangci-lint` (0 issues), agent zone-config + heartbeat tests.
- **Helm** — both providers render with `m2m` on (m2m listeners, API route, per-pod SNI routes, configmap `m2m_tunnel_domain`); `helm lint` passes the schema.
- **Docs** — split-horizon section in `deployment.md` + `helm-values.md`; `mkdocs build --strict` and content-hygiene clean.