### PR TITLE
feat(edge): CLI client-leg probe/cache + candidate_edges

### DIFF
--- a/cmd/bamf/cmd/connect.go
+++ b/cmd/bamf/cmd/connect.go
@@ -24,14 +24,15 @@ import (
 
 // ConnectResponse matches the Python API response model
 type ConnectResponse struct {
-	BridgeHostname   string    `json:"bridge_hostname"`
-	BridgePort       int       `json:"bridge_port"`
-	SessionCert      string    `json:"session_cert"`
-	SessionKey       string    `json:"session_key"`
-	CACertificate    string    `json:"ca_certificate"`
-	SessionID        string    `json:"session_id"`
-	SessionExpiresAt time.Time `json:"session_expires_at"`
-	ResourceType     string    `json:"resource_type"`
+	BridgeHostname   string            `json:"bridge_hostname"`
+	BridgePort       int               `json:"bridge_port"`
+	SessionCert      string            `json:"session_cert"`
+	SessionKey       string            `json:"session_key"`
+	CACertificate    string            `json:"ca_certificate"`
+	SessionID        string            `json:"session_id"`
+	SessionExpiresAt time.Time         `json:"session_expires_at"`
+	ResourceType     string            `json:"resource_type"`
+	CandidateEdges   []EdgeProbeTarget `json:"candidate_edges"`
 }
 
 // connectBridge is the shared tunnel setup: load creds, request session, dial bridge,
@@ -57,6 +58,11 @@ func connectBridge(ctx context.Context, resourceName string) (*reconnectingBridg
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to connect to bridge: %w", err)
 	}
+
+	// Refresh the client-leg latency cache in the background (#119). This never
+	// touches the live tunnel; a short-lived CLI may exit before it finishes,
+	// which is fine — the next connect re-probes.
+	go maybeRefreshEdgeCache(session.CandidateEdges)
 
 	stream := tunnel.NewStream(conn, tunnel.DefaultBufSize)
 
@@ -314,11 +320,17 @@ func requestConnect(ctx context.Context, creds *tokenResponse, resource, reconne
 	}
 	u.Path = "/api/v1/connect"
 
-	reqBody := map[string]string{
+	reqBody := map[string]any{
 		"resource_name": resource,
 	}
 	if reconnectSessionID != "" {
 		reqBody["reconnect_session_id"] = reconnectSessionID
+	}
+	// Send the cached client-leg latency vector (#119) so the API can pick the
+	// true client+agent rendezvous edge. Omitted when the cache is cold or
+	// stale — the API then routes to the agent-nearest edge.
+	if rtts := loadFreshEdgeRTTs(); len(rtts) > 0 {
+		reqBody["client_edge_rtts"] = rtts
 	}
 	reqData, _ := json.Marshal(reqBody)
 

--- a/cmd/bamf/cmd/connect_test.go
+++ b/cmd/bamf/cmd/connect_test.go
@@ -125,6 +125,7 @@ func TestSplice_OneSideClosed(t *testing.T) {
 // ── Tests: requestConnect ────────────────────────────────────────────
 
 func TestRequestConnect_Success(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // cold edge cache → no client_edge_rtts in body
 	expected := ConnectResponse{
 		BridgeHostname: "0.bridge.tunnel.example.com",
 		BridgePort:     443,
@@ -162,6 +163,7 @@ func TestRequestConnect_Success(t *testing.T) {
 }
 
 func TestRequestConnect_WithReconnectSession(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // cold edge cache → no client_edge_rtts in body
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var body map[string]string
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
@@ -177,6 +179,28 @@ func TestRequestConnect_WithReconnectSession(t *testing.T) {
 	result, err := requestConnect(context.Background(), creds, "res", "old-session-id")
 	require.NoError(t, err)
 	require.Equal(t, "old-session-id", result.SessionID)
+}
+
+func TestRequestConnect_SendsCachedClientEdgeRTTs(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	require.NoError(t, writeEdgeCache(map[string]int{"eu": 12, "us": 40}))
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		rtts, ok := body["client_edge_rtts"].(map[string]any)
+		require.True(t, ok, "warm cache should populate client_edge_rtts")
+		require.EqualValues(t, 12, rtts["eu"])
+		require.EqualValues(t, 40, rtts["us"])
+		require.NoError(t, json.NewEncoder(w).Encode(ConnectResponse{SessionID: "s"}))
+	}))
+	defer srv.Close()
+
+	t.Setenv("BAMF_API_URL", srv.URL)
+
+	creds := &tokenResponse{SessionToken: "tok"}
+	_, err := requestConnect(context.Background(), creds, "web-01", "")
+	require.NoError(t, err)
 }
 
 func TestRequestConnect_Unauthorized(t *testing.T) {

--- a/cmd/bamf/cmd/edgecache.go
+++ b/cmd/bamf/cmd/edgecache.go
@@ -1,0 +1,149 @@
+package cmd
+
+// Client-leg latency probe + cache for measured-latency edge selection (#119).
+// The CLI probes each candidate edge's regional ingress (TCP-connect timing),
+// caches the vector in ~/.bamf/edges.json, and sends it on the next connect so
+// the API can pick the true client+agent rendezvous edge. Probing runs in the
+// background after a tunnel is up — it never blocks or affects the connection.
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"sync"
+	"time"
+)
+
+// EdgeProbeTarget is one edge the CLI should latency-probe, delivered in the
+// connect response. Mirrors the Python EdgeProbeTarget model.
+type EdgeProbeTarget struct {
+	Name      string `json:"name"`
+	ProbeHost string `json:"probe_host"`
+	ProbePort int    `json:"probe_port"`
+}
+
+// edgeCacheTTL is how long a measured client-leg vector stays fresh. Within the
+// window the CLI reuses the cache and skips probing; after it, the next connect
+// triggers a background re-probe.
+const edgeCacheTTL = time.Hour
+
+// edgeProbeTimeout bounds a single edge's TCP-connect probe.
+const edgeProbeTimeout = 3 * time.Second
+
+// edgeRefreshBudget bounds the whole background probe sweep.
+const edgeRefreshBudget = 15 * time.Second
+
+// edgeCache is the on-disk client-leg latency vector (~/.bamf/edges.json).
+type edgeCache struct {
+	MeasuredAt time.Time      `json:"measured_at"`
+	RTTs       map[string]int `json:"rtts"` // edge name → milliseconds
+}
+
+func edgeCachePath() (string, error) {
+	dir, err := bamfDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "edges.json"), nil
+}
+
+// loadFreshEdgeRTTs returns the cached client-leg vector if present and within
+// the TTL, else nil. A cold or stale cache yields nil, so the connect request
+// carries no client legs and the API routes to the agent-nearest guess.
+func loadFreshEdgeRTTs() map[string]int {
+	path, err := edgeCachePath()
+	if err != nil {
+		return nil
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil
+	}
+	var c edgeCache
+	if err := json.Unmarshal(data, &c); err != nil {
+		return nil
+	}
+	if len(c.RTTs) == 0 || time.Since(c.MeasuredAt) > edgeCacheTTL {
+		return nil
+	}
+	return c.RTTs
+}
+
+// writeEdgeCache atomically persists a measured client-leg vector.
+func writeEdgeCache(rtts map[string]int) error {
+	path, err := edgeCachePath()
+	if err != nil {
+		return err
+	}
+	data, err := json.Marshal(edgeCache{MeasuredAt: time.Now(), RTTs: rtts})
+	if err != nil {
+		return err
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		return err
+	}
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0o600); err != nil {
+		return err
+	}
+	return os.Rename(tmp, path)
+}
+
+// probeEdge measures TCP-connect latency to one edge's bridge ingress. Each
+// edge's regional ingress has a distinct address, so connect time is a per-edge
+// client-leg RTT proxy — no TLS/cert handling needed for a latency sample.
+func probeEdge(ctx context.Context, target EdgeProbeTarget) (time.Duration, bool) {
+	addr := net.JoinHostPort(target.ProbeHost, strconv.Itoa(target.ProbePort))
+	dialer := &net.Dialer{Timeout: edgeProbeTimeout}
+	start := time.Now()
+	conn, err := dialer.DialContext(ctx, "tcp", addr)
+	if err != nil {
+		return 0, false
+	}
+	rtt := time.Since(start)
+	_ = conn.Close()
+	return rtt, true
+}
+
+// probeEdges probes all candidates concurrently and returns the measured
+// vector (edges whose probe failed are omitted).
+func probeEdges(ctx context.Context, candidates []EdgeProbeTarget) map[string]int {
+	var (
+		mu   sync.Mutex
+		wg   sync.WaitGroup
+		rtts = make(map[string]int, len(candidates))
+	)
+	for _, target := range candidates {
+		wg.Add(1)
+		go func(t EdgeProbeTarget) {
+			defer wg.Done()
+			if rtt, ok := probeEdge(ctx, t); ok {
+				mu.Lock()
+				rtts[t.Name] = int(rtt.Milliseconds())
+				mu.Unlock()
+			}
+		}(target)
+	}
+	wg.Wait()
+	return rtts
+}
+
+// maybeRefreshEdgeCache re-probes the candidate edges and rewrites the cache,
+// but only when the cache is stale — a warm CLI does not probe on every
+// connect. Safe to run in a detached goroutine after a tunnel is established: it
+// never touches the live connection, and a short-lived CLI that exits before it
+// finishes simply re-probes next time (the self-selecting property that keeps
+// latency work off short sessions).
+func maybeRefreshEdgeCache(candidates []EdgeProbeTarget) {
+	if len(candidates) == 0 || loadFreshEdgeRTTs() != nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), edgeRefreshBudget)
+	defer cancel()
+	if rtts := probeEdges(ctx, candidates); len(rtts) > 0 {
+		_ = writeEdgeCache(rtts)
+	}
+}

