### PR TITLE
feat(edge): hop-decision endpoint + hysteresis (proactive hop, part 1)

### DIFF
--- a/services/bamf/api/models/connect.py
+++ b/services/bamf/api/models/connect.py
@@ -32,6 +32,26 @@ class ConnectRequest(BAMFBaseModel):
     )
 
 
+class ReevaluateRequest(BAMFBaseModel):
+    """Ask whether a live tunnel should hop to a better edge (#260)."""
+
+    session_id: str = Field(..., description="The live tunnel's session id")
+    client_edge_rtts: dict[str, int] = Field(
+        default_factory=dict,
+        description="The client's freshly-measured per-edge latency (ms).",
+    )
+
+
+class ReevaluateResponse(BAMFBaseModel):
+    """The hop decision for a live tunnel."""
+
+    hop_edge: str | None = Field(
+        default=None,
+        description="Edge to migrate the tunnel to, or null to stay put. Applies "
+        "hysteresis — only set when a meaningfully better rendezvous edge exists.",
+    )
+
+
 class EdgeProbeTarget(BAMFBaseModel):
     """One edge the client should latency-probe for the client-leg (#119).
 

--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -52,7 +52,13 @@ from sqlalchemy.ext.asyncio import AsyncSession
 
 from bamf.api.agent_commands import build_tunnel_command, enqueue_agent_command
 from bamf.api.dependencies import get_current_user
-from bamf.api.models.connect import ConnectRequest, ConnectResponse, EdgeProbeTarget
+from bamf.api.models.connect import (
+    ConnectRequest,
+    ConnectResponse,
+    EdgeProbeTarget,
+    ReevaluateRequest,
+    ReevaluateResponse,
+)
 from bamf.auth.ca import get_ca, serialize_certificate, serialize_private_key
 from bamf.auth.sessions import Session
 from bamf.config import settings
@@ -65,6 +71,7 @@ from bamf.services.bridge_routing import resolve_agent_bridge_endpoint
 from bamf.services.edge_selection import (
     EdgeCandidate,
     get_agent_edge_rtts,
+    hop_target,
     select_edge,
 )
 from bamf.services.rbac_service import check_access
@@ -129,6 +136,53 @@ async def connect_to_resource(
     if request.reconnect_session_id:
         return await _handle_reconnect(request, db, r, current_user)
     return await _handle_new_connection(request, db, r, current_user)
+
+
+@router.post("/reevaluate", response_model=ReevaluateResponse)
+async def reevaluate_session_edge(
+    request: ReevaluateRequest,
+    r: aioredis.Redis = Depends(get_redis),
+    current_user: Session = Depends(get_current_user),
+) -> ReevaluateResponse:
+    """Ask whether a live tunnel should proactively hop to a better edge (#260).
+
+    Read-only: computes the current best rendezvous edge from the agent-leg
+    (Redis) and the client's freshly-measured client-leg, and returns a hop
+    target only when it beats the session's current edge by the hysteresis
+    margin. No side effects — the CLI acts on the answer by driving the normal
+    reconnect (which re-homes both ends, #256). The caller enforces hop-once.
+    """
+    raw = await r.get(tunnel_session_key(request.session_id))
+    if not raw:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Session not found or expired",
+        )
+    session_data = json.loads(raw)
+    if session_data.get("user_email") != current_user.email:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Session does not belong to this user",
+        )
+
+    current_edge = session_data.get("edge_name")
+    agent_id = session_data.get("agent_id")
+    if not current_edge or not agent_id:
+        return ReevaluateResponse(hop_edge=None)
+
+    agent_rtts = await get_agent_edge_rtts(r, agent_id)
+    client_rtts = request.client_edge_rtts
+    edges = set(agent_rtts) | set(client_rtts) | {current_edge}
+    candidates = [
+        EdgeCandidate(
+            name=edge,
+            has_capacity=await r.zcard(f"bridges:available:{edge}") > 0,
+            agent_rtt_ms=agent_rtts.get(edge),
+            client_rtt_ms=client_rtts.get(edge),
+        )
+        for edge in edges
+    ]
+    return ReevaluateResponse(hop_edge=hop_target(current_edge, candidates))
 
 
 async def _handle_new_connection(

--- a/services/bamf/services/edge_selection.py
+++ b/services/bamf/services/edge_selection.py
@@ -79,6 +79,59 @@ def select_edge(
     return None
 
 
+# Default hysteresis for a proactive hop: the candidate edge must beat the
+# current edge's rendezvous cost by at least this fraction before it is worth
+# migrating a healthy, working tunnel (#260). Prevents flapping on noisy RTTs.
+DEFAULT_HOP_MARGIN = 0.25
+
+
+def hop_target(
+    current_edge: str,
+    candidates: list[EdgeCandidate],
+    margin: float = DEFAULT_HOP_MARGIN,
+) -> str | None:
+    """Decide whether a *live* tunnel on ``current_edge`` should hop, and where.
+
+    Returns the edge to migrate to, or ``None`` to stay put. Unlike
+    :func:`select_edge` (which always returns the argmin), this applies
+    hysteresis so a healthy connection is only disturbed when the improvement is
+    real: the best rendezvous edge must beat the current edge's
+    ``client + agent`` cost by more than ``margin`` (a fraction, e.g. 0.25 =
+    25%). Costs are only compared when **both** legs are known for the edge in
+    question — the same "never compare a sum against a lone leg" rule as
+    :func:`select_edge`.
+
+    Guardrails this enforces (see #260): never hop to the same edge; never hop
+    for a marginal gain; never hop toward an edge we can't fully cost. Hop-once
+    per session is the caller's responsibility.
+    """
+    best = select_edge(candidates)
+    if best is None or best == current_edge:
+        return None
+
+    by_name = {c.name: c for c in candidates}
+
+    def full_cost(name: str) -> int | None:
+        c = by_name.get(name)
+        if c is None or c.agent_rtt_ms is None or c.client_rtt_ms is None:
+            return None
+        return c.client_rtt_ms + c.agent_rtt_ms
+
+    best_cost = full_cost(best)
+    if best_cost is None:
+        # Can't fully cost the winner (missing a leg) — don't disturb a working
+        # tunnel on a partial signal.
+        return None
+
+    current_cost = full_cost(current_edge)
+    if current_cost is None:
+        # We're on an edge we can't cost (e.g. it lost a leg); the measured best
+        # is strictly better information — hop.
+        return best
+
+    return best if best_cost < current_cost * (1 - margin) else None
+
+
 async def get_agent_edge_rtts(r, agent_id: str) -> dict[str, int]:
     """Read the agent-leg RTT table ``{edge → ms}`` for an agent from Redis.
 

--- a/services/tests/test_api/test_connect_router.py
+++ b/services/tests/test_api/test_connect_router.py
@@ -617,3 +617,68 @@ class TestBuildCandidateEdges:
         # us has an agent-leg but no bridge → only eu remains → <2 → [].
         r = _CandidateRedis({"eu": 12, "us": 40}, {"eu": "0.bridge.eu.tunnel.example.com"})
         assert await _build_candidate_edges(r, "a1") == []
+
+
+class _ReevalRedis:
+    """Fake Redis for the reevaluate endpoint: a session JSON blob, an agent-leg
+    table, and per-edge bridge capacity."""
+
+    def __init__(self, session_json, agent_rtts: dict[str, int], capacity: dict[str, int]):
+        self._session = session_json
+        self._rtt_keys = {f"agent:a1:edge_rtt:{e}": str(ms) for e, ms in agent_rtts.items()}
+        self._capacity = capacity
+
+    async def get(self, key):
+        if key.startswith("session:"):
+            return self._session
+        return self._rtt_keys.get(key)
+
+    async def scan(self, cursor="0", match=None, count=None):
+        import fnmatch
+
+        return "0", [k for k in self._rtt_keys if fnmatch.fnmatch(k, match)]
+
+    async def zcard(self, key):
+        return self._capacity.get(key.rsplit(":", 1)[-1], 0)
+
+
+@pytest.mark.asyncio
+class TestReevaluate:
+    def _session(self, user="user@example.com", edge="eu"):
+        return json.dumps({"user_email": user, "agent_id": "a1", "edge_name": edge})
+
+    async def _call(self, r):
+        from bamf.api.models.connect import ReevaluateRequest
+        from bamf.api.routers.connect import reevaluate_session_edge
+
+        req = ReevaluateRequest(session_id="s", client_edge_rtts={"eu": 50, "us": 20})
+        return await reevaluate_session_edge(req, r, USER_SESSION)
+
+    async def test_hops_when_a_meaningfully_better_edge_exists(self):
+        # eu 50+50=100 vs us 20+20=40 → hop to us.
+        r = _ReevalRedis(self._session(edge="eu"), {"eu": 50, "us": 20}, {"eu": 1, "us": 1})
+        assert (await self._call(r)).hop_edge == "us"
+
+    async def test_stays_when_current_edge_is_best(self):
+        from bamf.api.models.connect import ReevaluateRequest
+        from bamf.api.routers.connect import reevaluate_session_edge
+
+        r = _ReevalRedis(self._session(edge="eu"), {"eu": 10, "us": 50}, {"eu": 1, "us": 1})
+        req = ReevaluateRequest(session_id="s", client_edge_rtts={"eu": 10, "us": 50})
+        assert (await reevaluate_session_edge(req, r, USER_SESSION)).hop_edge is None
+
+    async def test_wrong_user_forbidden(self):
+        from fastapi import HTTPException
+
+        r = _ReevalRedis(self._session(user="other@example.com"), {}, {})
+        with pytest.raises(HTTPException) as exc:
+            await self._call(r)
+        assert exc.value.status_code == 403
+
+    async def test_session_not_found(self):
+        from fastapi import HTTPException
+
+        r = _ReevalRedis(None, {}, {})
+        with pytest.raises(HTTPException) as exc:
+            await self._call(r)
+        assert exc.value.status_code == 404

--- a/services/tests/test_services/test_edge_selection.py
+++ b/services/tests/test_services/test_edge_selection.py
@@ -119,3 +119,47 @@ class TestGetAgentEdgeRTTs:
     async def test_skips_malformed_values(self):
         r = _FakeRedis({"agent:a1:edge_rtt:eu": "not-a-number", "agent:a1:edge_rtt:us": "7"})
         assert await get_agent_edge_rtts(r, "a1") == {"us": 7}
+
+
+class TestHopTarget:
+    def test_stays_when_current_is_already_best(self):
+        from bamf.services.edge_selection import hop_target
+
+        c = [_c("eu", agent=10, client=10), _c("us", agent=50, client=50)]
+        assert hop_target("eu", c) is None
+
+    def test_stays_when_improvement_below_margin(self):
+        from bamf.services.edge_selection import hop_target
+
+        # current eu=100, best us=90 → only 10% better, under the 25% margin.
+        c = [_c("eu", agent=50, client=50), _c("us", agent=45, client=45)]
+        assert hop_target("eu", c, margin=0.25) is None
+
+    def test_hops_when_improvement_exceeds_margin(self):
+        from bamf.services.edge_selection import hop_target
+
+        # current eu=100, best us=40 → 60% better, well over the margin.
+        c = [_c("eu", agent=50, client=50), _c("us", agent=20, client=20)]
+        assert hop_target("eu", c, margin=0.25) == "us"
+
+    def test_stays_when_winner_cannot_be_fully_costed(self):
+        from bamf.services.edge_selection import hop_target
+
+        # us wins on the agent-only tier but has no client leg → don't disturb a
+        # healthy tunnel on a partial signal.
+        c = [_c("eu", agent=50, client=50), _c("us", agent=1)]
+        assert hop_target("eu", c) is None
+
+    def test_hops_when_current_edge_cannot_be_costed(self):
+        from bamf.services.edge_selection import hop_target
+
+        # We're on eu but have no legs for it; us is fully measured → hop.
+        c = [_c("eu"), _c("us", agent=20, client=20)]
+        assert hop_target("eu", c) == "us"
+
+    def test_never_hops_to_an_edge_without_capacity(self):
+        from bamf.services.edge_selection import hop_target
+
+        # us is far cheaper but has no bridge → select_edge excludes it → stay.
+        c = [_c("eu", agent=50, client=50), _c("us", capacity=False, agent=1, client=1)]
+        assert hop_target("eu", c) is None


### PR DESCRIPTION
Closes #261. Part 1 of the seamless proactive edge hop (#260) — the **read-only decision** half. The CLI trigger + the actual migration (reusing the existing, tested reconnect machinery) is part 2.

## Changes

- **`edge_selection.hop_target(current_edge, candidates, margin)`** — a pure function returning the edge to migrate to, or `None` to stay. Unlike `select_edge` (always the argmin), it applies **hysteresis**: the best rendezvous edge must beat the current edge's `client+agent` cost by more than `margin` (default 25%). Never hops to the same edge, for a marginal gain, toward an edge it can't fully cost, or toward one without capacity.
- **`POST /api/v1/connect/reevaluate {session_id, client_edge_rtts}` → `{hop_edge}`** — validates session ownership, builds candidates from the agent-leg (Redis) + the client's fresh client-leg + the current edge, and returns a hop target only when `hop_target` says so. **Read-only, no side effects** — the CLI acts by driving the normal reconnect (which re-homes both ends, #257). Hop-once is the caller's job.

## Why read-only + hysteresis

A proactive hop disturbs a *healthy* connection, so it must fire only when the improvement is real and (part 2) at most once per session. Keeping the decision side-effect-free lets the CLI ask "is it worth it?" without any migration, and trigger the tested reconnect path only on a yes.

## Verification

`hop_target` table (stay-when-best / below-margin / above-margin / uncostable-winner / uncostable-current / no-capacity) + reevaluate endpoint (hop / stay / wrong-user 403 / not-found 404). Full suite **1095 passed**, `ruff` 0.15.7 clean, content-hygiene clean.

Part 2 (CLI trigger) will consume `/reevaluate` and drive the proactive `stream.Reconnect` swap.