### PR TITLE
feat(edge): pure argmin edge selector + agent-leg reader

### DIFF
--- a/services/bamf/services/edge_selection.py
+++ b/services/bamf/services/edge_selection.py
@@ -1,0 +1,106 @@
+"""Measured-latency edge selection (#119).
+
+Routing a tunnel ``client → edge → agent`` costs
+
+    cost(E) = RTT(client, E) + RTT(E, agent)
+
+— the agent→target leg is constant and drops out, so the edge is a *rendezvous*
+and the goal is the shortest detour through it, not the nearest edge to either
+end. Selection minimizes that sum from **measured** scalar legs. It never
+triangulates or uses geography: internet latency is non-Euclidean and routinely
+violates the triangle inequality, so neither coordinates nor a single leg
+predict the sum (see #119).
+
+The leg tables are gathered separately — the agent-leg from Redis
+(``get_agent_edge_rtts``, harvested from heartbeats in #246), the client-leg
+from the client probe (a later step) — and fed to :func:`select_edge`, which is
+a pure, table-testable function.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class EdgeCandidate:
+    """One edge under consideration, with whatever legs have been measured.
+
+    ``agent_rtt_ms`` / ``client_rtt_ms`` are ``None`` when that leg has not been
+    measured yet. ``has_capacity`` is False when the edge has no live bridge to
+    serve a tunnel — such edges are never selected regardless of latency.
+    """
+
+    name: str
+    has_capacity: bool
+    agent_rtt_ms: int | None = None
+    client_rtt_ms: int | None = None
+
+
+def select_edge(
+    candidates: list[EdgeCandidate],
+    default_edge: str | None = None,
+) -> str | None:
+    """Pick the rendezvous edge minimizing ``client_leg + agent_leg``.
+
+    Only edges with capacity are candidates. Selection degrades by information
+    tier so a partial leg table still yields the best available decision:
+
+    1. edges with **both** legs   → ``argmin(client + agent)``  (true rendezvous)
+    2. else edges with agent-leg  → ``argmin(agent)``           (nearest-to-agent guess)
+    3. else edges with client-leg → ``argmin(client)``          (nearest-to-client)
+    4. else                       → the default edge, if it is healthy
+
+    Costs are only ever compared within a single tier, never across (a sum and a
+    lone leg are not comparable). Ties break deterministically by edge name, so
+    the choice is stable across calls and does not flap. Returns ``None`` when no
+    edge has capacity, or when tier 4 has no healthy default to fall back to.
+    """
+    healthy = [c for c in candidates if c.has_capacity]
+    if not healthy:
+        return None
+
+    both = [c for c in healthy if c.agent_rtt_ms is not None and c.client_rtt_ms is not None]
+    if both:
+        return min(both, key=lambda c: (c.client_rtt_ms + c.agent_rtt_ms, c.name)).name
+
+    agent_only = [c for c in healthy if c.agent_rtt_ms is not None]
+    if agent_only:
+        return min(agent_only, key=lambda c: (c.agent_rtt_ms, c.name)).name
+
+    client_only = [c for c in healthy if c.client_rtt_ms is not None]
+    if client_only:
+        return min(client_only, key=lambda c: (c.client_rtt_ms, c.name)).name
+
+    # No measurements at all — fall back to the default edge only if it can
+    # actually serve a tunnel; otherwise let the caller decide.
+    if default_edge and any(c.name == default_edge for c in healthy):
+        return default_edge
+    return None
+
+
+async def get_agent_edge_rtts(r, agent_id: str) -> dict[str, int]:
+    """Read the agent-leg RTT table ``{edge → ms}`` for an agent from Redis.
+
+    Reads the ``agent:{id}:edge_rtt:{edge}`` keys harvested from heartbeats
+    (#246). Missing or malformed values are skipped. Returns an empty dict when
+    the agent has reported no measurements.
+    """
+    from bamf.redis_keys import agent_edge_rtt_key
+
+    prefix = agent_edge_rtt_key(agent_id, "")
+    rtts: dict[str, int] = {}
+    cursor = "0"
+    while True:
+        cursor, keys = await r.scan(cursor=cursor, match=f"{prefix}*", count=50)
+        for key in keys:
+            value = await r.get(key)
+            if value is None:
+                continue
+            try:
+                rtts[key[len(prefix) :]] = int(value)
+            except TypeError, ValueError:
+                continue
+        if cursor == 0 or cursor == "0":
+            break
+    return rtts

--- a/services/tests/test_services/test_edge_selection.py
+++ b/services/tests/test_services/test_edge_selection.py
@@ -1,0 +1,121 @@
+"""Tests for measured-latency edge selection (#119, step 2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from bamf.services.edge_selection import (
+    EdgeCandidate,
+    get_agent_edge_rtts,
+    select_edge,
+)
+
+
+def _c(name, *, capacity=True, agent=None, client=None):
+    return EdgeCandidate(name=name, has_capacity=capacity, agent_rtt_ms=agent, client_rtt_ms=client)
+
+
+class TestSelectEdge:
+    def test_no_candidates_returns_none(self):
+        assert select_edge([]) is None
+
+    def test_no_healthy_candidates_returns_none(self):
+        # An edge with a great latency but no bridge is never chosen.
+        assert select_edge([_c("eu", capacity=False, agent=1, client=1)]) is None
+
+    def test_both_legs_minimizes_the_sum(self):
+        # eu: 40+40=80, us: 10+90=100, apac: 30+30=60  → apac wins the rendezvous,
+        # even though us has the smallest single (client) leg.
+        candidates = [
+            _c("eu", agent=40, client=40),
+            _c("us", agent=10, client=90),
+            _c("apac", agent=30, client=30),
+        ]
+        assert select_edge(candidates) == "apac"
+
+    def test_agent_only_is_nearest_to_agent_guess(self):
+        # No client legs yet → tier 2: argmin(agent).
+        candidates = [
+            _c("eu", agent=40),
+            _c("us", agent=12),
+            _c("apac", agent=25),
+        ]
+        assert select_edge(candidates) == "us"
+
+    def test_client_only_is_nearest_to_client(self):
+        candidates = [_c("eu", client=40), _c("us", client=12)]
+        assert select_edge(candidates) == "us"
+
+    def test_both_tier_wins_over_partial(self):
+        # A candidate with both legs is chosen from tier 1; the agent-only edge
+        # is never compared against it (sum vs lone leg is not comparable).
+        candidates = [
+            _c("eu", agent=5),  # agent-only, tiny — but ignored while tier 1 is non-empty
+            _c("us", agent=50, client=50),  # both legs
+        ]
+        assert select_edge(candidates) == "us"
+
+    def test_ties_break_deterministically_by_name(self):
+        # Equal sums → lexicographically smallest edge name, stable across calls.
+        candidates = [
+            _c("zeta", agent=20, client=20),
+            _c("alpha", agent=20, client=20),
+        ]
+        assert select_edge(candidates) == "alpha"
+
+    def test_unhealthy_edges_filtered_before_selection(self):
+        # us has the best latency but no capacity → eu is chosen.
+        candidates = [
+            _c("us", capacity=False, agent=1, client=1),
+            _c("eu", agent=40, client=40),
+        ]
+        assert select_edge(candidates) == "eu"
+
+    def test_default_used_when_no_measurements(self):
+        candidates = [_c("eu"), _c("us")]
+        assert select_edge(candidates, default_edge="us") == "us"
+
+    def test_default_ignored_when_unhealthy(self):
+        # Default names an edge with no capacity → no healthy fallback → None.
+        candidates = [_c("us", capacity=False)]
+        assert select_edge(candidates, default_edge="us") is None
+
+    def test_no_measurements_no_default_returns_none(self):
+        assert select_edge([_c("eu"), _c("us")]) is None
+
+
+class _FakeRedis:
+    """Minimal async Redis stub supporting a single-shot scan + get."""
+
+    def __init__(self, data: dict[str, str]):
+        self._data = data
+
+    async def scan(self, cursor="0", match=None, count=None):
+        import fnmatch
+
+        keys = [k for k in self._data if match is None or fnmatch.fnmatch(k, match)]
+        return "0", keys
+
+    async def get(self, key):
+        return self._data.get(key)
+
+
+@pytest.mark.asyncio
+class TestGetAgentEdgeRTTs:
+    async def test_reads_and_parses_table(self):
+        r = _FakeRedis(
+            {
+                "agent:a1:edge_rtt:eu": "12",
+                "agent:a1:edge_rtt:us-east": "40",
+                "agent:other:edge_rtt:eu": "5",  # different agent — excluded
+                "agent:a1:relay:eu": "bridge-0",  # sibling key — excluded by scan pattern
+            }
+        )
+        assert await get_agent_edge_rtts(r, "a1") == {"eu": 12, "us-east": 40}
+
+    async def test_empty_when_no_samples(self):
+        assert await get_agent_edge_rtts(_FakeRedis({}), "a1") == {}
+
+    async def test_skips_malformed_values(self):
+        r = _FakeRedis({"agent:a1:edge_rtt:eu": "not-a-number", "agent:a1:edge_rtt:us": "7"})
+        assert await get_agent_edge_rtts(r, "a1") == {"us": 7}


### PR DESCRIPTION
Closes #248. Second build step of measured-latency edge selection (#119) — the pure selection core.

## The metric

Routing a tunnel `client → edge → agent` costs `RTT(client, E) + RTT(E, agent)` (the agent→target leg is constant and drops out). The edge is a **rendezvous**, so selection is `argmin_E` of that *sum* over healthy edges — measured, never triangulated. Neither geography nor a single leg predicts the sum, because internet latency is non-Euclidean and routinely violates the triangle inequality (see #119).

## Changes (`services/bamf/services/edge_selection.py`)

- **`select_edge(candidates, default_edge)`** — a **pure**, table-testable function. Degrades by information tier so a partial leg table still yields the best available decision: (1) both legs → `argmin(client+agent)`; (2) else agent-leg → `argmin(agent)` (the nearest-to-agent free guess); (3) else client-leg → `argmin(client)`; (4) else the default edge if healthy. Costs are only compared within a tier (a sum and a lone leg aren't comparable); only edges with capacity are candidates; ties break deterministically by edge name (stable, no flapping).
- **`get_agent_edge_rtts(r, agent_id)`** — reads the `agent:{id}:edge_rtt:{edge}` table (#246) into `{edge → ms}`, skipping malformed values.

## Scope

Reusable core **only** — deliberately **not wired into `connect.py`**. That's a routing behaviour change and belongs with the client-leg step, where both legs exist and a 2-edge smoke can validate it. **No behaviour change** here.

## Verification

`ruff` (0.15.7) clean; full Python suite **1070 passed** (+13: the `select_edge` tier/tie-break/capacity table + `get_agent_edge_rtts` over a fake Redis). Content-hygiene clean. No Go/Helm/migration/docs surface touched.