--- a/cmd/bamf/cmd/edgecache_test.go
+++ b/cmd/bamf/cmd/edgecache_test.go
@@ -1,0 +1,109 @@
+package cmd
+
+import (
+	"context"
+	"encoding/json"
+	"net"
+	"os"
+	"path/filepath"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestEdgeCache_RoundTripAndTTL(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	// Cold cache → nil.
+	require.Nil(t, loadFreshEdgeRTTs())
+
+	// Write then read back within the TTL.
+	require.NoError(t, writeEdgeCache(map[string]int{"eu": 12, "us": 40}))
+	got := loadFreshEdgeRTTs()
+	require.Equal(t, map[string]int{"eu": 12, "us": 40}, got)
+}
+
+func TestEdgeCache_StaleReturnsNil(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	path, err := edgeCachePath()
+	require.NoError(t, err)
+
+	// Hand-write a cache older than the TTL.
+	stale := edgeCache{MeasuredAt: time.Now().Add(-2 * edgeCacheTTL), RTTs: map[string]int{"eu": 5}}
+	data, err := json.Marshal(stale)
+	require.NoError(t, err)
+	require.NoError(t, os.MkdirAll(filepath.Dir(path), 0o700))
+	require.NoError(t, os.WriteFile(path, data, 0o600))
+
+	require.Nil(t, loadFreshEdgeRTTs())
+}
+
+func TestEdgeCache_EmptyVectorTreatedAsCold(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	require.NoError(t, writeEdgeCache(map[string]int{})) // no measurements
+	require.Nil(t, loadFreshEdgeRTTs())
+}
+
+func TestProbeEdge_MeasuresReachableTarget(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+
+	host, port := splitHostPort(t, ln.Addr().String())
+	rtt, ok := probeEdge(context.Background(), EdgeProbeTarget{Name: "eu", ProbeHost: host, ProbePort: port})
+	require.True(t, ok)
+	require.GreaterOrEqual(t, rtt, time.Duration(0))
+}
+
+func TestProbeEdge_UnreachableFails(t *testing.T) {
+	// Reserved TEST-NET-1 address, filtered — connect will time out/refuse.
+	rtt, ok := probeEdge(context.Background(), EdgeProbeTarget{Name: "x", ProbeHost: "192.0.2.1", ProbePort: 9})
+	require.False(t, ok)
+	require.Zero(t, rtt)
+}
+
+func TestProbeEdges_OmitsFailures(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			c.Close()
+		}
+	}()
+	host, port := splitHostPort(t, ln.Addr().String())
+
+	rtts := probeEdges(context.Background(), []EdgeProbeTarget{
+		{Name: "up", ProbeHost: host, ProbePort: port},
+		{Name: "down", ProbeHost: "192.0.2.1", ProbePort: 9},
+	})
+	_, hasUp := rtts["up"]
+	_, hasDown := rtts["down"]
+	require.True(t, hasUp)
+	require.False(t, hasDown)
+}
+
+func splitHostPort(t *testing.T, addr string) (string, int) {
+	t.Helper()
+	host, portStr, err := net.SplitHostPort(addr)
+	require.NoError(t, err)
+	port, err := strconv.Atoi(portStr)
+	require.NoError(t, err)
+	return host, port
+}

