### PR TITLE
feat(edge): harvest agent→edge relay RTT into Redis

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -311,10 +311,31 @@ func (a *Agent) loadCertificates(ctx context.Context) error {
 	return nil
 }
 
-// sendHeartbeat sends a single heartbeat with current resources, labels, and
-// active tunnel count (for self-correcting Redis tunnel counts on drift).
+// sendHeartbeat sends a single heartbeat with current resources, labels,
+// active tunnel count (for self-correcting Redis tunnel counts on drift), and
+// the measured agent→edge relay latencies (the agent-leg table, #246).
 func (a *Agent) sendHeartbeat(ctx context.Context) error {
-	return a.apiClient.Heartbeat(ctx, a.agentID, a.cfg.Resources, a.cfg.Labels, a.cfg.ClusterInternal, a.cfg.Zone, a.instanceID, a.ActiveTunnelCount())
+	return a.apiClient.Heartbeat(ctx, a.agentID, a.cfg.Resources, a.cfg.Labels, a.cfg.ClusterInternal, a.cfg.Zone, a.instanceID, a.ActiveTunnelCount(), a.edgeRTTs())
+}
+
+// edgeRTTs snapshots each edge relay's smoothed latency in milliseconds,
+// keyed by edge name. Only edges with at least one dial sample are included.
+func (a *Agent) edgeRTTs() map[string]int {
+	a.relaysMu.Lock()
+	defer a.relaysMu.Unlock()
+	if len(a.relays) == 0 {
+		return nil
+	}
+	rtts := make(map[string]int, len(a.relays))
+	for edge, rl := range a.relays {
+		if rtt, ok := rl.RTT(); ok {
+			rtts[edge] = int(rtt.Milliseconds())
+		}
+	}
+	if len(rtts) == 0 {
+		return nil
+	}
+	return rtts
 }
 
 // checkAndRenewCertificate checks if the certificate is past its halfway point and renews it.

--- a/pkg/agent/api_client.go
+++ b/pkg/agent/api_client.go
@@ -86,13 +86,17 @@ type heartbeatRequest struct {
 	Zone            string              `json:"zone,omitempty"`
 	InstanceID      string              `json:"instance_id,omitempty"`
 	ActiveTunnels   int                 `json:"active_tunnels"`
+	// Measured agent→edge relay latency in milliseconds, keyed by edge name
+	// (the agent-leg of measured-latency edge selection, #246). Empty when
+	// the agent holds no relays or has no samples yet.
+	EdgeRTTs map[string]int `json:"edge_rtts,omitempty"`
 }
 
 // Heartbeat sends a heartbeat to the API with the agent's current
 // resources, labels, cluster_internal flag, instance identifier, and
 // active tunnel count (for self-correcting Redis tunnel counts).
 // Calls: POST /api/v1/agents/{id}/heartbeat
-func (c *APIClient) Heartbeat(ctx context.Context, agentID string, resources []ResourceConfig, labels map[string]string, clusterInternal bool, zone string, instanceID string, activeTunnels int) error {
+func (c *APIClient) Heartbeat(ctx context.Context, agentID string, resources []ResourceConfig, labels map[string]string, clusterInternal bool, zone string, instanceID string, activeTunnels int, edgeRTTs map[string]int) error {
 	hbResources := make([]heartbeatResource, len(resources))
 	for i, r := range resources {
 		hbResources[i] = heartbeatResource{
@@ -115,6 +119,7 @@ func (c *APIClient) Heartbeat(ctx context.Context, agentID string, resources []R
 		Zone:            zone,
 		InstanceID:      instanceID,
 		ActiveTunnels:   activeTunnels,
+		EdgeRTTs:        edgeRTTs,
 	}
 
 	return c.Client.Post(ctx, fmt.Sprintf("/api/v1/agents/%s/heartbeat", agentID), body, nil)

--- a/pkg/agent/api_client_test.go
+++ b/pkg/agent/api_client_test.go
@@ -75,6 +75,8 @@ func TestAPIClient_Heartbeat(t *testing.T) {
 		require.True(t, body.ClusterInternal)
 		require.Equal(t, "inst-1", body.InstanceID)
 		require.Equal(t, 3, body.ActiveTunnels)
+		// Agent-leg RTT table serializes as edge_rtts (#246 contract).
+		require.Equal(t, map[string]int{"eu": 12, "us-east": 40}, body.EdgeRTTs)
 
 		w.WriteHeader(http.StatusOK)
 	}))
@@ -90,7 +92,7 @@ func TestAPIClient_Heartbeat(t *testing.T) {
 			Labels:       map[string]string{"env": "prod"},
 		},
 	}
-	err := c.Heartbeat(context.Background(), "agent-123", resources, map[string]string{"env": "prod"}, true, "internal", "inst-1", 3)
+	err := c.Heartbeat(context.Background(), "agent-123", resources, map[string]string{"env": "prod"}, true, "internal", "inst-1", 3, map[string]int{"eu": 12, "us-east": 40})
 	require.NoError(t, err)
 }
 
