### PR TITLE
fix(edge): probe every edge for the agent-leg, not just web-app relays

### DIFF
--- a/pkg/agent/agent.go
+++ b/pkg/agent/agent.go
@@ -7,8 +7,10 @@ import (
 	"crypto/x509"
 	"fmt"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
+	"strconv"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -46,6 +48,15 @@ type Agent struct {
 	relays   map[string]*RelayManager
 	relaysMu sync.Mutex
 
+	// Agent-leg edge probing (#277). The heartbeat response lists the edges to
+	// probe; the agent TCP-times each bridge endpoint and records the RTT here,
+	// then reports them as edge_rtts on the next heartbeat. This populates the
+	// agent-leg table for every agent — not only those holding a web-app relay,
+	// which is the only thing that ever produced a relay RTT before.
+	probedRTTs map[string]int
+	probeMu    sync.Mutex
+	probing    atomic.Bool // guards against overlapping probe batches
+
 	// Metrics
 	sseConnected atomic.Bool // true when SSE connection is active
 
@@ -73,6 +84,7 @@ func New(cfg *Config, logger *slog.Logger) (*Agent, error) {
 		instanceID: generateInstanceID(),
 		tunnels:    make(map[string]*TunnelHandler),
 		relays:     make(map[string]*RelayManager),
+		probedRTTs: make(map[string]int),
 		shutdownCh: make(chan struct{}),
 	}
 
@@ -315,23 +327,84 @@ func (a *Agent) loadCertificates(ctx context.Context) error {
 // active tunnel count (for self-correcting Redis tunnel counts on drift), and
 // the measured agent→edge relay latencies (the agent-leg table, #246).
 func (a *Agent) sendHeartbeat(ctx context.Context) error {
-	return a.apiClient.Heartbeat(ctx, a.agentID, a.cfg.Resources, a.cfg.Labels, a.cfg.ClusterInternal, a.cfg.Zone, a.instanceID, a.ActiveTunnelCount(), a.edgeRTTs())
+	targets, err := a.apiClient.Heartbeat(ctx, a.agentID, a.cfg.Resources, a.cfg.Labels, a.cfg.ClusterInternal, a.cfg.Zone, a.instanceID, a.ActiveTunnelCount(), a.edgeRTTs())
+	if err != nil {
+		return err
+	}
+	// Probe the edges the API asked us to, off the heartbeat path so a slow or
+	// unreachable edge never delays the next heartbeat. The single-flight guard
+	// drops a new batch if the previous one is still running.
+	if len(targets) > 0 && a.probing.CompareAndSwap(false, true) {
+		go func() {
+			defer a.probing.Store(false)
+			a.probeEdges(ctx, targets)
+		}()
+	}
+	return nil
+}
+
+// edgeProbeTimeout bounds a single edge probe. A probe is one TCP connect, so
+// this only needs to cover network round-trips, not a full handshake.
+const edgeProbeTimeout = 3 * time.Second
+
+// probeEdges TCP-times each edge's bridge endpoint and records the result as
+// the agent-leg RTT for that edge (#277): connect, measure, drop — no
+// persistent connection. Results are reported as edge_rtts on the next
+// heartbeat. Edges that fail to probe are left untouched (their prior sample,
+// if any, ages out with the agent TTL on the API side).
+func (a *Agent) probeEdges(ctx context.Context, targets []AgentEdgeProbeTarget) {
+	for _, t := range targets {
+		rtt, err := probeEdgeRTT(ctx, net.JoinHostPort(t.Host, strconv.Itoa(t.Port)))
+		if err != nil {
+			a.logger.Debug("edge probe failed", "edge", t.Edge, "host", t.Host, "port", t.Port, "err", err)
+			continue
+		}
+		a.probeMu.Lock()
+		a.probedRTTs[t.Edge] = int(rtt.Milliseconds())
+		a.probeMu.Unlock()
+	}
+}
+
+// probeEdgeRTT measures the TCP connect time to addr — a proxy for the
+// agent→edge network latency. It deliberately does not complete a TLS or bridge
+// handshake; the bridge/ingress sees a connection that opens and immediately
+// closes.
+func probeEdgeRTT(ctx context.Context, addr string) (time.Duration, error) {
+	dctx, cancel := context.WithTimeout(ctx, edgeProbeTimeout)
+	defer cancel()
+	var d net.Dialer
+	start := time.Now()
+	conn, err := d.DialContext(dctx, "tcp", addr)
+	if err != nil {
+		return 0, err
+	}
+	rtt := time.Since(start)
+	_ = conn.Close()
+	return rtt, nil
 }
 
 // edgeRTTs snapshots each edge relay's smoothed latency in milliseconds,
 // keyed by edge name. Only edges with at least one dial sample are included.
 func (a *Agent) edgeRTTs() map[string]int {
-	a.relaysMu.Lock()
-	defer a.relaysMu.Unlock()
-	if len(a.relays) == 0 {
-		return nil
+	rtts := make(map[string]int)
+
+	// Probe samples cover every edge the API asked us to measure (#277).
+	a.probeMu.Lock()
+	for edge, ms := range a.probedRTTs {
+		rtts[edge] = ms
 	}
-	rtts := make(map[string]int, len(a.relays))
+	a.probeMu.Unlock()
+
+	// A live relay's own dial EWMA is a stronger signal for edges we hold one
+	// to, so let it override the probe sample for those edges.
+	a.relaysMu.Lock()
 	for edge, rl := range a.relays {
 		if rtt, ok := rl.RTT(); ok {
 			rtts[edge] = int(rtt.Milliseconds())
 		}
 	}
+	a.relaysMu.Unlock()
+
 	if len(rtts) == 0 {
 		return nil
 	}

--- a/pkg/agent/api_client.go
+++ b/pkg/agent/api_client.go
@@ -93,10 +93,13 @@ type heartbeatRequest struct {
 }
 
 // Heartbeat sends a heartbeat to the API with the agent's current
-// resources, labels, cluster_internal flag, instance identifier, and
-// active tunnel count (for self-correcting Redis tunnel counts).
+// resources, labels, cluster_internal flag, instance identifier, active tunnel
+// count (for self-correcting Redis tunnel counts), and measured agent→edge
+// RTTs. It returns the edges the API wants the agent to latency-probe for its
+// agent-leg (#277) — the caller probes them and reports the RTTs on the next
+// heartbeat.
 // Calls: POST /api/v1/agents/{id}/heartbeat
-func (c *APIClient) Heartbeat(ctx context.Context, agentID string, resources []ResourceConfig, labels map[string]string, clusterInternal bool, zone string, instanceID string, activeTunnels int, edgeRTTs map[string]int) error {
+func (c *APIClient) Heartbeat(ctx context.Context, agentID string, resources []ResourceConfig, labels map[string]string, clusterInternal bool, zone string, instanceID string, activeTunnels int, edgeRTTs map[string]int) ([]AgentEdgeProbeTarget, error) {
 	hbResources := make([]heartbeatResource, len(resources))
 	for i, r := range resources {
 		hbResources[i] = heartbeatResource{
@@ -122,7 +125,32 @@ func (c *APIClient) Heartbeat(ctx context.Context, agentID string, resources []R
 		EdgeRTTs:        edgeRTTs,
 	}
 
-	return c.Client.Post(ctx, fmt.Sprintf("/api/v1/agents/%s/heartbeat", agentID), body, nil)
+	var resp heartbeatResponse
+	if err := c.Client.Post(ctx, fmt.Sprintf("/api/v1/agents/%s/heartbeat", agentID), body, &resp); err != nil {
+		return nil, err
+	}
+	return resp.EdgeProbeTargets, nil
+}
+
+// AgentEdgeProbeTarget is one edge the agent should latency-probe to measure
+// its agent-leg (#277). The agent TCP-times a connect to (Host, Port) — the
+// agent-reachable endpoint of a live bridge in that edge — and reports the
+// result as edge_rtts on its next heartbeat. This populates the agent-leg
+// table for every agent (SSH/TCP-only included), decoupling the measurement
+// from web-app relays.
+//
+// CONTRACT: services/bamf/api/routers/agents.py AgentEdgeProbeTarget.
+type AgentEdgeProbeTarget struct {
+	Edge string `json:"edge"`
+	Host string `json:"host"`
+	Port int    `json:"port"`
+}
+
+// heartbeatResponse matches Python AgentHeartbeatResponse
+// (services/bamf/api/routers/agents.py).
+type heartbeatResponse struct {
+	Message          string                 `json:"message"`
+	EdgeProbeTargets []AgentEdgeProbeTarget `json:"edge_probe_targets"`
 }
 
 // DrainInstance notifies the API that this instance is draining (shutting down).

--- a/pkg/agent/api_client_test.go
+++ b/pkg/agent/api_client_test.go
@@ -78,7 +78,15 @@ func TestAPIClient_Heartbeat(t *testing.T) {
 		// Agent-leg RTT table serializes as edge_rtts (#246 contract).
 		require.Equal(t, map[string]int{"eu": 12, "us-east": 40}, body.EdgeRTTs)
 
+		// The response carries the edges to probe for the agent-leg (#277).
 		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{
+			"message": "OK",
+			"edge_probe_targets": []map[string]any{
+				{"edge": "eu", "host": "0.bridge.eu.tunnel.example.com", "port": 443},
+				{"edge": "us-east", "host": "bamf-bridge-0.bamf.svc.cluster.local", "port": 8443},
+			},
+		}))
 	}))
 	defer srv.Close()
 
@@ -92,8 +100,12 @@ func TestAPIClient_Heartbeat(t *testing.T) {
 			Labels:       map[string]string{"env": "prod"},
 		},
 	}
-	err := c.Heartbeat(context.Background(), "agent-123", resources, map[string]string{"env": "prod"}, true, "internal", "inst-1", 3, map[string]int{"eu": 12, "us-east": 40})
+	targets, err := c.Heartbeat(context.Background(), "agent-123", resources, map[string]string{"env": "prod"}, true, "internal", "inst-1", 3, map[string]int{"eu": 12, "us-east": 40})
 	require.NoError(t, err)
+	require.Equal(t, []AgentEdgeProbeTarget{
+		{Edge: "eu", Host: "0.bridge.eu.tunnel.example.com", Port: 443},
+		{Edge: "us-east", Host: "bamf-bridge-0.bamf.svc.cluster.local", Port: 8443},
+	}, targets)
 }
 
 func TestAPIClient_DrainInstance(t *testing.T) {
@@ -173,7 +185,7 @@ func TestAPIClient_Heartbeat_WithWebhooks(t *testing.T) {
 		require.Len(t, body.Resources[0].Webhooks, 1)
 		require.Equal(t, "/webhook", body.Resources[0].Webhooks[0].Path)
 		require.Equal(t, []string{"POST"}, body.Resources[0].Webhooks[0].Methods)
-		w.WriteHeader(http.StatusOK)
+		require.NoError(t, json.NewEncoder(w).Encode(map[string]any{"message": "OK"}))
 	}))
 	defer srv.Close()
 
@@ -190,6 +202,8 @@ func TestAPIClient_Heartbeat_WithWebhooks(t *testing.T) {
 			},
 		},
 	}
