### PR TITLE
feat(edge): measure-then-commit placement for recorded (non-migratable) sessions

### DIFF
--- a/cmd/bamf/cmd/connect.go
+++ b/cmd/bamf/cmd/connect.go
@@ -33,6 +33,10 @@ type ConnectResponse struct {
 	SessionExpiresAt time.Time         `json:"session_expires_at"`
 	ResourceType     string            `json:"resource_type"`
 	CandidateEdges   []EdgeProbeTarget `json:"candidate_edges"`
+	// ProbeRequired means no session was issued: this is a recorded
+	// (non-migratable) resource and the client must probe CandidateEdges and
+	// retry with fresh client_edge_rtts so it lands on the rendezvous edge (#267).
+	ProbeRequired bool `json:"probe_required"`
 }
 
 // connectBridge is the shared tunnel setup: load creds, request session, dial bridge,
@@ -49,7 +53,9 @@ func connectBridge(ctx context.Context, resourceName string) (*reconnectingBridg
 		return nil, nil, fmt.Errorf("credentials expired. Run 'bamf login' to refresh")
 	}
 
-	session, err := requestConnect(ctx, creds, resourceName, "")
+	// bamf tcp / psql / mysql are always migratable, so they keep the optimistic
+	// guess (they hop to correct it) — no probe-then-commit needed here.
+	session, err := requestConnect(ctx, creds, resourceName, "", false)
 	if err != nil {
 		return nil, nil, fmt.Errorf("failed to request session: %w", err)
 	}
@@ -253,7 +259,7 @@ func (rb *reconnectingBridge) doReconnect() error {
 		rb.mu.Lock()
 		sessionID := rb.session.SessionID
 		rb.mu.Unlock()
-		newSession, err := requestConnect(rb.ctx, rb.creds, rb.resourceName, sessionID)
+		newSession, err := requestConnect(rb.ctx, rb.creds, rb.resourceName, sessionID, false)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "Reconnect attempt %d/%d: API error: %v\n",
 				attempt+1, maxReconnectAttempts, err)
