### PR TITLE
feat(agent): hold one relay per edge, not a single shared relay

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -40,8 +40,11 @@ type Agent struct {
 	tunnels   map[string]*TunnelHandler
 	tunnelsMu sync.RWMutex
 
-	// HTTP relay
-	relay *RelayManager
+	// HTTP relays — one per edge (keyed by edge name; "" for the default/no-edge
+	// case). The agent maintains a relay to a bridge in every edge it's assigned
+	// so any edge can serve its resources (#194).
+	relays   map[string]*RelayManager
+	relaysMu sync.Mutex
 
 	// Metrics
 	sseConnected atomic.Bool // true when SSE connection is active
@@ -69,6 +72,7 @@ func New(cfg *Config, logger *slog.Logger) (*Agent, error) {
 		logger:     logger,
 		instanceID: generateInstanceID(),
 		tunnels:    make(map[string]*TunnelHandler),
+		relays:     make(map[string]*RelayManager),
 		shutdownCh: make(chan struct{}),
 	}
 
@@ -166,10 +170,12 @@ func (a *Agent) Shutdown(ctx context.Context) error {
 		_ = a.apiClient.DrainInstance(ctx, a.agentID, a.instanceID)
 	}
 
-	// Close relay connection (new relay requests will go to another instance)
-	if a.relay != nil {
-		a.relay.Close()
+	// Close all edge relay connections (new relay requests go to another instance)
+	a.relaysMu.Lock()
+	for _, rl := range a.relays {
+		rl.Close()
 	}
+	a.relaysMu.Unlock()
 
 	// Wait for active tunnels to finish naturally
 	a.waitForTunnels(ctx)
@@ -231,7 +237,14 @@ func (a *Agent) ActiveTunnelCount() int {
 
 // HasActiveRelay returns whether this instance has an active relay connection.
 func (a *Agent) HasActiveRelay() bool {
-	return a.relay != nil && a.relay.IsConnected()
+	a.relaysMu.Lock()
+	defer a.relaysMu.Unlock()
+	for _, rl := range a.relays {
+		if rl.IsConnected() {
+			return true
+		}
+	}
+	return false
 }
 
 func (a *Agent) hasCertificates(ctx context.Context) bool {
@@ -479,24 +492,33 @@ func (a *Agent) handleRelayConnect(data map[string]interface{}) {
 		}
 	}
 
-	// Create or reuse relay manager
-	if a.relay == nil {
-		a.relay = NewRelayManager(a.agentID, a.cfg.Resources, tlsCfg, a.logger)
-	} else {
-		a.relay.UpdateResources(a.cfg.Resources)
-		a.relay.UpdateTLSConfig(tlsCfg)
-	}
+	// Which edge this relay is for. "" = the default/no-edge case; each edge
+	// gets its own RelayManager so any edge can serve this agent (#194).
+	edge, _ := data["edge"].(string)
 
-	// Skip if a relay connection is already active. This prevents a race
-	// where auto-reconnect (after SSE detach) and an API relay_connect
-	// command both try to establish a connection simultaneously.
-	if a.relay.IsConnected() {
-		a.logger.Info("relay already connected, skipping relay_connect")
+	// Create or reuse the relay manager for THIS edge.
+	a.relaysMu.Lock()
+	relay := a.relays[edge]
+	if relay == nil {
+		relay = NewRelayManager(a.agentID, a.cfg.Resources, tlsCfg, a.logger)
+		a.relays[edge] = relay
+	} else {
+		relay.UpdateResources(a.cfg.Resources)
+		relay.UpdateTLSConfig(tlsCfg)
+	}
+	connected := relay.IsConnected()
+	a.relaysMu.Unlock()
+
+	// Skip if THIS edge's relay is already active — prevents a race where
+	// auto-reconnect (after SSE detach) and an API relay_connect both try to
+	// connect. A relay_connect for a *different* edge still gets its own relay.
+	if connected {
+		a.logger.Info("relay already connected for edge, skipping relay_connect", "edge", edge)
 		return
 	}
 
-	if err := a.relay.Connect(bridgeHost, int(bridgePort)); err != nil {
-		a.logger.Error("relay connection failed", "error", err)
+	if err := relay.Connect(bridgeHost, int(bridgePort)); err != nil {
+		a.logger.Error("relay connection failed", "edge", edge, "error", err)
 	}
 }
 

--- a/pkg/agent/agent_unit_test.go
+++ b/pkg/agent/agent_unit_test.go
@@ -317,11 +317,13 @@ func TestServeMetrics_Routes(t *testing.T) {
 func TestHasActiveRelay_RelayNotConnected(t *testing.T) {
 	// Relay exists but has no workers (not connected)
 	a := &Agent{
-		relay: &RelayManager{
-			agentID:   "test-agent",
-			resources: nil,
-			tlsConfig: &tls.Config{},
-			logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		relays: map[string]*RelayManager{
+			"": {
+				agentID:   "test-agent",
+				resources: nil,
+				tlsConfig: &tls.Config{},
+				logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+			},
 		},
 	}
 	require.False(t, a.HasActiveRelay())
@@ -538,7 +540,7 @@ func TestHandleMetrics_WithActiveRelay(t *testing.T) {
 	a := &Agent{
 		logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
 		tunnels: make(map[string]*TunnelHandler),
-		relay:   rm,
+		relays:  map[string]*RelayManager{"": rm},
 	}
 
 	rec := httptest.NewRecorder()
@@ -564,7 +566,7 @@ func TestHandleRelayConnect_MissingBridgeHost(t *testing.T) {
 		"bridge_port": float64(443),
 	}
 	a.handleRelayConnect(data)
-	require.Nil(t, a.relay, "relay should not be created with missing bridge_host")
+	require.Empty(t, a.relays, "no relay should be created with missing bridge_host")
 }
 
 func TestHandleRelayConnect_MissingBridgePort(t *testing.T) {
@@ -580,7 +582,7 @@ func TestHandleRelayConnect_MissingBridgePort(t *testing.T) {
 		"bridge_host": "bridge.local",
 	}
 	a.handleRelayConnect(data)
-	require.Nil(t, a.relay, "relay should not be created with missing bridge_port")
+	require.Empty(t, a.relays, "no relay should be created with missing bridge_port")
 }
 
 // ── Tests: Shutdown ──────────────────────────────────────────────────
@@ -676,4 +678,28 @@ func TestHandleRedial_ClosedTunnel(t *testing.T) {
 	// Redial for a closed tunnel should be a no-op
 	a.handleRedial("sess-1", "bridge.local", 443,
 		[]byte("cert"), []byte("key"), []byte("ca"))
+}
+
+// TestHandleRelayConnect_PerEdgeRelays is the core #194 guard: a relay_connect
+// for a second edge must create its OWN relay, not be skipped because a relay to
+// a different edge already exists. Connect fails fast against a refused port, but
+// the per-edge map entry is created regardless.
+func TestHandleRelayConnect_PerEdgeRelays(t *testing.T) {
+	a := &Agent{
+		logger:    slog.New(slog.NewTextHandler(io.Discard, nil)),
+		cfg:       &Config{},
+		tlsConfig: &tls.Config{},
+		relays:    make(map[string]*RelayManager),
+	}
+
+	a.handleRelayConnect(map[string]interface{}{
+		"bridge_host": "127.0.0.1", "bridge_port": float64(1), "edge": "eu",
+	})
+	a.handleRelayConnect(map[string]interface{}{
+		"bridge_host": "127.0.0.1", "bridge_port": float64(1), "edge": "us",
+	})
+
+	require.Len(t, a.relays, 2, "each edge gets its own relay")
+	require.NotNil(t, a.relays["eu"])
+	require.NotNil(t, a.relays["us"])
 }

--- a/services/bamf/api/bridge_relay.py
+++ b/services/bamf/api/bridge_relay.py
@@ -77,7 +77,9 @@ async def assign_relay_bridge(r, agent_id: str, edge_name: str | None = None) ->
     return bridge_id
 
 
-async def send_relay_connect(r, agent_id: str, bridge_id: str, edge_name: str | None = None) -> None:
+async def send_relay_connect(
+    r, agent_id: str, bridge_id: str, edge_name: str | None = None
+) -> None:
     """Send a relay_connect SSE event to a specific agent instance via Redis pub/sub.
 
     Selects the best instance (preferring one without an active relay) and

--- a/services/bamf/api/bridge_relay.py
+++ b/services/bamf/api/bridge_relay.py
@@ -77,7 +77,7 @@ async def assign_relay_bridge(r, agent_id: str, edge_name: str | None = None) ->
     return bridge_id
 
 
-async def send_relay_connect(r, agent_id: str, bridge_id: str) -> None:
+async def send_relay_connect(r, agent_id: str, bridge_id: str, edge_name: str | None = None) -> None:
     """Send a relay_connect SSE event to a specific agent instance via Redis pub/sub.
 
     Selects the best instance (preferring one without an active relay) and
@@ -110,6 +110,10 @@ async def send_relay_connect(r, agent_id: str, bridge_id: str) -> None:
             "bridge_host": bridge_host,
             "bridge_port": bridge_port,
             "ca_certificate": ca.ca_cert_pem,
+            # Which edge this relay is for — the agent keys its per-edge relay
+            # map on this so it holds one relay per edge (#194). Omitted (agent
+            # defaults to a single "" key) when no edge is in play.
+            **({"edge": edge_name} if edge_name else {}),
         },
     )
 
@@ -129,23 +133,26 @@ async def ensure_relay_connected(
     r,
     agent_id: str,
     relay_bridge: str,
+    edge_name: str | None = None,
 ) -> bool:
     """Ensure the agent has an active relay connection to the bridge.
 
     Uses a Redis lock to prevent duplicate relay_connect commands when
     many concurrent requests arrive for an unconnected agent (e.g. a
-    browser loading HTML + CSS + JS + favicon simultaneously).
+    browser loading HTML + CSS + JS + favicon simultaneously). The lock is
+    per-edge so concurrent requests to *different* edges each get their own
+    relay_connect (#194).
 
     Returns True if the relay is believed ready, False on timeout.
     """
-    lock_key = f"agent:{agent_id}:relay_connecting"
+    lock_key = f"agent:{agent_id}:relay_connecting:{edge_name or 'default'}"
 
     # Try to acquire the lock (NX = set-if-not-exists, EX = auto-expire)
     acquired = await r.set(lock_key, "1", nx=True, ex=RELAY_READY_TIMEOUT_SECONDS + 5)
 
     if acquired:
         # We won the race — send relay_connect and wait for it to establish.
-        await send_relay_connect(r, agent_id, relay_bridge)
+        await send_relay_connect(r, agent_id, relay_bridge, edge_name)
         await asyncio.sleep(RELAY_CONNECT_WAIT_SECONDS)
         # Clean up the lock so the next cold-start can send relay_connect.
         await r.delete(lock_key)

--- a/services/bamf/api/routers/internal_proxy.py
+++ b/services/bamf/api/routers/internal_proxy.py
@@ -482,14 +482,18 @@ async def _resolve_relay(r, resource, edge_name: str | None = None) -> RelayInfo
     # Resolve relay bridge — prefer edge-specific key, fall back to global
     relay_bridge = None
     if edge_name:
+        # For a specific edge, use ONLY that edge's relay — never fall back to
+        # another edge's bridge. That reuse was the single-relay bug: a request
+        # landing at a second edge would be handed the first edge's bridge,
+        # which has no path back to the agent from here (#194).
         relay_bridge = await r.get(f"agent:{agent_id}:relay:{edge_name}")
-    if relay_bridge is None:
+    else:
         relay_bridge = await r.get(f"agent:{agent_id}:relay_bridge")
     if relay_bridge is None:
         relay_bridge = await assign_relay_bridge(r, agent_id, edge_name)
         if relay_bridge is None:
             return None
-        ready = await ensure_relay_connected(r, agent_id, relay_bridge)
+        ready = await ensure_relay_connected(r, agent_id, relay_bridge, edge_name)
         if not ready:
             return None
 


### PR DESCRIPTION
Closes #194. Deliverable #1 (the foundation) of the edge flagship #119 — the all-edges relay *fabric* the data path needs, independent of how a client later *selects* an edge.

## Problem

The docs describe agents holding a persistent relay to a bridge in **every** edge ("any edge serves any resource"), but the agent held a **single** `relay *RelayManager` and skipped a second `relay_connect`. So a single-replica agent (the documented common case — "one agent per cluster") kept exactly one HTTP relay, to whichever edge first triggered it. A browser/kubectl HTTP-proxy request for that agent's resource landing at a **different** edge couldn't be served — the second `relay_connect` was skipped and the request stalled until timeout. (TCP tunnels were unaffected — those pick a bridge per-connection.)

## Fix

- **Agent** — `relays map[string]*RelayManager` keyed by edge (+ a mutex). `handleRelayConnect` parses `edge` and creates/reuses *that edge's* relay; the connected-skip is now **per-edge**, so a new edge always gets its own relay. Shutdown closes all; `HasActiveRelay` checks any.
- **API** — the `relay_connect` command carries `edge`; `ensure_relay_connected`'s dedup lock is per-edge; and the proxy no longer falls back to *another* edge's bridge for an edge-specific request (that reuse was the core bug).

## Verification

New `TestHandleRelayConnect_PerEdgeRelays` proves a second edge's `relay_connect` creates its own relay instead of being skipped. Full agent tests + `golangci-lint` (0 issues) + full Python suite (`1072 passed`).