--- a/docs/architecture/edge-deployments.md
+++ b/docs/architecture/edge-deployments.md
@@ -202,21 +202,35 @@ triangle inequality), both legs are **measured**, never inferred from geography.
 For TCP tunnels the API chooses the edge as follows:
 
 1. Resource has `edge` pinned → use that edge.
-2. Otherwise → the edge **nearest the agent** (lowest measured agent-leg RTT)
-   that has bridge capacity. The agent-leg is measured for free from the
-   relay each agent already holds to every edge (its `tls.Dial` handshake
-   latency), reported on heartbeats and cached in Redis.
+2. Otherwise, among edges with bridge capacity, `argmin` of the measured legs:
+   - **both legs** known → the true rendezvous `client-leg + agent-leg`;
+   - only the **agent-leg** (a cold client that hasn't probed yet) → the edge
+     nearest the agent — the *optimistic-connect guess*.
 3. Fallback → the configured default edge, when the agent has no measurements
-   yet or no measured edge has capacity.
+   or no measured edge has capacity.
 
-Step 2 is the **optimistic-connect guess**: the tunnel opens immediately on the
-agent-nearest edge with zero added setup latency. The remaining pieces of the
-edge flagship ([#119](https://github.com/mattrobinsonsre/bamf/issues/119)) —
-the client-leg probe (so the choice becomes the true client+agent rendezvous)
-and a seamless single hop to a better edge discovered in the background — build
-on this without ever blocking connection setup. This measured approach replaces
-the earlier, never-active GeoIP heuristic (geographic distance is a lossy proxy
-for network latency and hard to test).
+**The two legs are measured, never inferred, and gathered independently:**
+
+- **Agent-leg** (`RTT(E, agent)`) is free — each agent already holds a relay to
+  every edge, so its `tls.Dial` handshake latency is a per-edge sample, reported
+  on heartbeats and cached in Redis.
+- **Client-leg** (`RTT(client, E)`) is measured by the CLI: after a tunnel is
+  up, it TCP-probes each candidate edge's regional ingress **in the background**
+  (never blocking the connection), caches the vector in `~/.bamf/edges.json`, and
+  sends it on the next `POST /connect` so the API can compute the true
+  rendezvous. A cold or short-lived client simply routes to the agent-nearest
+  guess — the latency work self-selects onto the long-lived sessions that
+  benefit from it.
+
+The connect response lists the `candidate_edges` (name + a bridge ingress to
+probe) so the CLI knows what to measure; it is empty in single-edge deployments,
+where there is nothing to choose between.
+
+Still to come in the edge flagship
+([#119](https://github.com/mattrobinsonsre/bamf/issues/119)): a seamless single
+hop that migrates a live tunnel to a better edge discovered by the background
+probe. This measured approach replaces the earlier, never-active GeoIP heuristic
+(geographic distance is a lossy proxy for network latency and hard to test).
 
 ## Resource Region Pinning
 

--- a/services/bamf/api/models/connect.py
+++ b/services/bamf/api/models/connect.py
@@ -32,6 +32,19 @@ class ConnectRequest(BAMFBaseModel):
     )
 
 
+class EdgeProbeTarget(BAMFBaseModel):
+    """One edge the client should latency-probe for the client-leg (#119).
+
+    ``probe_host``/``probe_port`` is a reachable bridge ingress in that edge; a
+    TCP-connect to it measures the client→edge leg. The client caches the vector
+    and sends it back as ``client_edge_rtts`` on the next connect.
+    """
+
+    name: str = Field(..., description="Edge name")
+    probe_host: str = Field(..., description="Bridge ingress hostname to probe")
+    probe_port: int = Field(..., description="Bridge ingress port to probe")
+
+
 class ConnectResponse(BAMFBaseModel):
     """Connection response with bridge info and session certificate.
 
@@ -48,3 +61,8 @@ class ConnectResponse(BAMFBaseModel):
     session_id: str = Field(..., description="Session identifier (also in cert SAN)")
     session_expires_at: datetime = Field(..., description="Session certificate expiry")
     resource_type: str = Field(..., description="Type of resource (ssh, postgres, etc.)")
+    candidate_edges: list[EdgeProbeTarget] = Field(
+        default_factory=list,
+        description="Edges the client should latency-probe in the background to "
+        "measure its client-leg (#119). Empty in single-edge deployments.",
+    )

--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -52,7 +52,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from bamf.api.agent_commands import build_tunnel_command, enqueue_agent_command
 from bamf.api.dependencies import get_current_user
-from bamf.api.models.connect import ConnectRequest, ConnectResponse
+from bamf.api.models.connect import ConnectRequest, ConnectResponse, EdgeProbeTarget
 from bamf.auth.ca import get_ca, serialize_certificate, serialize_private_key
 from bamf.auth.sessions import Session
 from bamf.config import settings
@@ -266,6 +266,29 @@ async def _select_edge_for_agent(
         for edge in edges
     ]
     return select_edge(candidates, default_edge=settings.default_edge_name)
+
+
+async def _build_candidate_edges(r: aioredis.Redis, agent_id: str) -> list[EdgeProbeTarget]:
+    """List the edges the client should latency-probe for its client-leg (#119).
+
+    Candidates are the edges the agent relays to (has a measured agent-leg, #246)
+    that also have a live bridge; each carries that bridge's public ingress to
+    TCP-probe. Returns [] when there is fewer than one alternative to probe
+    (single-edge deployments), so a client with one choice never probes.
+    """
+    agent_rtts = await get_agent_edge_rtts(r, agent_id)
+    targets: list[EdgeProbeTarget] = []
+    for edge in sorted(agent_rtts):
+        bridges = await r.zrangebyscore(f"bridges:available:{edge}", "-inf", "+inf", start=0, num=1)
+        if not bridges:
+            continue
+        info = await r.hgetall(f"bridge:{bridges[0]}")
+        host = info.get("hostname")
+        if host:
+            targets.append(
+                EdgeProbeTarget(name=edge, probe_host=host, probe_port=settings.bridge_tunnel_port)
+            )
+    return targets if len(targets) >= 2 else []
 
 
 async def _handle_reconnect(
@@ -620,4 +643,5 @@ async def _issue_session(
         session_id=session_id,
         session_expires_at=expires_at,
         resource_type=resource_type,
+        candidate_edges=await _build_candidate_edges(r, agent_id),
     )

--- a/services/tests/test_api/test_connect_router.py
+++ b/services/tests/test_api/test_connect_router.py
@@ -18,6 +18,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from bamf.api.dependencies import get_current_user
 from bamf.api.routers.connect import (
     NON_MIGRATABLE_PROTOCOLS,
+    _build_candidate_edges,
     _extract_ordinal,
     _select_edge_for_agent,
     _validate_protocol_override,
@@ -482,3 +483,54 @@ class TestSelectEdgeForAgent:
         # candidate (tier 3), provided it has capacity.
         r = _EdgeRedis({}, {"eu": 2})
         assert await _select_edge_for_agent(r, "a1", {"eu": 15}) == "eu"
+
+
+class _CandidateRedis:
+    """Fake Redis for _build_candidate_edges: an agent-leg table, a bridge per
+    edge (bridges:available:{edge}), and each bridge's registered hostname."""
+
+    def __init__(self, agent_rtts: dict[str, int], bridge_hosts: dict[str, str]):
+        # bridge_hosts: edge -> bridge hostname (edge has a live bridge iff present)
+        self._keys = {f"agent:a1:edge_rtt:{e}": str(ms) for e, ms in agent_rtts.items()}
+        self._bridge_hosts = bridge_hosts
+
+    async def scan(self, cursor="0", match=None, count=None):
+        import fnmatch
+
+        return "0", [k for k in self._keys if fnmatch.fnmatch(k, match)]
+
+    async def get(self, key):
+        return self._keys.get(key)
+
+    async def zrangebyscore(self, key, *_args, **_kwargs):
+        edge = key.rsplit(":", 1)[-1]  # bridges:available:{edge}
+        return [f"bridge-{edge}"] if edge in self._bridge_hosts else []
+
+    async def hgetall(self, key):
+        edge = key.removeprefix("bridge:bridge-")  # bridge:bridge-{edge}
+        host = self._bridge_hosts.get(edge)
+        return {"hostname": host} if host else {}
+
+
+@pytest.mark.asyncio
+class TestBuildCandidateEdges:
+    async def test_lists_probe_targets_for_multi_edge(self):
+        r = _CandidateRedis(
+            {"eu": 12, "us": 40},
+            {"eu": "0.bridge.eu.tunnel.example.com", "us": "0.bridge.us.tunnel.example.com"},
+        )
+        targets = await _build_candidate_edges(r, "a1")
+        assert {t.name for t in targets} == {"eu", "us"}
+        eu = next(t for t in targets if t.name == "eu")
+        assert eu.probe_host == "0.bridge.eu.tunnel.example.com"
+        assert eu.probe_port > 0
+
+    async def test_empty_for_single_edge(self):
+        # Nothing to choose between → no probing.
+        r = _CandidateRedis({"eu": 12}, {"eu": "0.bridge.eu.tunnel.example.com"})
+        assert await _build_candidate_edges(r, "a1") == []
+
+    async def test_skips_edges_without_a_live_bridge(self):
+        # us has an agent-leg but no bridge → only eu remains → <2 → [].
+        r = _CandidateRedis({"eu": 12, "us": 40}, {"eu": "0.bridge.eu.tunnel.example.com"})
+        assert await _build_candidate_edges(r, "a1") == []


### PR DESCRIPTION
Closes #254. Completes the client-leg loop of measured-latency edge selection (#119), building on the API acceptance (#253). The CLI now measures its own client-leg and sends it, so the API computes the true `client+agent` rendezvous rather than only the agent-nearest guess.

## Changes

- **API** — the connect response carries **`candidate_edges`** (name + a reachable bridge ingress to probe), built from the edges the agent relays to that have capacity. Empty in single-edge deployments (nothing to choose between).
- **CLI** — after a tunnel is established, a **background** goroutine TCP-probes each candidate edge's regional ingress (distinct per region — no cert handling needed for a latency sample), caches the vector in `~/.bamf/edges.json` (1h TTL, atomic temp+rename write), and sends it as `client_edge_rtts` on the next connect. Cold/stale cache → nothing sent → the API's agent-nearest guess.

## Why it stays off the hot path

Probing runs **after** the tunnel is up and never touches the live connection; a short-lived CLI that exits before it finishes simply re-probes next time. So the latency work self-selects onto the long-lived sessions that actually benefit, and there are **no new round-trips on connect setup**.

## Behaviour

Warm multi-edge client → true rendezvous edge. Cold client or single-edge deployment → unchanged (agent-nearest guess / default).

## Verification

- **Go**: edge-cache round-trip + TTL/empty-vector staleness; `probeEdge` against a live listener and an unreachable host; `probeEdges` omits failures; `requestConnect` sends `client_edge_rtts` from a warm cache (existing `requestConnect` tests hardened with a clean `HOME`). Full `cmd/bamf` `-race` suite + `golangci-lint` (0 issues) + whole-module build.
- **Python**: `_build_candidate_edges` (multi-edge targets, single-edge `[]`, skip-no-bridge). Full suite **1079 passed**, `ruff` 0.15.7 clean.
- Docs (`edge-deployments.md`) updated to the full rendezvous behaviour; strict build + xref + content-hygiene clean.

Remaining #119 work: the seamless single hop (step 4) + the 2-edge E2E smoke.