### PR TITLE
feat(edge): re-home reconnects to the rendezvous edge

### DIFF
--- a/docs/architecture/edge-deployments.md
+++ b/docs/architecture/edge-deployments.md
@@ -226,11 +226,18 @@ The connect response lists the `candidate_edges` (name + a bridge ingress to
 probe) so the CLI knows what to measure; it is empty in single-edge deployments,
 where there is nothing to choose between.
 
+**Reconnects re-home.** When a bridge dies mid-tunnel, the reliable stream
+reconnects through a new bridge (no data loss). That reconnect is already
+re-establishing the tunnel, so it re-selects the edge from the client's warm
+legs — a session that opened cold on the agent-nearest guess lands on the true
+rendezvous edge after its first reconnect, for free.
+
 Still to come in the edge flagship
-([#119](https://github.com/mattrobinsonsre/bamf/issues/119)): a seamless single
-hop that migrates a live tunnel to a better edge discovered by the background
-probe. This measured approach replaces the earlier, never-active GeoIP heuristic
-(geographic distance is a lossy proxy for network latency and hard to test).
+([#119](https://github.com/mattrobinsonsre/bamf/issues/119)): a seamless
+*proactive* hop that migrates a still-healthy long-lived tunnel to a better edge
+the moment the background probe finds one, without waiting for a reconnect. This
+measured approach replaces the earlier, never-active GeoIP heuristic (geographic
+distance is a lossy proxy for network latency and hard to test).
 
 ## Resource Region Pinning
 

--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -359,6 +359,16 @@ async def _handle_reconnect(
             await r.zincrby(f"bridges:available:{edge_name}", -1, old_bridge_id)
         await r.hincrby(f"bridge:{old_bridge_id}", "active_tunnels", -1)
 
+    # Re-home the reconnect to the current best edge (#119, step 4a). The CLI
+    # sends its measured client-leg on every connect, so a reconnect — which is
+    # already re-establishing the tunnel — lands on the true client+agent
+    # rendezvous edge instead of pinning to the edge the session first opened on.
+    # No fresh measurements (or no better edge) → keep the session's prior edge.
+    if request.client_edge_rtts:
+        rehomed_edge = await _select_edge_for_agent(r, agent_id, request.client_edge_rtts)
+        if rehomed_edge:
+            edge_name = rehomed_edge
+
     return await _issue_session(
         db=db,
         r=r,

--- a/services/tests/test_api/test_connect_router.py
+++ b/services/tests/test_api/test_connect_router.py
@@ -428,6 +428,89 @@ class TestReconnect:
 
         assert resp.status_code == 503
 
+    @pytest.mark.asyncio
+    async def test_reconnect_rehomes_to_best_edge_with_client_legs(self, mock_db):
+        from bamf.api.models.connect import ConnectRequest
+        from bamf.api.routers.connect import _handle_reconnect
+
+        session_data = json.dumps(
+            {
+                "user_email": "user@example.com",
+                "resource_name": "web-01",
+                "agent_id": "agent-1",
+                "bridge_id": "bridge-0",
+                "edge_name": "eu",  # session opened on eu
+            }
+        )
+        r = _make_mock_redis()
+
+        async def get_side(key):
+            return "online" if "status" in key else session_data
+
+        r.get = AsyncMock(side_effect=get_side)
+
+        captured = {}
+
+        async def fake_issue(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        req = ConnectRequest(
+            resource_name="web-01",
+            reconnect_session_id="s",
+            client_edge_rtts={"us": 5},
+        )
+        with (
+            patch(
+                "bamf.api.routers.connect._select_edge_for_agent",
+                new=AsyncMock(return_value="us"),
+            ),
+            patch("bamf.api.routers.connect._issue_session", new=fake_issue),
+        ):
+            await _handle_reconnect(req, mock_db, r, USER_SESSION)
+
+        # Reconnect re-homed from eu to the rendezvous edge us.
+        assert captured["edge_name"] == "us"
+
+    @pytest.mark.asyncio
+    async def test_reconnect_keeps_edge_without_client_legs(self, mock_db):
+        from bamf.api.models.connect import ConnectRequest
+        from bamf.api.routers.connect import _handle_reconnect
+
+        session_data = json.dumps(
+            {
+                "user_email": "user@example.com",
+                "resource_name": "web-01",
+                "agent_id": "agent-1",
+                "bridge_id": "bridge-0",
+                "edge_name": "eu",
+            }
+        )
+        r = _make_mock_redis()
+
+        async def get_side(key):
+            return "online" if "status" in key else session_data
+
+        r.get = AsyncMock(side_effect=get_side)
+
+        captured = {}
+
+        async def fake_issue(**kwargs):
+            captured.update(kwargs)
+            return MagicMock()
+
+        req = ConnectRequest(resource_name="web-01", reconnect_session_id="s")
+        sel = AsyncMock(return_value="us")
+        with (
+            patch("bamf.api.routers.connect._select_edge_for_agent", new=sel),
+            patch("bamf.api.routers.connect._issue_session", new=fake_issue),
+        ):
+            await _handle_reconnect(req, mock_db, r, USER_SESSION)
+
+        # No fresh client legs → selector not consulted, prior edge kept.
+        sel.assert_not_awaited()
+        assert captured["edge_name"] == "eu"
+
 
 class _EdgeRedis:
     """Fake Redis for the edge-selection guess: an agent-leg RTT table plus


### PR DESCRIPTION
Closes #256. Step 4a of measured-latency edge selection (#119).

When a bridge dies mid-tunnel, the reliable stream reconnects through a new bridge (no data loss). Today that reconnect pins to the edge the session first opened on. But the CLI already sends its warm client-leg on **every** connect (#255), and a reconnect is *already* re-establishing the tunnel — so it should land on the current `client+agent` rendezvous edge.

## Change

`_handle_reconnect`: when the reconnect carries `client_edge_rtts`, re-select the edge via `_select_edge_for_agent` (same rendezvous logic as a fresh connect) and issue the new bridge there. No fresh measurements / no better edge → keep the session's prior edge (unchanged). **Free re-homing** — the churn of reconnecting is already being paid.

## Scope

Reuses the existing, tested reconnect + reliable-stream path — **no new client plumbing**. A session that opened cold on the agent-nearest guess lands on the true rendezvous edge after its first reconnect.

Deliberately **not** the proactive hop of a *healthy* long-lived session — that (step 4b) needs new concurrency-sensitive CLI plumbing and 2-edge E2E validation, tracked separately.

## Verification

`_handle_reconnect` unit tests: with client legs → re-homes to the re-selected edge; without → selector not consulted, prior edge kept. Full Python suite **1081 passed**, `ruff` 0.15.7 clean, docs strict + xref + content-hygiene clean.