### PR TITLE
feat(edge): proactive hop — migrate a healthy tunnel to a better edge

### DIFF
--- a/cmd/bamf/cmd/connect.go
+++ b/cmd/bamf/cmd/connect.go
@@ -59,11 +59,6 @@ func connectBridge(ctx context.Context, resourceName string) (*reconnectingBridg
 		return nil, nil, fmt.Errorf("failed to connect to bridge: %w", err)
 	}
 
-	// Refresh the client-leg latency cache in the background (#119). This never
-	// touches the live tunnel; a short-lived CLI may exit before it finishes,
-	// which is fine — the next connect re-probes.
-	go maybeRefreshEdgeCache(session.CandidateEdges)
-
 	stream := tunnel.NewStream(conn, tunnel.DefaultBufSize)
 
 	rb := &reconnectingBridge{
@@ -74,7 +69,62 @@ func connectBridge(ctx context.Context, resourceName string) (*reconnectingBridg
 		ctx:          ctx,
 	}
 
+	// In the background (#119/#260): measure the client-leg to each candidate
+	// edge, then ask the API whether a meaningfully-better rendezvous edge
+	// exists and, if so, proactively migrate this tunnel there — once. This
+	// never blocks connection setup; a short-lived CLI that exits first simply
+	// doesn't hop, so the cost lands only on long-lived sessions that benefit.
+	go rb.maybeHopToBetterEdge(session.CandidateEdges)
+
 	return rb, session, nil
+}
+
+// maybeHopToBetterEdge probes the candidate edges, consults the API's hop
+// decision, and — at most once per session — proactively migrates this tunnel
+// to a better edge by forcing a re-homing reconnect.
+func (rb *reconnectingBridge) maybeHopToBetterEdge(candidates []EdgeProbeTarget) {
+	// Probe + cache the client-leg (blocks only this goroutine, not the tunnel).
+	maybeRefreshEdgeCache(candidates)
+
+	rtts := loadFreshEdgeRTTs()
+	if len(rtts) == 0 {
+		return
+	}
+
+	rb.mu.Lock()
+	already := rb.hopped
+	sessionID := rb.session.SessionID
+	rb.mu.Unlock()
+	if already {
+		return
+	}
+
+	hopEdge, err := requestReevaluate(rb.ctx, rb.creds, sessionID, rtts)
+	if err != nil || hopEdge == "" {
+		return
+	}
+	rb.hop()
+}
+
+// hop forces a re-homing reconnect (once) to migrate a healthy tunnel to a
+// better edge. It drops the current bridge connection, which the bridge relays
+// to the agent, so both ends reconnect via the normal retransmit path and
+// re-home to the rendezvous edge (the reconnect carries the warm client-leg,
+// #256). No data is lost — unACKed frames are replayed on Reconnect.
+func (rb *reconnectingBridge) hop() {
+	rb.mu.Lock()
+	if rb.hopped || rb.reconnecting {
+		rb.mu.Unlock()
+		return
+	}
+	rb.hopped = true
+	rb.hopping = true
+	rb.mu.Unlock()
+
+	// Break the current connection; Read/Write then return ErrConnLost and the
+	// existing reconnect path (doReconnect) re-homes immediately (attempt 0, no
+	// backoff) using the freshly-cached client-leg.
+	rb.stream.DropConn()
 }
 
 // reconnectingBridge wraps a ReliableStream and handles bridge reconnection
