### PR TITLE
feat(outpost): add `bamf outpost-tokens` + `bamf outposts` CLI

### DIFF
--- a/cmd/bamf/cmd/outposts.go
+++ b/cmd/bamf/cmd/outposts.go
@@ -1,0 +1,224 @@
+// CLI reference: docs/reference/cli.md (Outposts)
+package cmd
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"text/tabwriter"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// ── Outpost tokens ────────────────────────────────────────────────────────────
+
+type outpostToken struct {
+	ID          string    `json:"id"`
+	Name        string    `json:"name"`
+	OutpostName string    `json:"outpost_name"`
+	Region      *string   `json:"region"`
+	ExpiresAt   time.Time `json:"expires_at"`
+	MaxUses     *int      `json:"max_uses"`
+	UseCount    int       `json:"use_count"`
+	IsRevoked   bool      `json:"is_revoked"`
+	CreatedBy   string    `json:"created_by"`
+}
+
+type outpostTokenCreateResp struct {
+	outpostToken
+	Token string `json:"token"`
+}
+
+type outpostInfo struct {
+	ID        string    `json:"id"`
+	Name      string    `json:"name"`
+	Region    *string   `json:"region"`
+	IsActive  bool      `json:"is_active"`
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
+}
+
+var (
+	outpostTokenOutpost string
+	outpostTokenRegion  string
+	outpostTokenTTL     int
+	outpostTokenMaxUses int
+)
+
+var outpostTokensCmd = &cobra.Command{
+	Use:     "outpost-tokens",
+	Aliases: []string{"outpost-token"},
+	Short:   "Manage outpost join tokens (admin)",
+}
+
+var outpostTokensListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List outpost join tokens",
+	RunE:  runOutpostTokensList,
+}
+
+var outpostTokensCreateCmd = &cobra.Command{
+	Use:   "create <name>",
+	Short: "Create an outpost join token",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runOutpostTokensCreate,
+}
+
+var outpostTokensRevokeCmd = &cobra.Command{
+	Use:   "revoke <name>",
+	Short: "Revoke an outpost join token by name",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runOutpostTokensRevoke,
+}
+
+// ── Outposts ──────────────────────────────────────────────────────────────────
+
+var outpostsCmd = &cobra.Command{
+	Use:   "outposts",
+	Short: "Manage registered outposts (admin)",
+}
+
+var outpostsListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List registered outposts",
+	RunE:  runOutpostsList,
+}
+
+var outpostsDeleteCmd = &cobra.Command{
+	Use:   "delete <id>",
+	Short: "Deregister an outpost by ID",
+	Args:  cobra.ExactArgs(1),
+	RunE:  runOutpostsDelete,
+}
+
+func init() {
+	outpostTokensCreateCmd.Flags().StringVar(&outpostTokenOutpost, "outpost", "", "Outpost name this token registers (required)")
+	outpostTokensCreateCmd.Flags().StringVar(&outpostTokenRegion, "region", "", "Human-readable region label")
+	outpostTokensCreateCmd.Flags().IntVar(&outpostTokenTTL, "ttl", 24, "Hours until the token expires")
+	outpostTokensCreateCmd.Flags().IntVar(&outpostTokenMaxUses, "max-uses", 0, "Max uses (0 = unlimited)")
+	_ = outpostTokensCreateCmd.MarkFlagRequired("outpost")
+
+	outpostTokensCmd.AddCommand(outpostTokensListCmd, outpostTokensCreateCmd, outpostTokensRevokeCmd)
+	outpostsCmd.AddCommand(outpostsListCmd, outpostsDeleteCmd)
+	rootCmd.AddCommand(outpostTokensCmd, outpostsCmd)
+}
+
+func runOutpostTokensList(_ *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var page struct {
+		Items []outpostToken `json:"items"`
+	}
+	if err := adminAPIRequest(ctx, http.MethodGet, "/api/v1/outpost-tokens", nil, &page); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return printJSON(page.Items)
+	}
+	if len(page.Items) == 0 {
+		fmt.Println("No outpost tokens found.")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tOUTPOST\tSTATUS\tEXPIRES\tUSES\tCREATED BY")
+	for _, t := range page.Items {
+		status := "active"
+		if t.IsRevoked {
+			status = "revoked"
+		} else if time.Now().After(t.ExpiresAt) {
+			status = "expired"
+		}
+		uses := fmt.Sprintf("%d", t.UseCount)
+		if t.MaxUses != nil {
+			uses = fmt.Sprintf("%d/%d", t.UseCount, *t.MaxUses)
+		}
+		fmt.Fprintf(w, "%s\t%s\t%s\t%s\t%s\t%s\n",
+			t.Name, t.OutpostName, status, t.ExpiresAt.Format("2006-01-02 15:04"), uses, t.CreatedBy)
+	}
+	return w.Flush()
+}
+
+func runOutpostTokensCreate(_ *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	body := map[string]any{
+		"name":             args[0],
+		"outpost_name":     outpostTokenOutpost,
+		"expires_in_hours": outpostTokenTTL,
+	}
+	if outpostTokenRegion != "" {
+		body["region"] = outpostTokenRegion
+	}
+	if outpostTokenMaxUses > 0 {
+		body["max_uses"] = outpostTokenMaxUses
+	}
+
+	var created outpostTokenCreateResp
+	if err := adminAPIRequest(ctx, http.MethodPost, "/api/v1/outpost-tokens", body, &created, http.StatusCreated); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return printJSON(created)
+	}
+	fmt.Printf("Created outpost token %q for outpost %q.\n\n", created.Name, created.OutpostName)
+	fmt.Printf("  %s\n\n", created.Token)
+	fmt.Println("This token is shown only once — store it securely (e.g. the outpost's join Secret).")
+	return nil
+}
+
+func runOutpostTokensRevoke(_ *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/api/v1/outpost-tokens/%s/revoke", args[0])
+	if err := adminAPIRequest(ctx, http.MethodPost, path, nil, nil); err != nil {
+		return err
+	}
+	fmt.Printf("Revoked outpost token %q.\n", args[0])
+	return nil
+}
+
+func runOutpostsList(_ *cobra.Command, _ []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	var page struct {
+		Items []outpostInfo `json:"items"`
+	}
+	if err := adminAPIRequest(ctx, http.MethodGet, "/api/v1/outposts", nil, &page); err != nil {
+		return err
+	}
+	if jsonOutput {
+		return printJSON(page.Items)
+	}
+	if len(page.Items) == 0 {
+		fmt.Println("No outposts registered.")
+		return nil
+	}
+	w := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(w, "NAME\tREGION\tACTIVE\tID")
+	for _, o := range page.Items {
+		region := "-"
+		if o.Region != nil && *o.Region != "" {
+			region = *o.Region
+		}
+		fmt.Fprintf(w, "%s\t%s\t%t\t%s\n", o.Name, region, o.IsActive, o.ID)
+	}
+	return w.Flush()
+}
+
+func runOutpostsDelete(_ *cobra.Command, args []string) error {
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	path := fmt.Sprintf("/api/v1/outposts/%s", args[0])
+	if err := adminAPIRequest(ctx, http.MethodDelete, path, nil, nil); err != nil {
+		return err
+	}
+	fmt.Printf("Deregistered outpost %q.\n", args[0])
+	return nil
+}

