### PR TITLE
fix(tunnel): generation-guard DropConn against a concurrent reconnect

### DIFF
--- a/cmd/bamf/cmd/connect.go
+++ b/cmd/bamf/cmd/connect.go
@@ -129,8 +129,10 @@ func (rb *reconnectingBridge) hop() {
 
 	// Break the current connection; Read/Write then return ErrConnLost and the
 	// existing reconnect path (doReconnect) re-homes immediately (attempt 0, no
-	// backoff) using the freshly-cached client-leg.
-	rb.stream.DropConn()
+	// backoff) using the freshly-cached client-leg. Pass the current connection
+	// generation so that if a real failure's reconnect swapped the connection in
+	// this window, we don't yank the fresh one out from under it (#266).
+	rb.stream.DropConn(rb.stream.ConnID())
 }
 
 // reconnectingBridge wraps a ReliableStream and handles bridge reconnection

--- a/pkg/tunnel/reliable.go
+++ b/pkg/tunnel/reliable.go
@@ -66,6 +66,10 @@ type ReliableStream struct {
 	conn     net.Conn
 	connLost bool
 	closed   bool
+	// connGen identifies the current underlying connection; Reconnect bumps it
+	// on each swap. DropConn uses it to close only the connection the caller
+	// observed, never one a concurrent Reconnect just established (#266).
+	connGen uint64
 
 	// Write path — writeMu serializes ALL writes to conn (data frames and
 	// ACK frames). This prevents interleaved partial writes.
@@ -345,6 +349,7 @@ func (s *ReliableStream) Reconnect(newConn net.Conn) error {
 	oldConn := s.conn
 	s.conn = newConn
 	s.connLost = false
+	s.connGen++
 	s.connMu.Unlock()
 
 	// Close old connection (may already be dead).
@@ -460,15 +465,31 @@ func (s *ReliableStream) Close() error {
 // a new bridge. This is how a healthy tunnel is proactively migrated to a
 // better edge (#260): the bridge relays the break to the peer, so both ends
 // reconnect and resume via the normal retransmit path — no data is lost (any
-// unACKed frames are replayed on Reconnect). No-op on an already-closed stream.
-func (s *ReliableStream) DropConn() {
+// unACKed frames are replayed on Reconnect).
+//
+// id is a connection generation from ConnID: DropConn is a no-op unless the
+// current connection is still that generation, so it never closes a connection
+// a concurrent Reconnect established after the caller decided to drop (#266).
+// Also a no-op on an already-closed stream.
+func (s *ReliableStream) DropConn(id uint64) {
 	s.connMu.Lock()
-	conn := s.conn
-	closed := s.closed
+	var conn net.Conn
+	if s.connGen == id && !s.closed {
+		conn = s.conn
+	}
 	s.connMu.Unlock()
-	if conn != nil && !closed {
+	if conn != nil {
 		_ = conn.Close()
 	}
+}
+
+// ConnID returns an identifier for the current underlying connection. Pass it
+// to DropConn so a proactive drop is ignored if a concurrent Reconnect has
+// swapped the connection in the meantime (#266).
+func (s *ReliableStream) ConnID() uint64 {
+	s.connMu.Lock()
+	defer s.connMu.Unlock()
+	return s.connGen
 }
 
 // IsConnLost reports whether the stream's connection is currently broken.

--- a/pkg/tunnel/reliable_test.go
+++ b/pkg/tunnel/reliable_test.go
@@ -468,7 +468,7 @@ func TestDropConnMakesBlockedReadReturnConnLost(t *testing.T) {
 	}()
 
 	time.Sleep(20 * time.Millisecond) // let the Read block on the (healthy) conn
-	s.DropConn()
+	s.DropConn(s.ConnID())
 
 	select {
 	case err := <-errCh:
@@ -477,4 +477,29 @@ func TestDropConnMakesBlockedReadReturnConnLost(t *testing.T) {
 		t.Fatal("Read did not unblock after DropConn")
 	}
 	require.True(t, s.IsConnLost())
+}
+
+func TestDropConnOnlyClosesMatchingGeneration(t *testing.T) {
+	// A DropConn carrying a generation other than the current one must be a
+	// no-op — this is what stops a proactive hop from closing a connection a
+	// concurrent Reconnect just established (#266).
+	connA, _ := tcpPair(t)
+	s := NewStream(connA, DefaultBufSize)
+	t.Cleanup(func() { _ = s.Close() })
+
+	// Stale/wrong generation → connection untouched.
+	s.DropConn(s.ConnID() + 1)
+	require.False(t, s.IsConnLost())
+
+	// Matching generation → connection dropped (a blocked Read sees ErrConnLost).
+	errCh := make(chan error, 1)
+	go func() { _, err := s.Read(make([]byte, 8)); errCh <- err }()
+	time.Sleep(20 * time.Millisecond)
+	s.DropConn(s.ConnID())
+	select {
+	case err := <-errCh:
+		require.ErrorIs(t, err, ErrConnLost)
+	case <-time.After(2 * time.Second):
+		t.Fatal("matching-generation DropConn did not close the conn")
+	}
 }


### PR DESCRIPTION
Addresses **finding 1** of the pre-release review follow-ups (#266): `reconnectingBridge.hop()` releases `rb.mu` before calling `stream.DropConn()`, so if a real bridge failure's `Reconnect()` swapped the underlying conn in that window, `DropConn` closed the freshly-established connection — a spurious extra reconnect. Self-healing (no data loss), but a genuine logical race in the tunnel hot path.

## Fix

Give the connection a **generation**: `Reconnect` bumps it on each swap, `ConnID()` reads it, and `DropConn(id)` closes the conn **only if it is still that generation**. `hop()` captures the generation and passes it, so a proactive drop becomes a no-op once a concurrent reconnect has already replaced the conn (that reconnect re-homes via the warm client-leg anyway, so the hop's intent is still met).

## Verification

New test: a wrong/stale generation is a no-op (connection untouched); the current generation drops it (a blocked `Read` sees `ErrConnLost`). Existing `DropConn` + hop tests updated. Full `pkg/tunnel` + `cmd/bamf` `-race` suites + `golangci-lint` (0 issues) + whole-module build.

Findings 2 (advisory per-edge load-counter drift) and 3 (404-vs-403 oracle) of #266 remain — both low/informational.