### PR TITLE
feat(edge): accept client-leg RTTs and merge into edge selection

### DIFF
--- a/services/bamf/api/models/connect.py
+++ b/services/bamf/api/models/connect.py
@@ -23,6 +23,13 @@ class ConnectRequest(BAMFBaseModel):
         "Used by web terminal to specify 'web-ssh' or 'web-db' instead "
         "of the resource's native type (e.g. 'ssh', 'postgres').",
     )
+    client_edge_rtts: dict[str, int] = Field(
+        default_factory=dict,
+        description="Client-measured latency in milliseconds to each edge "
+        "(the client-leg of measured-latency edge selection, #119). Merged "
+        "with the agent-leg to pick the rendezvous edge. Empty on a cold "
+        "client — the API then routes to the agent-nearest edge.",
+    )
 
 
 class ConnectResponse(BAMFBaseModel):

--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -210,7 +210,10 @@ async def _handle_new_connection(
     if resource.edge:
         edge_name = resource.edge
     else:
-        edge_name = await _select_edge_for_agent(r, agent_id) or settings.default_edge_name
+        edge_name = (
+            await _select_edge_for_agent(r, agent_id, request.client_edge_rtts)
+            or settings.default_edge_name
+        )
 
     session_id = secrets.token_urlsafe(24)
     return await _issue_session(
@@ -230,27 +233,37 @@ async def _handle_new_connection(
     )
 
 
-async def _select_edge_for_agent(r: aioredis.Redis, agent_id: str) -> str | None:
-    """Pick the edge nearest the agent among those with a live bridge.
+async def _select_edge_for_agent(
+    r: aioredis.Redis,
+    agent_id: str,
+    client_rtts: dict[str, int] | None = None,
+) -> str | None:
+    """Pick the rendezvous edge for a tunnel among those with a live bridge.
 
-    Reads the agent-leg RTT table (#246) and returns the lowest-latency edge
-    that also has bridge capacity — the optimistic-connect guess of
-    measured-latency selection (#119). Returns None when the agent has reported
-    no measurements or no measured edge has a bridge, so the caller falls back
-    to the configured default edge. Conservative by design: a non-default edge
-    is only ever chosen when it is both measured and confirmed to have capacity.
+    Combines the agent-leg RTT table (#246, from Redis) with the client-leg
+    ``client_rtts`` the CLI measured and sent on this request, and returns the
+    edge minimizing ``client + agent`` (:func:`select_edge`). With no client
+    legs this degrades to the agent-nearest optimistic-connect guess (#119).
+
+    Returns None when neither leg names any edge, or no measured edge has bridge
+    capacity, so the caller falls back to the configured default edge.
+    Conservative by design: a non-default edge is only ever chosen when it is
+    measured and confirmed to have capacity.
     """
     agent_rtts = await get_agent_edge_rtts(r, agent_id)
-    if not agent_rtts:
+    client_rtts = client_rtts or {}
+    edges = set(agent_rtts) | set(client_rtts)
+    if not edges:
         return None
 
     candidates = [
         EdgeCandidate(
             name=edge,
             has_capacity=await r.zcard(f"bridges:available:{edge}") > 0,
-            agent_rtt_ms=rtt_ms,
+            agent_rtt_ms=agent_rtts.get(edge),
+            client_rtt_ms=client_rtts.get(edge),
         )
-        for edge, rtt_ms in agent_rtts.items()
+        for edge in edges
     ]
     return select_edge(candidates, default_edge=settings.default_edge_name)
 

--- a/services/tests/test_api/test_connect_router.py
+++ b/services/tests/test_api/test_connect_router.py
@@ -467,3 +467,18 @@ class TestSelectEdgeForAgent:
     async def test_none_when_no_capacity_anywhere(self):
         r = _EdgeRedis({"eu": 40, "us": 12}, {"eu": 0, "us": 0})
         assert await _select_edge_for_agent(r, "a1") is None
+
+    async def test_client_legs_flip_the_choice_to_the_rendezvous(self):
+        # Agent-nearest is us (10). But the client is far from us and near eu,
+        # so the rendezvous (client+agent) is eu: 10+40=50 < 90+10=100.
+        r = _EdgeRedis({"eu": 40, "us": 10}, {"eu": 2, "us": 2})
+        assert await _select_edge_for_agent(r, "a1") == "us"  # no client legs → guess
+        assert (
+            await _select_edge_for_agent(r, "a1", {"eu": 10, "us": 90}) == "eu"
+        )  # with client legs → rendezvous
+
+    async def test_client_leg_only_edge_considered_when_no_agent_leg(self):
+        # An edge the agent never measured but the client did is still a
+        # candidate (tier 3), provided it has capacity.
+        r = _EdgeRedis({}, {"eu": 2})
+        assert await _select_edge_for_agent(r, "a1", {"eu": 15}) == "eu"


### PR DESCRIPTION
Closes #252. The API half of the client-leg step of measured-latency edge selection (#119).

Accepts a client-measured latency vector on the connect request and merges it with the agent-leg table (#246), so the chosen edge is the true rendezvous `argmin_E [client(E) + agent(E)]` rather than just the agent-nearest guess (#250).

## Changes

- **`ConnectRequest.client_edge_rtts: dict[str, int]`** — optional client-measured ms-per-edge. Empty on a cold client → the API keeps routing to the agent-nearest edge.
- **`_select_edge_for_agent(r, agent_id, client_rtts)`** — merges the agent-leg (Redis) and client-leg (request) per edge and defers to `select_edge` (#248). An edge named only by the client-leg is still a candidate (tier 3) when it has capacity.

## Scope

API-side only, contract-first, **backward compatible** — existing clients send no `client_edge_rtts`, so behaviour is unchanged (agent-nearest guess). The CLI probe/cache that measures and sends the client-leg, plus the `candidate_edges` the API returns for the CLI to probe, are the next step (3b-cli).

## Verification

New `_select_edge_for_agent` tests: client legs flip the choice from the agent-nearest guess to the rendezvous edge; a client-only edge is considered when it has capacity. Full Python suite **1076 passed**, `ruff` 0.15.7 clean.