### PR TITLE
fix(security): bump Go 1.26.4 → 1.26.5 for GO-2026-5856 (crypto/tls)

### DIFF
--- a/docker/Dockerfile.agent
+++ b/docker/Dockerfile.agent
@@ -1,7 +1,7 @@
 # BAMF Agent Dockerfile
 # Builds the Go agent binary
 
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 # Install git for go mod download
 RUN apk add --no-cache git

--- a/docker/Dockerfile.bridge
+++ b/docker/Dockerfile.bridge
@@ -1,7 +1,7 @@
 # BAMF Bridge Server Dockerfile
 # Builds the Go bridge binary (tunnel gateway)
 
-FROM golang:1.26.4-alpine AS builder
+FROM golang:1.26.5-alpine AS builder
 
 # Install git for go mod download
 RUN apk add --no-cache git

--- a/docker/Dockerfile.ci
+++ b/docker/Dockerfile.ci
@@ -2,7 +2,7 @@
 # Used for lint, test, and cross-compilation inside Docker.
 # Build: docker build -f docker/Dockerfile.ci -t bamf-ci:local .
 
-FROM golang:1.26.4-alpine
+FROM golang:1.26.5-alpine
 
 RUN apk add --no-cache git bash build-base
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/mattrobinsonsre/bamf
 
-go 1.26.4
+go 1.26.5
 
 require (
 	github.com/prometheus/client_golang v1.23.2


### PR DESCRIPTION
Fixes the red `main` after #239/#240 merged.

`govulncheck` flags **[GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856)** — an Encrypted Client Hello privacy leak in the standard-library `crypto/tls`, reached through the bridge/agent/tunnel TLS paths. It's not from the merged code: the advisory was published *after* those PRs went green, so it only surfaced on the post-merge `main` run (`Go Security (govulncheck)`). Fixed in **go1.26.5**.

Bumps the `go` directive and all three `golang:-alpine` base images (ci, bridge, agent). Verified: CI image rebuilt on `golang:1.26.5-alpine`, `govulncheck ./...` → **No vulnerabilities found**.