### PR TITLE
fix(edge): store the selected bridge's edge in the session (counter drift)

### DIFF
--- a/services/bamf/api/routers/connect.py
+++ b/services/bamf/api/routers/connect.py
@@ -637,19 +637,28 @@ async def _issue_session(
     }
     if original_resource_type:
         session_info["original_resource_type"] = original_resource_type
-    if edge_name:
-        session_info["edge_name"] = edge_name
+    # Record the edge the SELECTED bridge is actually in, not the requested
+    # edge_name — bridge selection may have fallen back to the global pool when
+    # the requested edge had no capacity (#266). We store EXACTLY what the
+    # per-edge increment below touches (the bridge's own edge, or nothing), so
+    # the reconnect's decrement always lands on the same set. This is also the
+    # edge the tunnel truly lives on (what re-homing / reevaluate compare
+    # against). No fallback to edge_name: adding the bridge to the requested
+    # edge's pool would advertise capacity that isn't there.
+    bridge_edge = bridge_info.get("edge")
+    if bridge_edge:
+        session_info["edge_name"] = bridge_edge
     session_data = json.dumps(session_info)
     await r.setex(tunnel_session_key(session_id), session_ttl, session_data)
 
     # Track session in active set for dashboard queries
     await r.sadd("sessions:active", session_id)
 
-    # Increment new bridge tunnel count.
+    # Increment new bridge tunnel count (per-edge set matches what the session
+    # stored, so the reconnect decrement lands on the same set).
     await r.zincrby("bridges:available", 1, bridge_id)
-    edge = bridge_info.get("edge")
-    if edge:
-        await r.zincrby(f"bridges:available:{edge}", 1, bridge_id)
+    if bridge_edge:
+        await r.zincrby(f"bridges:available:{bridge_edge}", 1, bridge_id)
     await r.hincrby(f"bridge:{bridge_id}", "active_tunnels", 1)
 
     # ── Notify agent via Redis pub/sub ────────────────────────────────

--- a/services/tests/test_api/test_connect_router.py
+++ b/services/tests/test_api/test_connect_router.py
@@ -759,3 +759,71 @@ class TestMeasureThenCommit:
         # Older CLI that can't handle probe_required → old behaviour (the guess).
         resp = await self._run(self._req(), candidates=self._two_edges())
         assert resp.session_id == "issued"
+
+
+@pytest.mark.asyncio
+class TestSessionEdgeConsistency:
+    """The session must record the SELECTED bridge's actual edge so the
+    reconnect decrement matches the connect increment (#266)."""
+
+    async def test_stores_bridge_edge_and_increments_matching_set(
+        self, connect_client, mock_redis, mock_db
+    ):
+        resource = _mock_resource()
+
+        def get_side_effect(key):
+            return "online" if "status" in key else None
+
+        mock_redis.get.side_effect = get_side_effect
+        mock_redis.zrangebyscore.return_value = [("bridge-0", 0)]
+        # The selected bridge actually lives in edge "us" (e.g. bridge selection
+        # fell back to the global pool from a different requested edge).
+        mock_redis.hgetall.return_value = {"hostname": "0.bridge.us.example.com", "edge": "us"}
+        ca = _mock_ca()
+
+        with (
+            patch("bamf.api.routers.connect.get_resource", new=AsyncMock(return_value=resource)),
+            patch("bamf.api.routers.connect.check_access", new=AsyncMock(return_value=True)),
+            patch("bamf.api.routers.connect.get_ca", return_value=ca),
+            patch("bamf.api.routers.connect.serialize_certificate", return_value=b"CERT-PEM"),
+            patch("bamf.api.routers.connect.serialize_private_key", return_value=b"KEY-PEM"),
+            patch("bamf.api.routers.connect.log_audit_event", new=AsyncMock()),
+            patch("bamf.api.routers.connect.settings") as mock_settings,
+            patch(
+                "bamf.services.agent_instances.select_agent_instance",
+                new=AsyncMock(return_value="inst-1"),
+            ),
+            patch("bamf.services.agent_instances.increment_instance_tunnels", new=AsyncMock()),
+        ):
+            mock_settings.target_tunnels_per_pod = 10
+            mock_settings.bridge_tunnel_port = 443
+            mock_settings.bridge_internal_tunnel_port = 8443
+            mock_settings.namespace = "bamf"
+            mock_settings.default_edge_name = None
+
+            resp = await connect_client.post(
+                "/api/v1/connect",
+                json={"resource_name": "web-01"},
+                headers={"Authorization": "Bearer test"},
+            )
+
+        assert resp.status_code == 200
+
+        # The session JSON stored via setex carries the BRIDGE's edge (us).
+        session_writes = [
+            c
+            for c in mock_redis.setex.call_args_list
+            if c.args
+            and str(c.args[0]).startswith("session:")
+            and not str(c.args[0]).endswith(":client_creds")
+        ]
+        assert session_writes, "session was stored"
+        stored = json.loads(session_writes[0].args[2])
+        assert stored["edge_name"] == "us"
+
+        # …and the per-edge increment used that same set — so a later reconnect,
+        # which decrements bridges:available:{stored edge}, lands on it.
+        assert any(
+            c.args and c.args[0] == "bridges:available:us"
+            for c in mock_redis.zincrby.call_args_list
+        ), "per-edge counter incremented on the bridge's actual edge"


### PR DESCRIPTION
Addresses **finding 2** of the pre-release review follow-ups (#266).

`_issue_session` stored the *requested* `edge_name` in the session but incremented the per-edge available-bridge counter using the *selected bridge's* edge (`bridge_info["edge"]`). When bridge selection fell back to the global pool (the requested edge had no capacity), those diverged — so the reconnect, which decrements `bridges:available:{session edge_name}`, missed the set the connect incremented, drifting the advisory per-edge load counters.

## Fix

Store **exactly what the increment touches**: the selected bridge's own edge (or nothing). Now the connect increment and the reconnect decrement always land on the same set, and the session's `edge_name` is the edge the tunnel truly lives on — which is also what reconnect re-homing and `reevaluate` compare against. No fallback to the requested `edge_name` (adding the bridge to that edge's pool would advertise capacity that isn't there).

## Verification

New test: when the selected bridge lives in a different edge than requested, the session records the bridge's edge and the per-edge increment lands on that same set. Full Python suite **1102 passed**, `ruff` clean, content-hygiene clean.

Finding 3 of #266 (404-vs-403 session oracle) remains — informational and unexploitable (192-bit session ids); 403 for a non-owner is arguably the correct status, so I'd lean toward leaving it. That would close out #266.