@@ -373,7 +379,7 @@ func loadCredentials() (*tokenResponse, error) {
 // requestConnect calls POST /api/v1/connect. If reconnectSessionID is non-empty,
 // it requests reconnection of an existing session through a new bridge.
 // Retries up to 3 times on 429 (rate limited) responses with backoff.
-func requestConnect(ctx context.Context, creds *tokenResponse, resource, reconnectSessionID string) (*ConnectResponse, error) {
+func requestConnect(ctx context.Context, creds *tokenResponse, resource, reconnectSessionID string, probeRetrySupported bool) (*ConnectResponse, error) {
 	api := resolveAPIURL()
 	if api == "" {
 		return nil, fmt.Errorf("API URL not configured. Use --api flag or set BAMF_API_URL")
@@ -390,6 +396,11 @@ func requestConnect(ctx context.Context, creds *tokenResponse, resource, reconne
 	}
 	if reconnectSessionID != "" {
 		reqBody["reconnect_session_id"] = reconnectSessionID
+	}
+	// Declare we can handle a probe_required response, so the API asks us to
+	// measure-then-commit for a recorded (non-migratable) session (#267).
+	if probeRetrySupported {
+		reqBody["probe_retry_supported"] = true
 	}
 	// Send the cached client-leg latency vector (#119) so the API can pick the
 	// true client+agent rendezvous edge. Omitted when the cache is cold or

--- a/cmd/bamf/cmd/connect_extra_test.go
+++ b/cmd/bamf/cmd/connect_extra_test.go
@@ -437,7 +437,7 @@ func TestRequestConnect_RateLimitedExhausted(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	_, err := requestConnect(context.Background(), creds, "res", "")
+	_, err := requestConnect(context.Background(), creds, "res", "", false)
 	require.Error(t, err)
 	// After maxConnectRetries (3) retries are exhausted, the final 429 falls
 	// through to the generic status check which returns "API error: 429 ..."
@@ -460,7 +460,7 @@ func TestRequestConnect_ContextCancellation(t *testing.T) {
 	cancel() // Cancel immediately
 
 	creds := &tokenResponse{SessionToken: "token"}
-	_, err := requestConnect(ctx, creds, "res", "")
+	_, err := requestConnect(ctx, creds, "res", "", false)
 	require.Error(t, err)
 }
 
@@ -474,7 +474,7 @@ func TestRequestConnect_UnexpectedStatusCode(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	_, err := requestConnect(context.Background(), creds, "res", "")
+	_, err := requestConnect(context.Background(), creds, "res", "", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "API error")
 }
@@ -490,7 +490,7 @@ func TestRequestConnect_InvalidResponseJSON(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	_, err := requestConnect(context.Background(), creds, "res", "")
+	_, err := requestConnect(context.Background(), creds, "res", "", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "failed to parse response")
 }
@@ -505,7 +505,7 @@ func TestRequestConnect_ServiceUnavailableInvalidJSON(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	_, err := requestConnect(context.Background(), creds, "res", "")
+	_, err := requestConnect(context.Background(), creds, "res", "", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "service unavailable")
 	require.Contains(t, err.Error(), "not json at all")
@@ -527,7 +527,7 @@ func TestRequestConnect_RateLimitWithRetryAfterHeader(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	result, err := requestConnect(context.Background(), creds, "res", "")
+	result, err := requestConnect(context.Background(), creds, "res", "", false)
 	require.NoError(t, err)
 	require.Equal(t, "success", result.SessionID)
 	require.Equal(t, 2, attempts)

--- a/cmd/bamf/cmd/connect_test.go
+++ b/cmd/bamf/cmd/connect_test.go
@@ -157,7 +157,7 @@ func TestRequestConnect_Success(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "test-token"}
-	result, err := requestConnect(context.Background(), creds, "web-01", "")
+	result, err := requestConnect(context.Background(), creds, "web-01", "", false)
 	require.NoError(t, err)
 	require.Equal(t, "0.bridge.tunnel.example.com", result.BridgeHostname)
 	require.Equal(t, 443, result.BridgePort)
@@ -178,7 +178,7 @@ func TestRequestConnect_WithReconnectSession(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	result, err := requestConnect(context.Background(), creds, "res", "old-session-id")
+	result, err := requestConnect(context.Background(), creds, "res", "old-session-id", false)
 	require.NoError(t, err)
 	require.Equal(t, "old-session-id", result.SessionID)
 }
@@ -201,7 +201,7 @@ func TestRequestConnect_SendsCachedClientEdgeRTTs(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "tok"}
-	_, err := requestConnect(context.Background(), creds, "web-01", "")
+	_, err := requestConnect(context.Background(), creds, "web-01", "", false)
 	require.NoError(t, err)
 }
 
@@ -214,7 +214,7 @@ func TestRequestConnect_Unauthorized(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "expired"}
-	_, err := requestConnect(context.Background(), creds, "res", "")
+	_, err := requestConnect(context.Background(), creds, "res", "", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "session expired")
 }
@@ -228,7 +228,7 @@ func TestRequestConnect_Forbidden(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	_, err := requestConnect(context.Background(), creds, "secret-db", "")
+	_, err := requestConnect(context.Background(), creds, "secret-db", "", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "access denied")
 }
@@ -242,7 +242,7 @@ func TestRequestConnect_NotFound(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	_, err := requestConnect(context.Background(), creds, "nonexistent", "")
+	_, err := requestConnect(context.Background(), creds, "nonexistent", "", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "resource not found")
 }
@@ -263,7 +263,7 @@ func TestRequestConnect_RateLimited(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	result, err := requestConnect(context.Background(), creds, "res", "")
+	result, err := requestConnect(context.Background(), creds, "res", "", false)
 	require.NoError(t, err)
 	require.Equal(t, "ok", result.SessionID)
 	require.Equal(t, 3, attempts)
@@ -279,7 +279,7 @@ func TestRequestConnect_ServiceUnavailable(t *testing.T) {
 	t.Setenv("BAMF_API_URL", srv.URL)
 
 	creds := &tokenResponse{SessionToken: "token"}
-	_, err := requestConnect(context.Background(), creds, "res", "")
+	_, err := requestConnect(context.Background(), creds, "res", "", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "no bridges available")
 }
@@ -295,7 +295,7 @@ func TestRequestConnect_NoAPIURL(t *testing.T) {
 	defer func() { apiURL = oldAPIURL }()
 
 	creds := &tokenResponse{SessionToken: "token"}
-	_, err := requestConnect(context.Background(), creds, "res", "")
+	_, err := requestConnect(context.Background(), creds, "res", "", false)
 	require.Error(t, err)
 	require.Contains(t, err.Error(), "API URL not configured")
 }
@@ -456,4 +456,40 @@ func TestReconnectingBridge_HopDropsConnOnce(t *testing.T) {
 	rb.mu.Lock()
 	require.True(t, rb.hopped)
 	rb.mu.Unlock()
+}
+
+func TestRequestConnect_SendsProbeRetryFlagAndParsesProbeRequired(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		require.Equal(t, true, body["probe_retry_supported"])
+		require.NoError(t, json.NewEncoder(w).Encode(ConnectResponse{
+			ProbeRequired:  true,
+			CandidateEdges: []EdgeProbeTarget{{Name: "eu", ProbeHost: "h", ProbePort: 443}},
+		}))
+	}))
+	defer srv.Close()
+	t.Setenv("BAMF_API_URL", srv.URL)
+
+	resp, err := requestConnect(context.Background(), &tokenResponse{}, "host", "", true)
+	require.NoError(t, err)
+	require.True(t, resp.ProbeRequired)
+	require.Len(t, resp.CandidateEdges, 1)
+}
+
+func TestRequestConnect_OmitsProbeRetryFlagWhenUnsupported(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		_, present := body["probe_retry_supported"]
+		require.False(t, present) // omitted when the caller doesn't support it
+		require.NoError(t, json.NewEncoder(w).Encode(ConnectResponse{SessionID: "s"}))
+	}))
+	defer srv.Close()
+	t.Setenv("BAMF_API_URL", srv.URL)
+
+	_, err := requestConnect(context.Background(), &tokenResponse{}, "host", "", false)
+	require.NoError(t, err)
 }