@@ -91,6 +141,8 @@ type reconnectingBridge struct {
 	mu           sync.Mutex
 	reconnecting bool
 	reconnectCh  chan struct{}
+	hopped       bool // proactive edge hop already attempted (hop-once, #260)
+	hopping      bool // the in-progress reconnect is a proactive hop, not a failure
 }
 
 func (rb *reconnectingBridge) Read(p []byte) (int, error) {
@@ -175,7 +227,15 @@ const (
 )
 
 func (rb *reconnectingBridge) doReconnect() error {
-	fmt.Fprintf(os.Stderr, "\nBridge connection lost, reconnecting...\n")
+	rb.mu.Lock()
+	hopping := rb.hopping
+	rb.hopping = false
+	rb.mu.Unlock()
+	if hopping {
+		fmt.Fprintf(os.Stderr, "\nMigrating to a lower-latency edge...\n")
+	} else {
+		fmt.Fprintf(os.Stderr, "\nBridge connection lost, reconnecting...\n")
+	}
 
 	for attempt := range maxReconnectAttempts {
 		if attempt > 0 {
@@ -403,4 +463,49 @@ func requestConnect(ctx context.Context, creds *tokenResponse, resource, reconne
 	}
 
 	return nil, fmt.Errorf("rate limited: max retries exceeded")
+}
+
+// requestReevaluate asks the API whether a live tunnel should proactively hop
+// to a better edge, sending the client's freshly-measured per-edge latency
+// (#260). Returns the edge to migrate to, or "" to stay put. Best-effort: any
+// error yields "" (no hop) so a hiccup never disturbs a working tunnel.
+func requestReevaluate(ctx context.Context, creds *tokenResponse, sessionID string, clientRTTs map[string]int) (string, error) {
+	api := resolveAPIURL()
+	if api == "" {
+		return "", fmt.Errorf("API URL not configured")
+	}
+	u, err := url.Parse(api)
+	if err != nil {
+		return "", err
+	}
+	u.Path = "/api/v1/connect/reevaluate"
+
+	reqData, _ := json.Marshal(map[string]any{
+		"session_id":       sessionID,
+		"client_edge_rtts": clientRTTs,
+	})
+	req, err := http.NewRequestWithContext(ctx, "POST", u.String(), bytes.NewReader(reqData))
+	if err != nil {
+		return "", err
+	}
+	req.Header.Set("Authorization", "Bearer "+creds.SessionToken)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("reevaluate error: %s - %s", resp.Status, string(body))
+	}
+
+	var out struct {
+		HopEdge string `json:"hop_edge"`
+	}
+	if err := json.Unmarshal(body, &out); err != nil {
+		return "", err
+	}
+	return out.HopEdge, nil
 }

--- a/cmd/bamf/cmd/connect_test.go
+++ b/cmd/bamf/cmd/connect_test.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
 
+	"github.com/mattrobinsonsre/bamf/pkg/tunnel"
 	"github.com/stretchr/testify/require"
 )
 
@@ -367,3 +369,91 @@ func (e *errRWC) Write(p []byte) (int, error) {
 	return len(p), nil
 }
 func (e *errRWC) Close() error { return nil }
+
+// ── Tests: reevaluate + proactive edge hop (#260) ────────────────────
+
+func TestRequestReevaluate_ReturnsHopEdge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.Equal(t, "/api/v1/connect/reevaluate", r.URL.Path)
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, "sess-1", body["session_id"])
+		rtts, ok := body["client_edge_rtts"].(map[string]any)
+		require.True(t, ok)
+		require.EqualValues(t, 12, rtts["eu"])
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"hop_edge": "us"}))
+	}))
+	defer srv.Close()
+	t.Setenv("BAMF_API_URL", srv.URL)
+
+	edge, err := requestReevaluate(context.Background(), &tokenResponse{SessionToken: "tok"},
+		"sess-1", map[string]int{"eu": 12})
+	require.NoError(t, err)
+	require.Equal(t, "us", edge)
+}
+
+func TestRequestReevaluate_NullMeansStay(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"hop_edge": nil}))
+	}))
+	defer srv.Close()
+	t.Setenv("BAMF_API_URL", srv.URL)
+
+	edge, err := requestReevaluate(context.Background(), &tokenResponse{}, "s", nil)
+	require.NoError(t, err)
+	require.Equal(t, "", edge)
+}
+
+func TestRequestReevaluate_ErrorYieldsNoHop(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+	t.Setenv("BAMF_API_URL", srv.URL)
+
+	edge, err := requestReevaluate(context.Background(), &tokenResponse{}, "s", nil)
+	require.Error(t, err)
+	require.Equal(t, "", edge)
+}
+
+func TestReconnectingBridge_HopDropsConnOnce(t *testing.T) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	accepted := make(chan net.Conn, 1)
+	go func() { c, _ := ln.Accept(); accepted <- c }()
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	peer := <-accepted
+	defer peer.Close()
+
+	stream := tunnel.NewStream(clientConn, tunnel.DefaultBufSize)
+	defer stream.Close()
+	rb := &reconnectingBridge{
+		stream:  stream,
+		session: &ConnectResponse{SessionID: "s"},
+		ctx:     context.Background(),
+	}
+
+	readErr := make(chan error, 1)
+	go func() { _, err := rb.stream.Read(make([]byte, 8)); readErr <- err }()
+	time.Sleep(20 * time.Millisecond) // let the Read block on the healthy conn
+
+	rb.hop()
+	rb.mu.Lock()
+	require.True(t, rb.hopped)
+	rb.mu.Unlock()
+
+	select {
+	case err := <-readErr:
+		require.ErrorIs(t, err, tunnel.ErrConnLost) // hop dropped the conn → reconnectable break
+	case <-time.After(2 * time.Second):
+		t.Fatal("hop did not drop the connection")
+	}
+
+	// Hop-once: a second hop() is a no-op and must not panic.
+	rb.hop()
+	rb.mu.Lock()
+	require.True(t, rb.hopped)
+	rb.mu.Unlock()
+}