-	err := c.Heartbeat(context.Background(), "agent-1", resources, nil, false, "", "inst-1", 0, nil)
+	// No edges available → empty target list, agent probes nothing.
+	targets, err := c.Heartbeat(context.Background(), "agent-1", resources, nil, false, "", "inst-1", 0, nil)
 	require.NoError(t, err)
+	require.Empty(t, targets)
 }

--- a/services/bamf/api/bridge_relay.py
+++ b/services/bamf/api/bridge_relay.py
@@ -181,3 +181,44 @@ def build_bridge_relay_host(relay_bridge: str) -> str:
     """Return the FQDN of a bridge pod's internal relay endpoint."""
     headless_svc = settings.bridge_headless_service
     return f"{relay_bridge}.{headless_svc}.{settings.namespace}.svc.cluster.local"
+
+
+async def build_agent_edge_probe_targets(r, agent_id: str) -> list[tuple[str, str, int]]:
+    """Edges the agent should latency-probe to measure its agent-leg (#277).
+
+    Returns ``(edge, host, port)`` for every edge that has a live bridge, where
+    ``(host, port)`` is the agent-reachable endpoint of that edge's least-loaded
+    bridge (resolved per the agent's network zone, exactly as a real relay/tunnel
+    dial would be). The agent TCP-times each and reports it as ``edge_rtts`` on
+    its next heartbeat.
+
+    This decouples the agent-leg measurement from web-app relays: before, an
+    RTT only existed for edges the agent happened to hold a relay to, so
+    SSH/DB/TCP-only and idle agents measured nothing and measured-latency
+    selection silently fell back to the default edge. Now every online agent
+    measures every reachable edge.
+    """
+    prefix = "bridges:available:"
+    targets: list[tuple[str, str, int]] = []
+    seen: set[str] = set()
+    cursor = "0"
+    while True:
+        cursor, keys = await r.scan(cursor=cursor, match=f"{prefix}*", count=50)
+        for key in keys:
+            edge = key[len(prefix) :]
+            if not edge or edge in seen:
+                continue
+            seen.add(edge)
+            bridges = await r.zrangebyscore(key, "-inf", "+inf", start=0, num=1)
+            if not bridges:
+                continue
+            bridge_id = bridges[0]
+            info = await r.hgetall(f"bridge:{bridge_id}")
+            hostname = info.get("hostname")
+            if not hostname:
+                continue
+            host, port = await resolve_agent_bridge_endpoint(r, agent_id, bridge_id, hostname)
+            targets.append((edge, host, port))
+        if cursor == 0 or cursor == "0":
+            break
+    return targets

