### PR TITLE
security: sanitize logged untrusted values (CodeQL go/log-injection)

### DIFF
--- a/pkg/agent/relay.go
+++ b/pkg/agent/relay.go
@@ -15,6 +15,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mattrobinsonsre/bamf/pkg/logutil"
 )
 
 // relayPoolSize is the number of concurrent relay connections the agent
@@ -261,8 +263,8 @@ func (rm *RelayManager) serve(w *relayWorker) {
 		// relay conn is dead and the worker exits.
 		if isUpgradeRequest(req) {
 			rm.logger.Info("relay handling upgrade request",
-				"path", req.URL.Path,
-				"upgrade", req.Header.Get("Upgrade"),
+				"path", logutil.Safe(req.URL.Path),
+				"upgrade", logutil.Safe(req.Header.Get("Upgrade")),
 			)
 			// Detach this worker's conn so Close()/Connect() won't
 			// interfere while the splice is running.
@@ -282,7 +284,7 @@ func (rm *RelayManager) serve(w *relayWorker) {
 			// Streaming response (SSE). Detach this worker and let
 			// the stream run in a background goroutine.
 			rm.logger.Info("relay handling streaming response",
-				"path", req.URL.Path,
+				"path", logutil.Safe(req.URL.Path),
 				"content_type", resp.Header.Get("Content-Type"),
 			)
 
@@ -444,7 +446,7 @@ func (rm *RelayManager) handleUpgrade(req *http.Request, relayConn net.Conn) {
 		targetConn, err = net.DialTimeout("tcp", targetAddr, 10*time.Second)
 	}
 	if err != nil {
-		rm.logger.Error("upgrade: target dial failed", "target", targetAddr, "error", err)
+		rm.logger.Error("upgrade: target dial failed", "target", logutil.Safe(targetAddr), "error", err)
 		resp := errorResponse(req, http.StatusBadGateway, "target dial failed: "+err.Error())
 		_ = resp.Write(relayConn)
 		return
@@ -502,7 +504,7 @@ func (rm *RelayManager) handleUpgrade(req *http.Request, relayConn net.Conn) {
 	}
 
 	rm.logger.Info("upgrade: splicing relay ↔ target",
-		"path", outURL.Path,
+		"path", logutil.Safe(outURL.Path),
 		"upgrade", resp.Header.Get("Upgrade"),
 	)
 
@@ -524,7 +526,7 @@ func (rm *RelayManager) handleUpgrade(req *http.Request, relayConn net.Conn) {
 	}()
 	<-done
 
-	rm.logger.Info("upgrade: splice ended", "path", outURL.Path)
+	rm.logger.Info("upgrade: splice ended", "path", logutil.Safe(outURL.Path))
 }
 
 // replenishPool opens new relay connections to bring the pool back up to
@@ -703,7 +705,7 @@ func (rm *RelayManager) forwardRequest(req *http.Request) *http.Response {
 	resp, err := client.Do(outReq)
 	if err != nil {
 		rm.logger.Error("relay forward error",
-			"target", outURL.String(),
+			"target", logutil.Safe(outURL.String()),
 			"error", err,
 		)
 		return errorResponse(req, http.StatusBadGateway, "target error: "+err.Error())

--- a/pkg/apiclient/client.go
+++ b/pkg/apiclient/client.go
@@ -16,12 +16,14 @@ import (
 	"strconv"
 	"sync"
 	"time"
+
+	"github.com/mattrobinsonsre/bamf/pkg/logutil"
 )
 
 const (
-	maxRetries      = 3
-	retryMaxDelay   = 10 * time.Second
-	retryBaseDelay  = 1 * time.Second
+	maxRetries     = 3
+	retryMaxDelay  = 10 * time.Second
+	retryBaseDelay = 1 * time.Second
 )
 
 // Config holds options for creating a Client.
@@ -173,7 +175,7 @@ func (c *Client) do(req *http.Request, response any) error {
 	for attempt := range maxRetries + 1 {
 		c.logger.Debug("API request",
 			"method", req.Method,
-			"path", req.URL.Path,
+			"path", logutil.Safe(req.URL.Path),
 			"attempt", attempt+1,
 		)
 
@@ -197,7 +199,7 @@ func (c *Client) do(req *http.Request, response any) error {
 			c.logger.Warn("rate limited, retrying",
 				"attempt", attempt+1,
 				"delay", delay,
-				"path", req.URL.Path,
+				"path", logutil.Safe(req.URL.Path),
 			)
 
 			// Reset body for retry — http.NewRequest with *bytes.Reader

--- a/pkg/bridge/relay.go
+++ b/pkg/bridge/relay.go
@@ -10,6 +10,8 @@ import (
 	"strings"
 	"sync"
 	"time"
+
+	"github.com/mattrobinsonsre/bamf/pkg/logutil"
 )
 
 const relayIdleTimeout = 5 * time.Minute
@@ -68,7 +70,7 @@ func (p *RelayPool) Add(agentID string, conn net.Conn) {
 	poolSize := len(p.conns[agentID])
 	p.mu.Unlock()
 
-	p.logger.Info("relay connection added", "agent_id", agentID, "pool_size", poolSize)
+	p.logger.Info("relay connection added", "agent_id", logutil.Safe(agentID), "pool_size", poolSize)
 }
 
 // acquire returns an available (unlocked) relay connection for an agent.
@@ -109,7 +111,7 @@ func (p *RelayPool) acquire(agentID string) (*relayConn, bool) {
 		}
 	}
 
-	p.logger.Warn("relay pool acquire timeout", "agent_id", agentID,
+	p.logger.Warn("relay pool acquire timeout", "agent_id", logutil.Safe(agentID),
 		"pool_size", len(conns), "timeout", relayAcquireTimeout)
 	return nil, false
 }
@@ -159,7 +161,7 @@ func (p *RelayPool) Remove(agentID string) {
 		rc.conn.Close()
 	}
 	if len(pool) > 0 {
-		p.logger.Info("relay connections removed", "agent_id", agentID, "count", len(pool))
+		p.logger.Info("relay connections removed", "agent_id", logutil.Safe(agentID), "count", len(pool))
 	}
 }
 
@@ -181,7 +183,7 @@ func (p *RelayPool) Detach(agentID string) *relayConn {
 	}
 	p.mu.Unlock()
 
-	p.logger.Info("relay connection detached for upgrade", "agent_id", agentID)
+	p.logger.Info("relay connection detached for upgrade", "agent_id", logutil.Safe(agentID))
 	return rc
 }
 
@@ -303,7 +305,7 @@ func (p *RelayPool) handleRelayRequest(w http.ResponseWriter, r *http.Request) {
 
 	// Write request to relay connection
 	if err := innerReq.Write(rc.conn); err != nil {
-		p.logger.Error("relay write error", "agent_id", agentID, "error", err)
+		p.logger.Error("relay write error", "agent_id", logutil.Safe(agentID), "error", err)
 		rc.mu.Unlock()
 		http.Error(w, "relay connection error", http.StatusBadGateway)
 		p.removeConn(agentID, rc)
@@ -313,7 +315,7 @@ func (p *RelayPool) handleRelayRequest(w http.ResponseWriter, r *http.Request) {
 	// Read response from relay connection
 	resp, err := http.ReadResponse(rc.reader, innerReq)
 	if err != nil {
-		p.logger.Error("relay read error", "agent_id", agentID, "error", err)
+		p.logger.Error("relay read error", "agent_id", logutil.Safe(agentID), "error", err)
 		rc.mu.Unlock()
 		http.Error(w, "relay connection error", http.StatusBadGateway)
 		p.removeConn(agentID, rc)
@@ -438,7 +440,7 @@ func (p *RelayPool) handleUpgradeResponse(
 	}
 
 	p.logger.Info("upgrade: splicing API ↔ agent relay",
-		"agent_id", agentID,
+		"agent_id", logutil.Safe(agentID),
 		"upgrade", resp.Header.Get("Upgrade"),
 	)
 
@@ -469,5 +471,5 @@ func (p *RelayPool) handleUpgradeResponse(
 
 	apiConn.Close()
 	rc.conn.Close()
-	p.logger.Info("upgrade: splice ended", "agent_id", agentID)
+	p.logger.Info("upgrade: splice ended", "agent_id", logutil.Safe(agentID))
 }

--- a/pkg/logutil/logutil.go
+++ b/pkg/logutil/logutil.go
@@ -1,0 +1,15 @@
+// Package logutil provides helpers for safe structured logging.
+package logutil
+
+import "strings"
+
+// Safe strips carriage returns and line feeds from an untrusted string so it
+// cannot forge or split a log entry (log injection, CWE-117). Values logged as
+// slog fields to the JSON handler are already escaped, but sanitizing at the
+// source is defense-in-depth (correct even under a text handler) and clears the
+// taint flow that code scanning tracks.
+func Safe(s string) string {
+	s = strings.ReplaceAll(s, "\n", "")
+	s = strings.ReplaceAll(s, "\r", "")
+	return s
+}

--- a/pkg/logutil/logutil_test.go
+++ b/pkg/logutil/logutil_test.go
@@ -1,0 +1,18 @@
+package logutil
+
+import "testing"
+
+func TestSafe(t *testing.T) {
+	cases := map[string]string{
+		"plain":              "plain",
+		"with\nnewline":      "withnewline",
+		"carriage\rreturn":   "carriagereturn",
+		"forged\r\nAUDIT ok": "forgedAUDIT ok",
+		"":                   "",
+	}
+	for in, want := range cases {
+		if got := Safe(in); got != want {
+			t.Errorf("Safe(%q) = %q, want %q", in, got, want)
+		}
+	}
+}


### PR DESCRIPTION
Closes #273. Resolves the **14 open `go/log-injection` (CWE-117, medium)** code-scanning alerts.

## Context

The bridge/agent relay path logs network-controlled identifiers (`req.URL.Path`, `Upgrade`/`Content-Type` headers, `agent_id`, target URLs) via `slog`. An attacker controlling such a value could embed CR/LF to forge or split a log line.

The production binaries log via `slog.NewJSONHandler` (`cmd/bamf-{bridge,agent}/main.go`), which escapes control characters — so the injection is **already neutralized for JSON output**. This fix adds source sanitization anyway: defense-in-depth (correct even under a text handler) and it clears the taint flow code scanning tracks.

## Change

- New `pkg/logutil.Safe(s)` — strips CR/LF using the `strings.ReplaceAll` pattern CodeQL recognizes as a log-injection sanitizer. Unit-tested.
- Applied to the flagged values in `pkg/agent/relay.go`, `pkg/bridge/relay.go`, `pkg/apiclient/client.go` (plus a few sibling `agent_id` logs for consistency).

## Verification

`go build ./...`, `pkg/{logutil,agent,bridge,apiclient}` tests, `golangci-lint` (0 issues). The CodeQL run on this PR should close the 14 alerts.

The 1 remaining `py/ineffectual-statement` note (`await task` — a CodeQL false positive; `await` has an effect) is dismissed separately, not code-changed.