@@ -188,6 +190,6 @@ func TestAPIClient_Heartbeat_WithWebhooks(t *testing.T) {
 			},
 		},
 	}
-	err := c.Heartbeat(context.Background(), "agent-1", resources, nil, false, "", "inst-1", 0)
+	err := c.Heartbeat(context.Background(), "agent-1", resources, nil, false, "", "inst-1", 0, nil)
 	require.NoError(t, err)
 }

--- a/pkg/agent/relay.go
+++ b/pkg/agent/relay.go
@@ -50,6 +50,15 @@ type RelayManager struct {
 	// Cached bridge address for auto-reconnect after SSE/upgrade detach
 	lastBridgeHost string
 	lastBridgePort int
+
+	// EWMA of the relay's connection-establishment latency (TCP + TLS
+	// handshake in dial). This is the agent→edge leg of measured-latency
+	// edge selection (#246): the handshake traverses the exact path real
+	// relay traffic uses, so its time is a monotonic RTT proxy. Zero until
+	// the first successful dial. Guarded by rttMu (separate from mu — RTT is
+	// recorded inside dial, which the workers/serve path also touches).
+	rttMu   sync.Mutex
+	rttEWMA time.Duration
 }
 
 // relayWorker represents a single relay connection with its own serve loop.
@@ -172,10 +181,13 @@ func (rm *RelayManager) dial(bridgeHost string, bridgePort int) (net.Conn, error
 	tlsCfg := rm.tlsConfig.Clone()
 	tlsCfg.ServerName = bridgeHost
 
+	start := time.Now()
 	conn, err := tls.Dial("tcp", addr, tlsCfg)
 	if err != nil {
 		return nil, fmt.Errorf("relay dial failed: %w", err)
 	}
+	// Record the handshake latency as the agent→edge RTT sample (#246).
+	rm.recordRTT(time.Since(start))
 
 	// Send relay protocol header
 	if _, err := fmt.Fprintf(conn, "RELAY\n%s\n", rm.agentID); err != nil {
@@ -785,4 +797,27 @@ func (rm *RelayManager) IsConnected() bool {
 	rm.mu.Lock()
 	defer rm.mu.Unlock()
 	return len(rm.workers) > 0
+}
+
+// rttEWMAAlpha weights each new dial sample against the running average.
+// 0.3 smooths transient spikes while still tracking a genuine path change
+// within a few samples (the pool dials 32 connections per Connect).
+const rttEWMAAlpha = 0.3
+
+// recordRTT folds a dial-latency sample into the EWMA.
+func (rm *RelayManager) recordRTT(sample time.Duration) {
+	rm.rttMu.Lock()
+	defer rm.rttMu.Unlock()
+	if rm.rttEWMA == 0 {
+		rm.rttEWMA = sample
+		return
+	}
+	rm.rttEWMA = time.Duration(rttEWMAAlpha*float64(sample) + (1-rttEWMAAlpha)*float64(rm.rttEWMA))
+}
+
+// RTT returns the smoothed agent→edge latency and whether a sample exists.
+func (rm *RelayManager) RTT() (time.Duration, bool) {
+	rm.rttMu.Lock()
+	defer rm.rttMu.Unlock()
+	return rm.rttEWMA, rm.rttEWMA > 0
 }

--- a/pkg/agent/relay_test.go
+++ b/pkg/agent/relay_test.go
@@ -9,6 +9,7 @@ import (
 	"net/url"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/require"
 )
@@ -236,9 +237,9 @@ func TestForwardRequest_AlwaysStripsImpersonateHeaders(t *testing.T) {
 		Method: "GET",
 		URL:    &url.URL{Path: "/"},
 		Header: http.Header{
-			"X-Bamf-Target":    {ts.URL},
-			"X-Bamf-Resource":  {"app"},
-			"Impersonate-User": {"admin@evil.com"},
+			"X-Bamf-Target":     {ts.URL},
+			"X-Bamf-Resource":   {"app"},
+			"Impersonate-User":  {"admin@evil.com"},
 			"Impersonate-Group": {"system:masters"},
 			"X-Forwarded-Email": {"alice@example.com"},
 		},
@@ -281,4 +282,25 @@ func TestForwardRequest_K8sDetectedByK8sGroupsHeader(t *testing.T) {
 	require.Equal(t, http.StatusBadGateway, resp.StatusCode)
 	body, _ := io.ReadAll(resp.Body)
 	require.True(t, strings.Contains(string(body), "SA token"))
+}
+
+func TestRelayManager_RTT(t *testing.T) {
+	rm := NewRelayManager("agent-1", nil, nil, slog.Default())
+
+	// No dial has happened yet — no sample.
+	_, ok := rm.RTT()
+	require.False(t, ok)
+
+	// The first sample seeds the EWMA exactly.
+	rm.recordRTT(100 * time.Millisecond)
+	rtt, ok := rm.RTT()
+	require.True(t, ok)
+	require.Equal(t, 100*time.Millisecond, rtt)
+
+	// Subsequent samples move toward the new value (alpha=0.3):
+	// 0.3*200ms + 0.7*100ms = 130ms.
+	rm.recordRTT(200 * time.Millisecond)
+	rtt, ok = rm.RTT()
+	require.True(t, ok)
+	require.Equal(t, 130*time.Millisecond, rtt)
 }

--- a/services/bamf/api/routers/agents.py
+++ b/services/bamf/api/routers/agents.py
@@ -54,10 +54,12 @@ from bamf.auth.ca import (
     serialize_private_key,
 )
 from bamf.auth.sessions import Session
+from bamf.config import settings
 from bamf.db.models import Agent, JoinToken
 from bamf.db.session import get_db, get_db_read
 from bamf.logging_config import get_logger
 from bamf.redis.client import get_redis
+from bamf.redis_keys import agent_edge_rtt_key
 from bamf.services.audit_service import log_audit_event
 from bamf.services.bridge_routing import VALID_ZONES
 from bamf.services.resource_catalog import (
@@ -169,6 +171,10 @@ class AgentHeartbeatRequest(BAMFBaseModel):
     zone: str | None = None
     instance_id: str | None = None
     active_tunnels: int = 0
+    # Measured agent→edge relay latency in milliseconds, keyed by edge name
+    # (the agent-leg of measured-latency edge selection, #246). An empty edge
+    # key (co-located/default relay) maps to the configured default edge.
+    edge_rtts: dict[str, int] = Field(default_factory=dict)
 
 
 class AgentDrainRequest(BAMFBaseModel):
@@ -398,6 +404,19 @@ async def agent_heartbeat(
             await r.setex(f"agent:{agent_id_str}:zone", AGENT_TTL_SECONDS, body.zone)
         else:
             await r.delete(f"agent:{agent_id_str}:zone")
+
+        # Store measured agent→edge relay latencies — the agent-leg table for
+        # measured-latency edge selection (#246). Each sample is refreshed with
+        # the agent TTL, so an edge whose relay drops (agent stops reporting it)
+        # expires on its own. An empty edge key is the co-located/default relay.
+        for edge, rtt_ms in body.edge_rtts.items():
+            edge_name = edge or settings.default_edge_name
+            if edge_name:
+                await r.setex(
+                    agent_edge_rtt_key(agent_id_str, edge_name),
+                    AGENT_TTL_SECONDS,
+                    rtt_ms,
+                )
 
     return SuccessResponse(message="OK")
 

--- a/services/bamf/redis_keys.py
+++ b/services/bamf/redis_keys.py
@@ -24,3 +24,15 @@ def tunnel_session_key(session_id: str) -> str:
 def tunnel_session_creds_key(session_id: str) -> str:
     """Redis key for a tunnel session's cached client credentials."""
     return f"session:{session_id}:client_creds"
+
+
+def agent_edge_rtt_key(agent_id: str, edge: str) -> str:
+    """Redis key for an agent's measured latency to a given edge (#246).
+
+    Value is the smoothed agent→edge relay RTT in milliseconds, reported on
+    each heartbeat and refreshed with the agent TTL. This is the agent-leg
+    of the rendezvous cost in measured-latency edge selection (#119). Keyed
+    under ``agent:{id}:*`` alongside the sibling ``agent:{id}:relay:{edge}``
+    assignment key, so per-agent cleanup scans reach it.
+    """
+    return f"agent:{agent_id}:edge_rtt:{edge}"

--- a/services/tests/test_api/test_agents_router.py
+++ b/services/tests/test_api/test_agents_router.py
@@ -24,6 +24,7 @@ from bamf.api.dependencies import (
 )
 from bamf.api.routers.agents import router
 from bamf.auth.sessions import Session
+from bamf.config import settings
 from bamf.db.session import get_db, get_db_read
 from bamf.redis.client import get_redis
 
@@ -327,6 +328,38 @@ class TestAgentHeartbeat:
 
         assert resp.status_code == 200
         mock_redis.setex.assert_any_call(f"agent:{AGENT_UUID}:status", 180, "online")
+
+    @pytest.mark.asyncio
+    async def test_heartbeat_stores_edge_rtts(self, agents_client, mock_db, mock_redis):
+        """Reported agent→edge RTTs are stored per (agent, edge); an empty edge
+        key maps to the configured default edge (#246)."""
+        agent = _make_mock_agent()
+        mock_db.execute = _mock_db_execute_returning(agent)
+
+        with (
+            patch("bamf.api.routers.agents.set_agent_labels", new_callable=AsyncMock),
+            patch("bamf.api.routers.agents.set_agent_resources", new_callable=AsyncMock),
+            patch("bamf.api.routers.agents.set_tunnel_hostnames", new_callable=AsyncMock),
+            patch("bamf.services.agent_instances.register_instance", new_callable=AsyncMock),
+            patch(
+                "bamf.services.agent_instances.update_instance_tunnel_count", new_callable=AsyncMock
+            ),
+            patch("bamf.services.agent_instances.cleanup_stale_instances", new_callable=AsyncMock),
+            patch.object(settings, "default_edge_name", "central"),
+        ):
+            resp = await agents_client.post(
+                f"/api/v1/agents/{AGENT_UUID}/heartbeat",
+                json={
+                    "resources": [],
+                    "instance_id": "inst-1",
+                    "edge_rtts": {"eu": 12, "": 3},
+                },
+            )
+
+        assert resp.status_code == 200
+        # Named edge stored verbatim; empty edge folded into the default.
+        mock_redis.setex.assert_any_call(f"agent:{AGENT_UUID}:edge_rtt:eu", 180, 12)
+        mock_redis.setex.assert_any_call(f"agent:{AGENT_UUID}:edge_rtt:central", 180, 3)
 
     @pytest.mark.asyncio
     async def test_heartbeat_by_name(self, agents_client, mock_db, mock_redis):

--- a/services/tests/test_redis_keys.py
+++ b/services/tests/test_redis_keys.py
@@ -10,7 +10,11 @@ from pathlib import Path
 
 import bamf
 from bamf.auth.sessions import SESSION_PREFIX
-from bamf.redis_keys import tunnel_session_creds_key, tunnel_session_key
+from bamf.redis_keys import (
+    agent_edge_rtt_key,
+    tunnel_session_creds_key,
+    tunnel_session_key,
+)
 
 _BAMF_SRC = Path(bamf.__file__).resolve().parent
 
@@ -18,6 +22,13 @@ _BAMF_SRC = Path(bamf.__file__).resolve().parent
 def test_tunnel_session_key_formats():
     assert tunnel_session_key("abc") == "session:abc"
     assert tunnel_session_creds_key("abc") == "session:abc:client_creds"
+
+
+def test_agent_edge_rtt_key_format():
+    # Keyed under agent:{id}:* (like the sibling relay-assignment key), and
+    # never in the tunnel-session namespace.
+    assert agent_edge_rtt_key("agent-1", "eu") == "agent:agent-1:edge_rtt:eu"
+    assert not agent_edge_rtt_key("a", "eu").startswith("session:")
 
 
 def test_session_namespaces_stay_distinct():


### PR DESCRIPTION
Closes #246. First build step of the measured-latency edge selection designed in #119 — the **agent-leg** of the rendezvous cost `RTT(client, E) + RTT(E, agent)`.

## Why this is free

After #194 the agent holds a persistent relay to a bridge in **every** edge. The relay's `tls.Dial` (TCP + TLS handshake) to `N.bridge.{edge}...` traverses the exact path real relay/tunnel traffic uses — through the same ingress/LB. Timing that handshake is a zero-extra-cost, monotonic RTT proxy: no new relay protocol, no active probe. The 32-connection pool produces a solid EWMA the instant an edge goes active (on `relay_connect`) and refreshes it on every reconnect/replenish — i.e. exactly when the edge matters.

## Changes

- **Agent (`RelayManager`)** — time each successful `tls.Dial`, fold it into a per-edge EWMA (`alpha=0.3`), expose `RTT()`.
- **Heartbeat contract** — new optional `edge_rtts: {edge → ms}` map on the agent heartbeat: Go `heartbeatRequest` ↔ Python `AgentHeartbeatRequest` (both sides + `api_client` serialization assertion). Backward compatible — older agents omit it, the field defaults to `{}`.
- **API** — on heartbeat, store each `(agent, edge) → rtt_ms` via a new canonical `redis_keys.agent_edge_rtt_key` builder, refreshed with the agent TTL (a dropped edge's sample expires on its own). An empty edge key (co-located/default relay) folds into the configured default edge.

## Scope

This only makes the agent-leg table **exist** in Redis. It is **not** wired into any routing decision yet — no behaviour change. The client-leg probe, the pure `argmin` selector, and the single-hop trigger follow as later #119 steps; the `docs/architecture/edge-deployments.md` selection section updates when the selector goes live.

## Verification

Go: build + `go test -race ./pkg/agent/` + `golangci-lint` (0 issues). Python: `ruff` (0.15.7) clean, full suite **1056 passed** (+2: `test_agent_edge_rtt_key_format`, `test_heartbeat_stores_edge_rtts`). Content-hygiene clean.