### PR TITLE
feat(edge): give bamf ssh the proactive edge hop (only tcp hops today)

### DIFF
--- a/cmd/bamf/cmd/connect_test.go
+++ b/cmd/bamf/cmd/connect_test.go
@@ -493,3 +493,35 @@ func TestRequestConnect_OmitsProbeRetryFlagWhenUnsupported(t *testing.T) {
 	_, err := requestConnect(context.Background(), &tokenResponse{}, "host", "", false)
 	require.NoError(t, err)
 }
+
+func TestMaybeHopToBetterEdge_NoCandidatesColdCacheIsNoop(t *testing.T) {
+	// Single-edge / cold-cache path (e.g. bamf ssh to a single-edge deployment):
+	// no candidates + no cached legs → no probe, no reevaluate, no hop, and the
+	// live connection is left completely untouched.
+	t.Setenv("HOME", t.TempDir()) // cold edge cache
+
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer ln.Close()
+	accepted := make(chan net.Conn, 1)
+	go func() { c, _ := ln.Accept(); accepted <- c }()
+	clientConn, err := net.Dial("tcp", ln.Addr().String())
+	require.NoError(t, err)
+	peer := <-accepted
+	defer peer.Close()
+
+	stream := tunnel.NewStream(clientConn, tunnel.DefaultBufSize)
+	defer stream.Close()
+	rb := &reconnectingBridge{
+		stream:  stream,
+		session: &ConnectResponse{SessionID: "s"},
+		ctx:     context.Background(),
+	}
+
+	rb.maybeHopToBetterEdge(nil) // called synchronously for a deterministic assertion
+
+	rb.mu.Lock()
+	require.False(t, rb.hopped, "must not attempt a hop with no candidates/legs")
+	rb.mu.Unlock()
+	require.False(t, rb.stream.IsConnLost(), "live connection must be untouched")
+}

--- a/cmd/bamf/cmd/pipe.go
+++ b/cmd/bamf/cmd/pipe.go
@@ -115,6 +115,12 @@ func runPipe(cmd *cobra.Command, args []string) error {
 	}
 	defer rb.Close()
 
+	// Plain SSH is migratable, so give it the same background probe + proactive
+	// edge hop that bamf tcp gets (#269) — long-lived interactive SSH is exactly
+	// the session type the hop benefits. (ssh-audit returned above; recorded
+	// sessions are non-migratable and never reach here.)
+	go rb.maybeHopToBetterEdge(session.CandidateEdges)
+
 	// Splice stdin/stdout <-> bridge
 	return splice(ctx, readWriteCloser{os.Stdin, os.Stdout}, rb)
 }


### PR DESCRIPTION
Closes #269. Fixes a gap that undercut the flagship's headline use case.

The proactive hop (#260) is spawned by `connectBridge`, which only `bamf tcp` / `psql` / `mysql` use. `bamf ssh` (via `bamf pipe`) builds its own `reconnectingBridge` inline and never started `maybeHopToBetterEdge` — so a plain SSH session survived bridge death (reliable-stream reconnect) but **never proactively hopped to a better edge**. That's backwards: long-lived interactive SSH is exactly the session type the hop was designed to benefit.

## Change

Spawn the same one-shot background probe + proactive hop in `bamf pipe`'s **plain-ssh** path. `ssh-audit` returns earlier (non-migratable → measure-then-commit, #267), so recorded sessions structurally never reach the hop and are never migrated.

No new mechanism — this wires the **already-tested** hop (`maybeHopToBetterEdge` / `hop` / `DropConn` / `requestReevaluate`, covered by #263) into the ssh path. The hop is transparent to `ssh` for the same reason bridge-death survival already is: the reliable stream preserves the byte stream across the bridge swap.

## Verification

Adds a test that a no-candidate / cold-cache case (single-edge ssh) is a safe **no-op** — no probe, no hop, live connection untouched. Full `cmd/bamf` + `pkg/...` `-race` suites + `golangci-lint` (0 issues) + whole-module build. Content-hygiene clean. Docs unchanged — the "Proactive hop" section already describes it for long-lived tunnels without qualifying tcp-only.