### PR TITLE
feat(edge): route non-pinned tunnels to the agent-nearest edge (optimistic guess)

### DIFF
--- a/docs/architecture/edge-deployments.md
+++ b/docs/architecture/edge-deployments.md
@@ -193,19 +193,30 @@ streams.
 
 ### Edge Selection
 
-For TCP tunnels, the API chooses the edge as follows:
+A tunnel is a rendezvous: `client → edge → agent → target`. The agent→target
+leg is fixed, so the edge that minimizes latency is the one with the shortest
+detour — `argmin_E [ RTT(client, E) + RTT(E, agent) ]` — not simply the edge
+nearest either end. Because internet latency is non-Euclidean (it violates the
+triangle inequality), both legs are **measured**, never inferred from geography.
 
-1. Resource has `edge` pinned → use that edge
-2. Otherwise → the configured default edge
+For TCP tunnels the API chooses the edge as follows:
 
-**Measured-latency nearest-edge selection** — where the connecting client
-probes candidate edges along the real network path, picks the lowest RTT,
-and caches the result — is planned as part of the edge flagship
-([#119](https://github.com/mattrobinsonsre/bamf/issues/119)). It replaces
-the earlier (never-active) GeoIP approach: geographic distance is a lossy
-proxy for network latency under VPN egress, CGNAT, anycast, and asymmetric
-routing, and it is hard to test. Until it lands, a non-pinned resource
-routes through the configured default edge.
+1. Resource has `edge` pinned → use that edge.
+2. Otherwise → the edge **nearest the agent** (lowest measured agent-leg RTT)
+   that has bridge capacity. The agent-leg is measured for free from the
+   relay each agent already holds to every edge (its `tls.Dial` handshake
+   latency), reported on heartbeats and cached in Redis.
+3. Fallback → the configured default edge, when the agent has no measurements
+   yet or no measured edge has capacity.
+
+Step 2 is the **optimistic-connect guess**: the tunnel opens immediately on the
+agent-nearest edge with zero added setup latency. The remaining pieces of the
+edge flagship ([#119](https://github.com/mattrobinsonsre/bamf/issues/119)) —
+the client-leg probe (so the choice becomes the true client+agent rendezvous)
+and a seamless single hop to a better edge discovered in the background — build
+on this without ever blocking connection setup. This measured approach replaces
+the earlier, never-active GeoIP heuristic (geographic distance is a lossy proxy
+for network latency and hard to test).
 
 ## Resource Region Pinning
 

--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -62,6 +62,11 @@ from bamf.redis.client import get_redis
 from bamf.redis_keys import tunnel_session_creds_key, tunnel_session_key
 from bamf.services.audit_service import log_audit_event
 from bamf.services.bridge_routing import resolve_agent_bridge_endpoint
+from bamf.services.edge_selection import (
+    EdgeCandidate,
+    get_agent_edge_rtts,
+    select_edge,
+)
 from bamf.services.rbac_service import check_access
 from bamf.services.resource_catalog import get_resource
 
@@ -196,10 +201,16 @@ async def _handle_new_connection(
         resource_type = request.protocol
 
     # ── 5. Determine edge for bridge selection ───────────────────
-    # Priority: resource pin > default. Measured-latency nearest-edge
-    # selection is tracked under the edge flagship (#119); until then a
-    # non-pinned resource routes through the configured default edge.
-    edge_name = resource.edge or settings.default_edge_name
+    # Priority: resource pin > measured agent-nearest guess > default.
+    # A non-pinned tunnel opens on the edge nearest the *agent* — the leg we
+    # already measured for free (#246). This is the optimistic-connect "guess"
+    # of measured-latency selection (#119); the client-leg and the seamless hop
+    # to the true rendezvous edge follow in later steps. Falls back to the
+    # configured default when there is no measurement or no edge with capacity.
+    if resource.edge:
+        edge_name = resource.edge
+    else:
+        edge_name = await _select_edge_for_agent(r, agent_id) or settings.default_edge_name
 
     session_id = secrets.token_urlsafe(24)
     return await _issue_session(
@@ -217,6 +228,31 @@ async def _handle_new_connection(
         audit_action="access_granted",
         edge_name=edge_name,
     )
+
+
+async def _select_edge_for_agent(r: aioredis.Redis, agent_id: str) -> str | None:
+    """Pick the edge nearest the agent among those with a live bridge.
+
+    Reads the agent-leg RTT table (#246) and returns the lowest-latency edge
+    that also has bridge capacity — the optimistic-connect guess of
+    measured-latency selection (#119). Returns None when the agent has reported
+    no measurements or no measured edge has a bridge, so the caller falls back
+    to the configured default edge. Conservative by design: a non-default edge
+    is only ever chosen when it is both measured and confirmed to have capacity.
+    """
+    agent_rtts = await get_agent_edge_rtts(r, agent_id)
+    if not agent_rtts:
+        return None
+
+    candidates = [
+        EdgeCandidate(
+            name=edge,
+            has_capacity=await r.zcard(f"bridges:available:{edge}") > 0,
+            agent_rtt_ms=rtt_ms,
+        )
+        for edge, rtt_ms in agent_rtts.items()
+    ]
+    return select_edge(candidates, default_edge=settings.default_edge_name)
 
 
 async def _handle_reconnect(

--- a/services/tests/test_api/test_connect_router.py
+++ b/services/tests/test_api/test_connect_router.py
@@ -19,6 +19,7 @@ from bamf.api.dependencies import get_current_user
 from bamf.api.routers.connect import (
     NON_MIGRATABLE_PROTOCOLS,
     _extract_ordinal,
+    _select_edge_for_agent,
     _validate_protocol_override,
     router,
 )
@@ -425,3 +426,44 @@ class TestReconnect:
         )
 
         assert resp.status_code == 503
+
+
+class _EdgeRedis:
+    """Fake Redis for the edge-selection guess: an agent-leg RTT table plus
+    per-edge bridge capacity."""
+
+    def __init__(self, rtts: dict[str, int], capacity: dict[str, int]):
+        self._keys = {f"agent:a1:edge_rtt:{e}": str(ms) for e, ms in rtts.items()}
+        self._capacity = capacity
+
+    async def scan(self, cursor="0", match=None, count=None):
+        import fnmatch
+
+        return "0", [k for k in self._keys if fnmatch.fnmatch(k, match)]
+
+    async def get(self, key):
+        return self._keys.get(key)
+
+    async def zcard(self, key):
+        # key is "bridges:available:{edge}"
+        return self._capacity.get(key.rsplit(":", 1)[-1], 0)
+
+
+@pytest.mark.asyncio
+class TestSelectEdgeForAgent:
+    async def test_selects_agent_nearest_with_capacity(self):
+        r = _EdgeRedis({"eu": 40, "us": 12}, {"eu": 2, "us": 2})
+        assert await _select_edge_for_agent(r, "a1") == "us"
+
+    async def test_skips_nearest_without_capacity(self):
+        # us is nearer but has no bridge → eu is chosen.
+        r = _EdgeRedis({"eu": 40, "us": 12}, {"eu": 2, "us": 0})
+        assert await _select_edge_for_agent(r, "a1") == "eu"
+
+    async def test_none_when_no_measurements(self):
+        # No agent-leg data → caller falls back to the default edge.
+        assert await _select_edge_for_agent(_EdgeRedis({}, {}), "a1") is None
+
+    async def test_none_when_no_capacity_anywhere(self):
+        r = _EdgeRedis({"eu": 40, "us": 12}, {"eu": 0, "us": 0})
+        assert await _select_edge_for_agent(r, "a1") is None


### PR DESCRIPTION
Closes #250. Wires the selector (#248) + agent-leg table (#246) into `POST /api/v1/connect` — the **optimistic-connect guess** of measured-latency edge selection (#119). **First real routing change** of the flagship.

## Behaviour

A non-pinned TCP tunnel now opens on the edge **nearest the agent** (lowest measured agent-leg RTT) that has bridge capacity, instead of always the configured default — with **zero added setup latency** (no probe on the connect path; the agent-leg is already in Redis from #246).

Edge choice for a non-pinned resource:
1. `resource.edge` pinned → that edge (unchanged).
2. else agent-nearest edge **with bridge capacity**.
3. else the configured default edge.

**Conservative by design:** a non-default edge is chosen only when it's both measured *and* confirmed to have a live bridge. So single-edge deployments and the no-measurement case route exactly as before — no behaviour change there.

## Scope

Guess-only. The **client-leg** probe (turning the guess into the true `client+agent` rendezvous) and the **seamless single hop** to a better background-discovered edge are later #119 steps. No CLI change, no new round-trips, no client-facing contract change.

## Verification

`_select_edge_for_agent` unit tests (agent-nearest-with-capacity, skip-nearest-without-capacity, no-measurements→default, no-capacity→default); existing connect tests unchanged. Full Python suite **1074 passed**, `ruff` 0.15.7 clean, docs strict + xref + content-hygiene clean. `docs/architecture/edge-deployments.md` Edge Selection section updated to the active rendezvous behaviour.

## Note on validation

Multi-edge routing is unit-tested (mocked Redis); a real **2-edge end-to-end smoke** is part of #119's acceptance and lands with the later steps (the local Tilt stack is single-edge). Single-edge behaviour is fully covered and unchanged.