--- a/cmd/bamf/cmd/outposts_test.go
+++ b/cmd/bamf/cmd/outposts_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+// writeOutpostTestCreds writes a credentials.json into a temp HOME and returns
+// nothing — callers set BAMF_API_URL to their test server.
+func writeOutpostTestCreds(t *testing.T) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	bamfPath := filepath.Join(home, ".bamf")
+	require.NoError(t, os.MkdirAll(bamfPath, 0700))
+	creds := tokenResponse{
+		SessionToken: "tok",
+		ExpiresAt:    time.Now().Add(time.Hour),
+		Email:        "admin@example.com",
+		APIURL:       "https://bamf.example.com",
+	}
+	data, _ := json.MarshalIndent(creds, "", "  ")
+	require.NoError(t, os.WriteFile(filepath.Join(bamfPath, "credentials.json"), data, 0600))
+}
+
+func captureStdout(t *testing.T, fn func() error) (string, error) {
+	t.Helper()
+	old := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+	err := fn()
+	_ = w.Close()
+	os.Stdout = old
+	out, _ := io.ReadAll(r)
+	return string(out), err
+}
+
+func TestRunOutpostTokensList_NoCredentials(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	err := runOutpostTokensList(outpostTokensListCmd, nil)
+	require.Error(t, err)
+}
+
+func TestRunOutpostTokensList_Success(t *testing.T) {
+	writeOutpostTestCreds(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/outpost-tokens", r.URL.Path)
+		require.Equal(t, "GET", r.Method)
+		require.Equal(t, "Bearer tok", r.Header.Get("Authorization"))
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []outpostToken{{
+				Name: "eu-token", OutpostName: "eu", UseCount: 1,
+				ExpiresAt: time.Now().Add(24 * time.Hour), CreatedBy: "admin@example.com",
+			}},
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("BAMF_API_URL", srv.URL)
+
+	out, err := captureStdout(t, func() error { return runOutpostTokensList(outpostTokensListCmd, nil) })
+	require.NoError(t, err)
+	require.Contains(t, out, "eu-token")
+	require.Contains(t, out, "eu")
+}
+
+func TestRunOutpostTokensCreate_Success(t *testing.T) {
+	writeOutpostTestCreds(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/outpost-tokens", r.URL.Path)
+		require.Equal(t, "POST", r.Method)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "eu-token", body["name"])
+		require.Equal(t, "eu", body["outpost_name"])
+		w.WriteHeader(http.StatusCreated)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"name": "eu-token", "outpost_name": "eu", "token": "bamf_out_secret",
+			"expires_at": time.Now().Add(24 * time.Hour), "use_count": 0,
+			"created_by": "admin@example.com",
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("BAMF_API_URL", srv.URL)
+
+	outpostTokenOutpost = "eu"
+	defer func() { outpostTokenOutpost = "" }()
+
+	out, err := captureStdout(t, func() error { return runOutpostTokensCreate(outpostTokensCreateCmd, []string{"eu-token"}) })
+	require.NoError(t, err)
+	require.Contains(t, out, "bamf_out_secret")
+	require.True(t, strings.Contains(out, "only once"))
+}
+
+func TestRunOutpostsList_Success(t *testing.T) {
+	writeOutpostTestCreds(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/outposts", r.URL.Path)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"items": []outpostInfo{{ID: "out-1", Name: "eu", IsActive: true}},
+		})
+	}))
+	defer srv.Close()
+	t.Setenv("BAMF_API_URL", srv.URL)
+
+	out, err := captureStdout(t, func() error { return runOutpostsList(outpostsListCmd, nil) })
+	require.NoError(t, err)
+	require.Contains(t, out, "eu")
+	require.Contains(t, out, "out-1")
+}

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -235,6 +235,59 @@ Revoke a join token.
 bamf tokens revoke <token-name>
 ```
 
+## Outpost Management
+
+Manage the tokens and lifecycle for [remote outpost](../admin/deployment.md)
+deployments (admin only). Mirrors the agent-token surface above.
+
+### bamf outpost-tokens list
+
+List outpost join tokens.
+
+```
+bamf outpost-tokens list
+```
+
+### bamf outpost-tokens create
+
+Mint a join token for an outpost. The secret value is printed **once** — store
+it in the outpost's join Secret.
+
+```
+bamf outpost-tokens create <name> --outpost <outpost-name> [flags]
+```
+
+| Flag | Description |
+|------|-------------|
+| `--outpost` | Outpost name this token registers (required) |
+| `--region` | Human-readable region label |
+| `--ttl` | Hours until the token expires (default: `24`) |
+| `--max-uses` | Max uses (`0` = unlimited) |
+
+### bamf outpost-tokens revoke
+
+Revoke an outpost join token by name.
+
+```
+bamf outpost-tokens revoke <name>
+```
+
+### bamf outposts list
+
+List registered outposts.
+
+```
+bamf outposts list
+```
+
+### bamf outposts delete
+
+Deregister an outpost by ID.
+
+```
+bamf outposts delete <id>
+```
+
 ## User Management
 
 Manage locally-managed users (admin only). SSO users are not stored locally and


### PR DESCRIPTION
Closes #195.

The outpost management API (`outpost_tokens.py`, `outposts.py`) was fully built but had **no shipped client** — an outpost join token could only be minted via raw `curl`, so the documented remote-outpost topology couldn't be operated end-to-end. This adds the operator CLI, mirroring the agent-token surface (`bamf tokens`):

- **`bamf outpost-tokens`** — `list`, `create <name> --outpost <name> [--region --ttl --max-uses]` (secret printed once), `revoke <name>`
- **`bamf outposts`** — `list`, `delete <id>`

Built on the shared `adminAPIRequest` helper (session-token Bearer auth, FastAPI `{"detail"}` error extraction), with a `CLI reference:` cross-ref comment. Tests (`outposts_test.go`) cover list/create/no-credentials against a fake server; `docs/reference/cli.md` gains an Outpost Management section. Verified: `go build`, `go test -race` (Outpost tests pass), `gofmt`, `golangci-lint` (0 issues), `mkdocs --strict`.