--- a/docs/architecture/edge-deployments.md
+++ b/docs/architecture/edge-deployments.md
@@ -232,12 +232,21 @@ re-establishing the tunnel, so it re-selects the edge from the client's warm
 legs — a session that opened cold on the agent-nearest guess lands on the true
 rendezvous edge after its first reconnect, for free.
 
-Still to come in the edge flagship
-([#119](https://github.com/mattrobinsonsre/bamf/issues/119)): a seamless
-*proactive* hop that migrates a still-healthy long-lived tunnel to a better edge
-the moment the background probe finds one, without waiting for a reconnect. This
-measured approach replaces the earlier, never-active GeoIP heuristic (geographic
-distance is a lossy proxy for network latency and hard to test).
+**Proactive hop.** A still-healthy long-lived tunnel doesn't have to wait for a
+reconnect to benefit. Right after the background probe caches the client-leg,
+the CLI asks the API (`POST /connect/reevaluate`) whether a *meaningfully*
+better rendezvous edge exists — a hysteresis margin (default 25%) so a marginal
+delta never disturbs a working connection. If it does, the CLI migrates once
+(hop-once per session): it drops its bridge connection, the bridge relays the
+break to the agent, and both ends re-home to the better edge through the normal
+reliable-stream reconnect — replaying only unACKed frames, so no data is lost.
+Because the hop is proactive (no failure-detection delay, no backoff), the
+cut-over is a brief sub-second pause, not a stall. Short or cold sessions exit
+before the probe completes and never hop, so the cost falls only on the
+long-lived sessions that gain from it.
+
+This whole measured approach replaces the earlier, never-active GeoIP heuristic
+(geographic distance is a lossy proxy for network latency and hard to test).
 
 ## Resource Region Pinning
 

--- a/pkg/tunnel/reliable.go
+++ b/pkg/tunnel/reliable.go
@@ -454,6 +454,23 @@ func (s *ReliableStream) Close() error {
 	return nil
 }
 
+// DropConn closes the underlying connection WITHOUT shutting down the stream
+// or sending a close frame, so a blocked Read/Write returns ErrConnLost (not
+// ErrClosed) and the caller's reconnect logic re-establishes the tunnel through
+// a new bridge. This is how a healthy tunnel is proactively migrated to a
+// better edge (#260): the bridge relays the break to the peer, so both ends
+// reconnect and resume via the normal retransmit path — no data is lost (any
+// unACKed frames are replayed on Reconnect). No-op on an already-closed stream.
+func (s *ReliableStream) DropConn() {
+	s.connMu.Lock()
+	conn := s.conn
+	closed := s.closed
+	s.connMu.Unlock()
+	if conn != nil && !closed {
+		_ = conn.Close()
+	}
+}
+
 // IsConnLost reports whether the stream's connection is currently broken.
 func (s *ReliableStream) IsConnLost() bool {
 	return s.isConnLost()

--- a/pkg/tunnel/reliable_test.go
+++ b/pkg/tunnel/reliable_test.go
@@ -453,3 +453,28 @@ func TestConcurrentReadWrite(t *testing.T) {
 
 	wg.Wait()
 }
+
+func TestDropConnMakesBlockedReadReturnConnLost(t *testing.T) {
+	// DropConn on a HEALTHY stream must surface ErrConnLost (a reconnectable
+	// break), not ErrClosed — this is what drives the proactive edge hop (#260).
+	connA, _ := tcpPair(t)
+	s := NewStream(connA, DefaultBufSize)
+	t.Cleanup(func() { _ = s.Close() })
+
+	errCh := make(chan error, 1)
+	go func() {
+		_, err := s.Read(make([]byte, 64))
+		errCh <- err
+	}()
+
+	time.Sleep(20 * time.Millisecond) // let the Read block on the (healthy) conn
+	s.DropConn()
+
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, ErrConnLost)
+	case <-time.After(2 * time.Second):
+		t.Fatal("Read did not unblock after DropConn")
+	}
+	require.True(t, s.IsConnLost())
+}


### PR DESCRIPTION
Closes #260. Part 2 (the CLI trigger) of the seamless proactive edge hop, on top of the read-only decision endpoint (#262). This completes the edge flagship #119 — a still-healthy long-lived tunnel now migrates to a better edge **without** waiting for a reconnect.

## Mechanism — reuses the entire tested reconnect path; one new stream primitive

The map of the existing machinery showed `ReliableStream.Reconnect` needs the old conn already broken (it acquires `readMu`, which a Read blocked on a *healthy* conn holds). The elegant consequence: if the CLI simply **closes its own conn**, the bridge's byte-relay `io.Copy` errors and closes the *agent's* conn too — so both ends break and reconnect via the **existing, tested** path, re-homing through 4a's warm client-leg (#257). No new coordination protocol.

- **`pkg/tunnel`: `ReliableStream.DropConn()`** — closes the underlying conn *without* a clean shutdown, so a blocked Read/Write returns `ErrConnLost` (not `ErrClosed`). No data lost — unACKed frames replay on `Reconnect`.
- **CLI**: after the background probe caches the client-leg, `maybeHopToBetterEdge` calls `POST /connect/reevaluate` (server-side hysteresis, #262). On a hop target, `hop()` drops the bridge conn **once per session**; `doReconnect` runs at attempt 0 (no backoff) so the cut-over is a **brief sub-second pause**, not a stall. `requestReevaluate` is best-effort — any error → no hop, so a hiccup never disturbs a working tunnel.

## Honest scope

This is a proactive *fast-swap*, not the theoretical zero-stall make-before-break (which would need a new stream protocol). Deliberate: a one-time sub-second per-session pause, gated by hysteresis + hop-once, isn't worth that risk/complexity. Short/cold sessions exit before the probe completes and never hop — the cost self-selects onto long-lived sessions that benefit.

## Verification

- **Go**: `DropConn` surfaces `ErrConnLost` on a healthy stream (new `pkg/tunnel` test); `requestReevaluate` (hop / null-stay / error→no-hop); `hop()` drops the conn once and is idempotent (hop-once). Full `pkg/tunnel` + `cmd/bamf` `-race` suites + `golangci-lint` (0 issues) + whole-module build. The drop→reconnect→resume-lossless path is covered by the existing reliable-stream reconnect tests (same mechanism).
- Docs (`edge-deployments.md`) updated to describe the live proactive hop; strict build + xref + content-hygiene clean.