--- a/cmd/bamf/cmd/pipe.go
+++ b/cmd/bamf/cmd/pipe.go
@@ -60,9 +60,24 @@ func runPipe(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not logged in: %w\nRun 'bamf login' to authenticate", err)
 	}
 
-	session, err := requestConnect(ctx, creds, resourceName, "")
+	// Advertise probe-then-commit: a recorded (ssh-audit) session terminates at
+	// the bridge and can't hop later, so the API may ask us to measure our
+	// client-leg and retry before it commits to an edge (#267).
+	session, err := requestConnect(ctx, creds, resourceName, "", true)
 	if err != nil {
 		return fmt.Errorf("failed to request session: %w", err)
+	}
+	if session.ProbeRequired {
+		// Measure-then-commit: probe the candidate edges, cache the client-leg,
+		// then retry (flag off so we never loop, even if a probe failed — the
+		// API then falls back to the agent-nearest guess).
+		if rtts := probeEdges(ctx, session.CandidateEdges); len(rtts) > 0 {
+			_ = writeEdgeCache(rtts)
+		}
+		session, err = requestConnect(ctx, creds, resourceName, "", false)
+		if err != nil {
+			return fmt.Errorf("failed to request session: %w", err)
+		}
 	}
 
 	if session.ResourceType == "ssh-audit" {

--- a/docs/architecture/edge-deployments.md
+++ b/docs/architecture/edge-deployments.md
@@ -245,6 +245,16 @@ cut-over is a brief sub-second pause, not a stall. Short or cold sessions exit
 before the probe completes and never hop, so the cost falls only on the
 long-lived sessions that gain from it.
 
+**Recorded sessions measure-then-commit instead.** `ssh-audit` sessions
+terminate SSH *at the bridge* (that is where recording happens — deliberately
+outside the audited host's trust domain), which makes them **non-migratable**:
+they cannot hop later. So they flip the strategy — for a cold client on a
+multi-edge deployment, the API returns `probe_required` with the candidate edges
+*instead of* a session; the CLI probes its client-leg and retries, and the
+session is placed on the true rendezvous edge before it commits. This trades a
+little setup latency for a permanent optimal placement, and only for the type
+that has no second chance; migratable sessions keep the optimistic guess.
+
 This whole measured approach replaces the earlier, never-active GeoIP heuristic
 (geographic distance is a lossy proxy for network latency and hard to test).
 

--- a/services/bamf/api/models/connect.py
+++ b/services/bamf/api/models/connect.py
@@ -30,6 +30,13 @@ class ConnectRequest(BAMFBaseModel):
         "with the agent-leg to pick the rendezvous edge. Empty on a cold "
         "client — the API then routes to the agent-nearest edge.",
     )
+    probe_retry_supported: bool = Field(
+        default=False,
+        description="Client can handle a probe_required response: for a "
+        "non-migratable (recorded) session it will probe the returned "
+        "candidate_edges and retry with fresh client_edge_rtts, so the API "
+        "can place the un-hoppable session on the true rendezvous edge (#267).",
+    )
 
 
 class ReevaluateRequest(BAMFBaseModel):
@@ -85,4 +92,11 @@ class ConnectResponse(BAMFBaseModel):
         default_factory=list,
         description="Edges the client should latency-probe in the background to "
         "measure its client-leg (#119). Empty in single-edge deployments.",
+    )
+    probe_required: bool = Field(
+        default=False,
+        description="No session was issued — this is a non-migratable (recorded) "
+        "session and the client must probe candidate_edges and retry the connect "
+        "with fresh client_edge_rtts so it is placed on the rendezvous edge (#267). "
+        "When true, the session fields above are empty placeholders.",
     )

