### PR TITLE
docs: reflect shipped measured-latency edge selection (pre-release audit for v0.10.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,9 +84,12 @@ BAMF is **MPL-2.0** — no usage restrictions, no feature gating:
 - **Multi-region edge deployments** — deploy proxy+bridge clusters in
   multiple regions with a central API as the single source of truth. Agents
   relay to all edges simultaneously so any edge can serve any resource.
-  Region-pinned resources get stable per-edge URLs; non-pinned resources
-  route through the configured default edge (measured-latency nearest-edge
-  selection is on the roadmap).
+  Non-pinned tunnels are placed by **measured-latency selection**: the API
+  picks the edge that minimizes real `RTT(client,edge) + RTT(edge,agent)` (the
+  rendezvous), opening instantly on the agent-nearest guess and converging as
+  the client's background probe warms; a healthy long-lived tunnel proactively
+  hops once to a better edge without a stall. Region-pinned resources get
+  stable per-edge URLs.
   [Architecture](docs/architecture/edge-deployments.md)
 
 - **Certificate-based trust model** — BAMF CA issues short-lived x509 and SSH

--- a/llms.txt
+++ b/llms.txt
@@ -83,7 +83,11 @@ the repo — no hallucinated endpoints, Helm values, or config keys.
   Redis sliding-window limiter (`core.api.config.rate_limit`) with a strict
   `/auth/*` tier for login brute-force defence.
   [docs/reference/helm-values.md](docs/reference/helm-values.md).
-- **Edge deployments** — data-plane components deployed close to targets.
+- **Edge deployments** — regional proxy+bridge clusters close to targets; the
+  central API places each tunnel on the edge that minimizes measured
+  client→edge + edge→agent latency (the rendezvous), opening on the
+  agent-nearest guess and proactively hopping a long-lived tunnel to a better
+  edge as the client's background probe warms.
   [docs/architecture/edge-deployments.md](docs/architecture/edge-deployments.md).
 
 ## Enabling features (operator quick-reference)


### PR DESCRIPTION
Pre-release audit for **v0.10.0** (the release that ships the edge-selection flagship #119, the M2M split-horizon ingress #239, and the outpost CLI #240 — 18 commits since v0.9.1). Per AGENTS.md, the audit lands its doc fixes before tagging.

Two stale claims caught (audit items A/H — user-visible features must be reflected in `README.md` and `llms.txt`):

- **README** called measured-latency nearest-edge selection "on the roadmap" — it shipped. Rewrote the bullet to describe the real behaviour (rendezvous placement + agent-nearest guess + proactive hop).
- **llms.txt** edge entry was a generic one-liner predating the feature; expanded it so the machine-facing map reflects the capability.

Rest of the audit is clean: `helm lint` (values↔schema in sync), content-hygiene over the whole `v0.9.1..HEAD` diff, no stale hardcoded versions in docs, both vuln-ignore allowlists (trivy, pip-audit) empty. Docs strict build + xref pass.