### PR TITLE
fix(edge): register co-located bridge into its per-edge available set

### DIFF
--- a/helm/bamf/templates/configmap-api.yaml
+++ b/helm/bamf/templates/configmap-api.yaml
@@ -52,6 +52,18 @@ data:
     m2m_tunnel_domain: {{ .Values.gateway.m2m.tunnelDomain | quote }}
     {{- end }}
 
+    {{- /* Default edge for non-pinned tunnels. When the core and an edge are
+           co-located, default to that edge's name so the co-located bridge
+           bootstraps/registers into its per-edge available set — otherwise
+           measured-latency selection can never pick the co-located edge (#119). */}}
+    {{- $defaultEdge := .Values.core.api.config.default_edge_name }}
+    {{- if and (not $defaultEdge) .Values.core.enabled .Values.edge.enabled .Values.edge.name }}
+    {{- $defaultEdge = .Values.edge.name }}
+    {{- end }}
+    {{- if $defaultEdge }}
+    default_edge_name: {{ $defaultEdge | quote }}
+    {{- end }}
+
     # Bridge headless service for internal relay communication
     bridge_headless_service: {{ printf "%s-bridge-headless" (include "bamf.fullname" .) | quote }}
 

--- a/pkg/bridge/api_client.go
+++ b/pkg/bridge/api_client.go
@@ -79,10 +79,16 @@ func (c *APIClient) RenewCertificate(ctx context.Context) (*RenewResponse, error
 
 // RegisterBridge registers this bridge with the API server.
 // Calls: POST /api/v1/internal/bridges/register
-func (c *APIClient) RegisterBridge(ctx context.Context, bridgeID, hostname string) error {
+func (c *APIClient) RegisterBridge(ctx context.Context, bridgeID, hostname, edgeName string) error {
 	body := map[string]any{
 		"bridge_id": bridgeID,
 		"hostname":  hostname,
+	}
+	// Tell the API which edge this bridge serves so it is added to
+	// bridges:available:{edge} — the per-edge set measured-latency selection
+	// reads (#119). Omitted when unset (single-edge / no edge affinity).
+	if edgeName != "" {
+		body["edge_name"] = edgeName
 	}
 
 	return c.Client.Post(ctx, "/api/v1/internal/bridges/register", body, nil)

--- a/pkg/bridge/api_client_test.go
+++ b/pkg/bridge/api_client_test.go
@@ -89,14 +89,29 @@ func TestBridgeAPIClient_RegisterBridge(t *testing.T) {
 		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
 		require.Equal(t, "bridge-1", body["bridge_id"])
 		require.Equal(t, "1.bridge.tunnel.bamf.local", body["hostname"])
+		require.Equal(t, "eu", body["edge_name"]) // edge sent → per-edge registration (#119)
 
 		w.WriteHeader(http.StatusOK)
 	}))
 	defer srv.Close()
 
 	c := NewAPIClient(srv.URL, slog.Default())
-	err := c.RegisterBridge(context.Background(), "bridge-1", "1.bridge.tunnel.bamf.local")
+	err := c.RegisterBridge(context.Background(), "bridge-1", "1.bridge.tunnel.bamf.local", "eu")
 	require.NoError(t, err)
+}
+
+func TestBridgeAPIClient_RegisterBridge_OmitsEmptyEdge(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var body map[string]any
+		require.NoError(t, json.NewDecoder(r.Body).Decode(&body))
+		_, present := body["edge_name"]
+		require.False(t, present) // omitted when the bridge has no edge affinity
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer srv.Close()
+
+	c := NewAPIClient(srv.URL, slog.Default())
+	require.NoError(t, c.RegisterBridge(context.Background(), "bridge-1", "h", ""))
 }
 
 func TestBridgeAPIClient_UpdateBridgeStatus(t *testing.T) {

--- a/pkg/bridge/config.go
+++ b/pkg/bridge/config.go
@@ -30,9 +30,11 @@ type Config struct {
 	DataDir string // Directory for certificate storage
 
 	// Bridge identification
-	BridgeID  string // Unique identifier for this bridge instance (e.g., "bamf-bridge-0")
-	Ordinal   int    // StatefulSet ordinal extracted from pod name (e.g., 0, 1, 2)
-	Hostname  string // Public SNI hostname for this bridge (e.g., "bridge-0.tunnel.bamf.local")
+	BridgeID string // Unique identifier for this bridge instance (e.g., "bamf-bridge-0")
+	Ordinal  int    // StatefulSet ordinal extracted from pod name (e.g., 0, 1, 2)
+	Hostname string // Public SNI hostname for this bridge (e.g., "bridge-0.tunnel.bamf.local")
+	EdgeName string // Edge this bridge belongs to; sent on register so the API
+	//        adds it to bridges:available:{edge} for measured-latency selection (#119)
 
 	// Timeouts
 	TunnelSetupTimeout time.Duration // Max time to establish tunnel
@@ -61,6 +63,7 @@ func LoadConfig() (*Config, error) {
 
 		BridgeID: getEnvOrDefault("BAMF_BRIDGE_ID", ""),
 		Hostname: getEnvOrDefault("BAMF_HOSTNAME", ""),
+		EdgeName: getEnvOrDefault("BAMF_EDGE_NAME", ""),
 
 		TunnelSetupTimeout: getDurationEnvOrDefault("BAMF_TUNNEL_SETUP_TIMEOUT", 30*time.Second),
 		IdleTimeout:        getDurationEnvOrDefault("BAMF_IDLE_TIMEOUT", 0),

--- a/pkg/bridge/server.go
+++ b/pkg/bridge/server.go
@@ -517,7 +517,7 @@ func (s *Server) handleReady(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *Server) registerWithAPI(ctx context.Context) error {
-	return s.apiClient.RegisterBridge(ctx, s.cfg.BridgeID, s.cfg.Hostname)
+	return s.apiClient.RegisterBridge(ctx, s.cfg.BridgeID, s.cfg.Hostname, s.cfg.EdgeName)
 }
 
 func (s *Server) notifyDraining(ctx context.Context) error {


### PR DESCRIPTION
## Summary

Found by the live Tilt smoke of the edge-selection flagship (#119): on the running stack `bridges:available:local` was **empty** and `bridge:bamf-bridge-0` had `edge: ""`. The co-located bridge only ever joined the **global** `bridges:available` set, never its per-edge set.

Candidate selection gates each edge on `zcard bridges:available:{edge}` (`_build_candidate_edges` / `_select_edge_for_agent`). An edge with an empty per-edge set counts as having no capacity and is filtered out — so **measured-latency selection could never pick the co-located edge**, leaving the whole feature inert in practice. Unit tests can't catch this; they mock the per-edge set as populated.

## Root causes (both fixed)

1. **Bridge never sent its edge on register.** Helm passes `BAMF_EDGE_NAME` to the bridge pod, but the Go config never read it and `RegisterBridge` never sent it, so `POST /internal/bridges/register` always saw an empty edge and skipped the per-edge `zadd`. (Propagating via the bootstrap response wouldn't help — bootstrap is skipped once the cert is cached.) The bridge now reads `BAMF_EDGE_NAME`; `RegisterBridge` sends `edge_name`, omitted when unset so single-edge/no-affinity behaviour is unchanged.
2. **`default_edge_name` was `None`** for the co-located deployment — the chart never defaulted it. `configmap-api.yaml` now defaults `default_edge_name` to `edge.name` when core and an edge are co-located.

## Test / verification

- `pkg/bridge` unit tests updated: `TestBridgeAPIClient_RegisterBridge` asserts `edge_name` is sent; new `TestBridgeAPIClient_RegisterBridge_OmitsEmptyEdge` asserts it's absent when unset.
- `helm lint ./helm/bamf` clean; `configmap-api.yaml` renders `default_edge_name: "local"` for the co-located profile.
- **Verified live on the Tilt stack**: after the fix, `bridges:available:local` populates and `bridge:bamf-bridge-0` carries `edge: local`.

closes #275