--- a/services/bamf/api/routers/agents.py
+++ b/services/bamf/api/routers/agents.py
@@ -34,6 +34,7 @@ from sqlalchemy.ext.asyncio import AsyncSession
 from starlette.responses import StreamingResponse
 
 from bamf.api.agent_commands import command_queue_key, enqueue_agent_command
+from bamf.api.bridge_relay import build_agent_edge_probe_targets
 from bamf.api.dependencies import (
     AgentIdentity,
     get_agent_identity,
@@ -177,6 +178,32 @@ class AgentHeartbeatRequest(BAMFBaseModel):
     edge_rtts: dict[str, int] = Field(default_factory=dict)
 
 
+class AgentEdgeProbeTarget(BAMFBaseModel):
+    """One edge the agent should latency-probe for its agent-leg (#277).
+
+    ``host``/``port`` is the agent-reachable endpoint of a live bridge in that
+    edge. The agent TCP-times a connect to it and reports the result as
+    ``edge_rtts`` on its next heartbeat, so the agent-leg table populates for
+    every agent — not only those holding a web-app relay.
+
+    Go contract: AgentEdgeProbeTarget in pkg/agent/api_client.go.
+    """
+
+    edge: str = Field(..., description="Edge name")
+    host: str = Field(..., description="Agent-reachable bridge host to probe")
+    port: int = Field(..., description="Bridge tunnel port to probe")
+
+
+class AgentHeartbeatResponse(BAMFBaseModel):
+    """Heartbeat response: the edges the agent should probe (#277).
+
+    Go contract: heartbeatResponse in pkg/agent/api_client.go.
+    """
+
+    message: str = "OK"
+    edge_probe_targets: list[AgentEdgeProbeTarget] = Field(default_factory=list)
+
+
 class AgentDrainRequest(BAMFBaseModel):
     """Request to mark an agent instance as draining.
 
@@ -307,14 +334,14 @@ async def join_agent(
 # ── Agent Heartbeat & Status ────────────────────────────────────────────
 
 
-@router.post("/{agent_id}/heartbeat", response_model=SuccessResponse)
+@router.post("/{agent_id}/heartbeat", response_model=AgentHeartbeatResponse)
 async def agent_heartbeat(
     agent_id: str,
     body: AgentHeartbeatRequest | None = None,
     db: AsyncSession = Depends(get_db),
     r: aioredis.Redis = Depends(get_redis),
     agent_identity: AgentIdentity = Depends(get_agent_identity),
-) -> SuccessResponse:
+) -> AgentHeartbeatResponse:
     """Agent heartbeat — refreshes TTL in Redis and updates resource catalog.
 
     The agent_id can be either a UUID or the agent name (for Go agent compatibility
@@ -418,7 +445,16 @@ async def agent_heartbeat(
                     rtt_ms,
                 )
 
-    return SuccessResponse(message="OK")
+    # Tell the agent which edges to latency-probe for its agent-leg (#277). This
+    # is what populates the agent-leg table for SSH/DB/TCP-only and idle agents,
+    # which never hold a web-app relay and so previously measured nothing.
+    probe_targets = await build_agent_edge_probe_targets(r, agent_id_str)
+    return AgentHeartbeatResponse(
+        edge_probe_targets=[
+            AgentEdgeProbeTarget(edge=edge, host=host, port=port)
+            for edge, host, port in probe_targets
+        ]
+    )
 
 
 # ── Certificate Renewal ────────────────────────────────────────────────

--- a/services/tests/test_api/test_agents_router.py
+++ b/services/tests/test_api/test_agents_router.py
@@ -362,6 +362,43 @@ class TestAgentHeartbeat:
         mock_redis.setex.assert_any_call(f"agent:{AGENT_UUID}:edge_rtt:central", 180, 3)
 
     @pytest.mark.asyncio
+    async def test_heartbeat_returns_edge_probe_targets(self, agents_client, mock_db, mock_redis):
+        """The heartbeat response carries the edges the agent should probe for
+        its agent-leg (#277), mapped from the builder's (edge, host, port)."""
+        agent = _make_mock_agent()
+        mock_db.execute = _mock_db_execute_returning(agent)
+
+        with (
+            patch("bamf.api.routers.agents.set_agent_labels", new_callable=AsyncMock),
+            patch("bamf.api.routers.agents.set_agent_resources", new_callable=AsyncMock),
+            patch("bamf.api.routers.agents.set_tunnel_hostnames", new_callable=AsyncMock),
+            patch("bamf.services.agent_instances.register_instance", new_callable=AsyncMock),
+            patch(
+                "bamf.services.agent_instances.update_instance_tunnel_count", new_callable=AsyncMock
+            ),
+            patch("bamf.services.agent_instances.cleanup_stale_instances", new_callable=AsyncMock),
+            patch(
+                "bamf.api.routers.agents.build_agent_edge_probe_targets",
+                new=AsyncMock(
+                    return_value=[
+                        ("eu", "0.bridge.eu.tunnel.example.com", 443),
+                        ("local", "bamf-bridge-0.bamf.svc.cluster.local", 8443),
+                    ]
+                ),
+            ),
+        ):
+            resp = await agents_client.post(
+                f"/api/v1/agents/{AGENT_UUID}/heartbeat",
+                json={"resources": [], "instance_id": "inst-1"},
+            )
+
+        assert resp.status_code == 200
+        assert resp.json()["edge_probe_targets"] == [
+            {"edge": "eu", "host": "0.bridge.eu.tunnel.example.com", "port": 443},
+            {"edge": "local", "host": "bamf-bridge-0.bamf.svc.cluster.local", "port": 8443},
+        ]
+
+    @pytest.mark.asyncio
     async def test_heartbeat_by_name(self, agents_client, mock_db, mock_redis):
         """Agent can heartbeat using its name instead of UUID."""
         agent = _make_mock_agent()

--- a/services/tests/test_api/test_bridge_relay.py
+++ b/services/tests/test_api/test_bridge_relay.py
@@ -1,0 +1,75 @@
+"""Tests for bridge relay helpers (services/bamf/api/bridge_relay.py)."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from bamf.api.bridge_relay import build_agent_edge_probe_targets
+
+
+def _redis_with(edges: dict[str, list[str]], bridges: dict[str, dict]):
+    """A mock async Redis whose SCAN yields ``bridges:available:{edge}`` keys.
+
+    ``edges`` maps edge name → the bridge ids in its available set (order =
+    score order). ``bridges`` maps bridge id → its ``bridge:{id}`` hash.
+    """
+    r = AsyncMock()
+
+    async def scan(cursor="0", match=None, count=None):
+        keys = [f"bridges:available:{e}" for e in edges]
+        return ("0", keys)
+
+    async def zrangebyscore(key, *a, **k):
+        edge = key.removeprefix("bridges:available:")
+        return list(edges.get(edge, []))
+
+    async def hgetall(key):
+        return bridges.get(key.removeprefix("bridge:"), {})
+
+    r.scan = scan
+    r.zrangebyscore = zrangebyscore
+    r.hgetall = hgetall
+    return r
+
+
+@pytest.mark.asyncio
+async def test_build_probe_targets_one_per_edge():
+    """One (edge, host, port) per edge with a live bridge; the least-loaded
+    (first in the available set) bridge is used, resolved to the agent-reachable
+    endpoint."""
+    r = _redis_with(
+        edges={"eu": ["bamf-bridge-eu-0", "bamf-bridge-eu-1"], "us": ["bamf-bridge-us-0"]},
+        bridges={
+            "bamf-bridge-eu-0": {"hostname": "0.bridge.eu.tunnel.example.com"},
+            "bamf-bridge-us-0": {"hostname": "0.bridge.us.tunnel.example.com"},
+        },
+    )
+    with patch(
+        "bamf.api.bridge_relay.resolve_agent_bridge_endpoint",
+        new=AsyncMock(side_effect=lambda r, aid, bid, host: (host, 443)),
+    ):
+        targets = await build_agent_edge_probe_targets(r, "agent-1")
+
+    assert sorted(targets) == [
+        ("eu", "0.bridge.eu.tunnel.example.com", 443),
+        ("us", "0.bridge.us.tunnel.example.com", 443),
+    ]
+
+
+@pytest.mark.asyncio
+async def test_build_probe_targets_skips_empty_and_bridgeless():
+    """Edges with no live bridge, and a bridge with no hostname, are skipped;
+    the global ``bridges:available`` set (empty edge name) is ignored."""
+    r = _redis_with(
+        edges={"": ["global-ignored"], "eu": ["bamf-bridge-eu-0"], "drained": []},
+        bridges={"bamf-bridge-eu-0": {"hostname": "0.bridge.eu.tunnel.example.com"}},
+    )
+    with patch(
+        "bamf.api.bridge_relay.resolve_agent_bridge_endpoint",
+        new=AsyncMock(side_effect=lambda r, aid, bid, host: (host, 443)),
+    ):
+        targets = await build_agent_edge_probe_targets(r, "agent-1")
+
+    assert targets == [("eu", "0.bridge.eu.tunnel.example.com", 443)]


### PR DESCRIPTION
## Summary

Second gap found by the live 2-edge Tilt smoke of #119 (sibling of #275/#276).

Measured-latency edge selection needs the **agent-leg** table `agent:{id}:edge_rtt:{edge}`. That was only ever populated when the agent held a **relay** to an edge — and relays are established on-demand **solely by the first web-app/HTTP-proxy request** for that agent (`bridge_relay.ensure_relay_connected` ← `internal_proxy`). An SSH/DB/TCP tunnel dials the bridge a different way that records nothing. So **SSH-only and idle agents measured no agent-leg at all**, and `select_edge` silently fell back to the tier-4 default edge — the flagship's headline (measured selection for SSH/TCP) was inert in practice. Verified live: the single online agent had **zero** `edge_rtt` keys despite being healthy.

## Fix

Decouple the measurement from relays, over the existing 60s heartbeat:

1. **API** — `build_agent_edge_probe_targets()` enumerates edges from `bridges:available:*`, resolves each edge's least-loaded bridge to an **agent-reachable** endpoint (per the agent's network zone, exactly as a real relay/tunnel dial would be). The heartbeat response (`AgentHeartbeatResponse`) returns them as `edge_probe_targets`.
2. **Agent** — TCP-times each target (connect → measure → drop, no persistent connection), off the heartbeat path with a single-flight guard, and reports the results as `edge_rtts` on the next heartbeat. A live relay's own dial EWMA still wins for edges it holds one to.

Result: every online agent measures every reachable edge, so measured-latency selection engages for SSH/TCP — no persistent S×A relay mesh required.

## Tests & verification

- `test_bridge_relay.py`: builder enumeration — one target per edge, least-loaded bridge, skips empty-edge/bridgeless/hostname-less.
- `test_agents_router.py`: heartbeat response returns the mapped probe targets.
- `api_client_test.go`: Go client parses `edge_probe_targets`; empty when no edges.
- Full `test_api/` (777) + `pkg/agent`/`pkg/apiclient` Go suites green; build/vet/gofmt clean.
- **API half verified live** against the running stack (read-only): the builder yields `[('local', 'bamf-bridge-0.bamf.svc.cluster.local', 8443)]` — a valid in-cluster probe endpoint the agent would TCP-time and report as `edge_rtt:local`. Full end-to-end (agent probing + reporting) will confirm on the next bamf Tilt session.

closes #277