--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -254,6 +254,36 @@ async def _handle_new_connection(
         _validate_protocol_override(request.protocol, original_resource_type)
         resource_type = request.protocol
 
+    # ── 4b. Measure-then-commit for recorded / non-migratable sessions ───
+    # ssh-audit (and web terminal) sessions terminate at the bridge, so they
+    # cannot hop to a better edge later (#260) — a cold client would otherwise be
+    # stuck on the agent-nearest *guess* for the session's whole life. When the
+    # client can retry (probe_retry_supported), ask it to measure its client-leg
+    # and pick the true rendezvous edge before we commit: trade a little setup
+    # latency for a permanent optimal placement. Only fires for a non-pinned,
+    # non-migratable resource with no client-leg yet and ≥2 edges to choose
+    # between; migratable sessions keep the optimistic guess (they hop to fix it).
+    if (
+        request.probe_retry_supported
+        and not resource.edge
+        and resource_type in NON_MIGRATABLE_PROTOCOLS
+        and not request.client_edge_rtts
+    ):
+        candidate_edges = await _build_candidate_edges(r, agent_id)
+        if candidate_edges:  # ≥2 edges (single-edge → nothing to choose → skip)
+            return ConnectResponse(
+                bridge_hostname="",
+                bridge_port=0,
+                session_cert="",
+                session_key="",
+                ca_certificate="",
+                session_id="",
+                session_expires_at=datetime.now(UTC),
+                resource_type=resource_type,
+                candidate_edges=candidate_edges,
+                probe_required=True,
+            )
+
     # ── 5. Determine edge for bridge selection ───────────────────
     # Priority: resource pin > measured agent-nearest guess > default.
     # A non-pinned tunnel opens on the edge nearest the *agent* — the leg we

--- a/services/tests/test_api/test_connect_router.py
+++ b/services/tests/test_api/test_connect_router.py
@@ -52,6 +52,7 @@ def _make_mock_redis():
     r.hincrby = AsyncMock()
     r.hgetall = AsyncMock(return_value={})
     r.zrangebyscore = AsyncMock(return_value=[])
+    r.zcard = AsyncMock(return_value=0)
     r.publish = AsyncMock()
     r.expire = AsyncMock()
     r.scan = AsyncMock(return_value=("0", []))
@@ -682,3 +683,79 @@ class TestReevaluate:
         with pytest.raises(HTTPException) as exc:
             await self._call(r)
         assert exc.value.status_code == 404
+
+
+@pytest.mark.asyncio
+class TestMeasureThenCommit:
+    """Gate: recorded (non-migratable) sessions probe-then-commit rather than
+    open on the un-hoppable guess (#267)."""
+
+    async def _run(self, req, *, resource_type="ssh-audit", edge=None, candidates):
+        from bamf.api.routers.connect import _handle_new_connection
+
+        resource = _mock_resource(resource_type=resource_type, edge=edge)
+        r = _make_mock_redis()
+        r.get = AsyncMock(return_value="online")  # agent status
+
+        async def fake_issue(**kwargs):
+            return MagicMock(probe_required=False, session_id="issued")
+
+        with (
+            patch("bamf.api.routers.connect.get_resource", new=AsyncMock(return_value=resource)),
+            patch("bamf.api.routers.connect.check_access", new=AsyncMock(return_value=True)),
+            patch(
+                "bamf.api.routers.connect._build_candidate_edges",
+                new=AsyncMock(return_value=candidates),
+            ),
+            patch("bamf.api.routers.connect._issue_session", new=fake_issue),
+        ):
+            return await _handle_new_connection(req, AsyncMock(), r, USER_SESSION)
+
+    def _req(self, **kw):
+        from bamf.api.models.connect import ConnectRequest
+
+        return ConnectRequest(resource_name="host", **kw)
+
+    def _two_edges(self):
+        from bamf.api.models.connect import EdgeProbeTarget
+
+        return [
+            EdgeProbeTarget(name="eu", probe_host="0.bridge.eu.example.com", probe_port=443),
+            EdgeProbeTarget(name="us", probe_host="0.bridge.us.example.com", probe_port=443),
+        ]
+
+    async def test_probe_required_for_cold_ssh_audit_multi_edge(self):
+        resp = await self._run(self._req(probe_retry_supported=True), candidates=self._two_edges())
+        assert resp.probe_required is True
+        assert resp.session_id == ""  # no session issued
+        assert {c.name for c in resp.candidate_edges} == {"eu", "us"}
+
+    async def test_no_probe_when_client_legs_already_present(self):
+        # Warm client → already has the client-leg → place directly, no round-trip.
+        resp = await self._run(
+            self._req(probe_retry_supported=True, client_edge_rtts={"eu": 5}),
+            candidates=self._two_edges(),
+        )
+        assert resp.session_id == "issued"
+
+    async def test_no_probe_for_migratable_resource(self):
+        resp = await self._run(
+            self._req(probe_retry_supported=True), resource_type="ssh", candidates=self._two_edges()
+        )
+        assert resp.session_id == "issued"
+
+    async def test_no_probe_for_pinned_resource(self):
+        resp = await self._run(
+            self._req(probe_retry_supported=True), edge="eu", candidates=self._two_edges()
+        )
+        assert resp.session_id == "issued"
+
+    async def test_no_probe_for_single_edge(self):
+        # _build_candidate_edges returns [] when there is nothing to choose between.
+        resp = await self._run(self._req(probe_retry_supported=True), candidates=[])
+        assert resp.session_id == "issued"
+
+    async def test_no_probe_without_capability_flag(self):
+        # Older CLI that can't handle probe_required → old behaviour (the guess).
+        resp = await self._run(self._req(), candidates=self._two_edges())
+        assert resp.session_id == "issued"


### PR DESCRIPTION
Closes #267. The counterpart to the proactive hop (#260), for the session type that *can't* hop.

## Why

`ssh-audit` sessions terminate SSH **at the bridge** — that's where recording happens, deliberately **outside the audited host's trust domain** (the agent runs *on* the host, so it can't be trusted to record itself). That makes them **non-migratable**: no hop to fix a bad edge later. So a cold client would open a recorded session on the agent-nearest *guess* and be stuck there for its whole life.

## Change: flip the strategy for non-migratable sessions

**Measure-then-commit** instead of guess-then-hop, via a small backward-compatible handshake that only fires when needed:
- **CLI** (`bamf pipe`) advertises `probe_retry_supported: true`.
- **API**: for a non-pinned, non-migratable resource with no client-leg yet and **≥2** candidate edges, returns `probe_required: true` + `candidate_edges` **instead of** issuing a session.
- **CLI**: on `probe_required`, probes the candidates, caches the client-leg, and retries (flag off, so it never loops — a failed probe falls back to the guess). The session lands on the true rendezvous edge before it commits.

Only **non-migratable + cold + multi-edge** connects pay the extra round-trips. Migratable sessions (`bamf tcp`/`psql`/`mysql` send the flag false — they hop to correct), warm clients, single-edge deployments, and older CLIs (no capability flag) are all untouched.

## Verification

- **API**: gate returns `probe_required` for ssh-audit + cold + multi-edge + capability; and **not** for migratable / warm / pinned / single-edge / no-capability. Full Python suite **1101 passed**, `ruff` clean.
- **Go**: `requestConnect` sends the flag when supported and omits it otherwise; `ProbeRequired` parses. `cmd/bamf` `-race` suite + `golangci-lint` (0 issues) + whole-module build.
- Contract in sync (`ConnectRequest.probe_retry_supported` ↔ request body; `ConnectResponse.probe_required` ↔ Go `ProbeRequired`). Docs + xref + content-hygiene clean.