### PR TITLE
fix(cli): guard rb.session under the mutex in doReconnect (data race)

### DIFF
--- a/cmd/bamf/cmd/connect.go
+++ b/cmd/bamf/cmd/connect.go
@@ -250,7 +250,10 @@ func (rb *reconnectingBridge) doReconnect() error {
 			}
 		}
 
-		newSession, err := requestConnect(rb.ctx, rb.creds, rb.resourceName, rb.session.SessionID)
+		rb.mu.Lock()
+		sessionID := rb.session.SessionID
+		rb.mu.Unlock()
+		newSession, err := requestConnect(rb.ctx, rb.creds, rb.resourceName, sessionID)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Reconnect attempt %d/%d: API error: %v\n",
 				attempt+1, maxReconnectAttempts, err)
@@ -270,7 +273,9 @@ func (rb *reconnectingBridge) doReconnect() error {
 			continue
 		}
 
+		rb.mu.Lock()
 		rb.session = newSession
+		rb.mu.Unlock()
 		fmt.Fprintf(os.Stderr, "Reconnected via %s\n", newSession.BridgeHostname)
 		return nil
 	}


### PR DESCRIPTION
Pre-release adversarial review for v0.10.0 found a data race: `doReconnect` read (`connect.go:253`) and wrote (`connect.go:273`) `rb.session` **without** holding `rb.mu`, while the proactive-hop goroutine `maybeHopToBetterEdge` reads `rb.session.SessionID` **under** `rb.mu` (`connect.go:96`). With only one side locking, the mutex gave zero protection — a real bridge failure's reconnect can run concurrently with the one-shot hop goroutine (which sits up to 15s probing before reading the session id), tripping `go test -race` and being UB per the Go memory model.

Functional impact was low (the session id is invariant across reconnects, so the torn read yields the same value), but a clean `-race` is table stakes for a release.

## Fix

Take `rb.mu` around both the read in the reconnect loop and the `rb.session = newSession` write.

## Verification

`go test -race ./cmd/bamf/...` passes; `golangci-lint` 0 issues; whole-module build.

Part of the v0.10.0 pre-release audit. The review's other findings are low/informational follow-ups (a self-healing `DropConn` TOCTOU that only costs a spurious reconnect, a pre-existing advisory per-edge load-counter drift on global-pool fallback, and a 404-vs-403 session oracle that's unexploitable given 192-bit session ids) — none block the release.