### PR TITLE
docs: fix residual drift (SSH-CA overstatement, missing proxy/kubamf values, resource GET)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ BAMF is **MPL-2.0** — no usage restrictions, no feature gating:
   stable per-edge URLs.
   [Architecture](docs/architecture/edge-deployments.md)
 
-- **Certificate-based trust model** — BAMF CA issues short-lived x509 and SSH
+- **Certificate-based trust model** — BAMF CA issues short-lived x509
   certificates. No long-lived secrets. Session certs encode the authorization
   decision directly — the bridge validates certs locally during tunnel operation.
 

--- a/docs/comparison.md
+++ b/docs/comparison.md
@@ -96,7 +96,7 @@ common options but not all.
 
 | Feature | BAMF | Teleport Community |
 |---|---|---|
-| Short-lived certificates | Yes (x509 + SSH) | Yes (SSH + x509) |
+| Short-lived certificates | Yes (x509) | Yes (SSH + x509) |
 | Certificate authority | Built-in | Built-in |
 | mTLS tunnels | Yes | Yes |
 | Role-based access control | Yes | Yes |

--- a/docs/guides/ssh.md
+++ b/docs/guides/ssh.md
@@ -87,16 +87,23 @@ After this, plain `ssh user@web-prod-01.prod` routes through BAMF automatically.
 
 ## Host Key Verification
 
-Agents present host certificates signed by the BAMF CA. `bamf ssh` passes
-`UserKnownHostsFile ~/.bamf/known_hosts` to native ssh. To skip per-host TOFU
-prompts, add the BAMF CA as a cert-authority to that file yourself:
+`bamf ssh` passes `UserKnownHostsFile ~/.bamf/known_hosts` to native ssh, so
+BAMF keeps its own host-key cache separate from your personal
+`~/.ssh/known_hosts`. How the host key is verified depends on the resource type:
 
-```
-@cert-authority * <BAMF CA public key>
-```
+- **`ssh` (transparent tunnel):** the tunnel is a byte relay, so your ssh client
+  completes its handshake directly with the target host and sees the target's
+  own host key. Verification is standard ssh TOFU (Trust On First Use) against
+  `~/.bamf/known_hosts`.
+- **`ssh-audit` (recorded sessions):** the bridge terminates SSH to record the
+  session, so it presents BAMF's own SSH host key — a single Ed25519 key
+  generated once per deployment and shared by all bridge pods. The
+  bridge-to-target hop is secured by the mTLS tunnel, not by SSH host
+  verification.
 
-This eliminates per-host TOFU (Trust On First Use) prompts while maintaining
-cryptographic verification of host identity.
+BAMF does not issue per-host SSH certificates or use an `@cert-authority`
+model. The mTLS tunnel (CLI ↔ bridge ↔ agent), authenticated with BAMF-CA
+certificates, is the security boundary for the connection.
 
 ## Session Recording (`ssh-audit`)
 

--- a/docs/reference/api.md
+++ b/docs/reference/api.md
@@ -62,6 +62,7 @@ All endpoints are prefixed with `/api/v1` unless otherwise noted.
 | Method | Path | Auth | Description |
 |--------|------|------|-------------|
 | GET | `/resources` | Yes | List accessible resources |
+| GET | `/resources/{name}` | Yes | Get a single accessible resource by name |
 
 Resources are reported by agents via heartbeats and stored in Redis. There is no
 CRUD API for resources — they are managed through agent configuration.

--- a/docs/reference/helm-values.md
+++ b/docs/reference/helm-values.md
@@ -143,6 +143,42 @@ edge:
       enabled: true                  # Token-based cert bootstrap
 ```
 
+## Proxy (standalone HTTP proxy)
+
+The HTTP reverse proxy for web-app and Kubernetes-API access runs as its own
+`bamf-proxy` deployment within an edge (not inside the API server). It is
+stateless and scales on request volume.
+
+```yaml
+edge:
+  proxy:
+    replicas: 2
+    image:
+      repository: ghcr.io/mattrobinsonsre/bamf-proxy
+      tag: ""                        # Defaults to appVersion
+      pullPolicy: IfNotPresent
+    resources:
+      requests: { cpu: 100m, memory: 128Mi }
+      limits: { cpu: 500m, memory: 256Mi }
+    autoscaling:
+      enabled: false
+      minReplicas: 2
+      maxReplicas: 10
+      targetCPUUtilizationPercentage: 70
+    pdb:
+      enabled: true
+      minAvailable: 1
+    internalToken: ""                # proxy→API internal auth; auto-generated into a Secret if empty
+    logLevel: info
+    jsonLogs: "true"
+    preStopSleepSeconds: 15
+    terminationGracePeriodSeconds: 120
+    # apiUrl: https://bamf.example.com  # Remote central API for edge-only deployments
+```
+
+For a remote edge (`core.enabled=false`), set `edge.proxy.apiUrl` to the central
+API's URL so the proxy can reach it.
+
 ## Web UI
 
 ```yaml
@@ -328,6 +364,29 @@ core:
   migrations:
     enabled: true                    # Run Alembic migrations on install/upgrade
 ```
+
+## kubamf (optional Kubernetes GUI)
+
+An optional web-based Kubernetes dashboard deployed alongside an agent and
+accessed through the BAMF proxy chain (so BAMF RBAC governs every K8s call). Off
+by default.
+
+```yaml
+kubamf:
+  enabled: false
+  bamf:
+    enabled: true                  # Always BAMF mode when deployed via this chart
+    apiUrl: ""                     # Defaults to http://{release}-api:8000
+    kubeResourceName: ""           # Name of the `kubernetes`-type resource to route through
+  image:
+    repository: ghcr.io/mattrobinsonsre/kubamf
+    tag: latest
+  resourceName: ""                 # Agent registration name (default: "{agent.config.name}-kubamf")
+  tunnelHostname: ""               # HTTP proxy hostname (default: resourceName)
+```
+
+`kubeResourceName` must match a `type: kubernetes` resource in
+`agent.config.resources`.
 
 ## Metrics
 


### PR DESCRIPTION
## Summary

Closes the committed-doc portion of the drift omnibus (#126). A full re-audit against current code found **11 of the original ~18 claims already fixed** and **3 confined to the gitignored `CLAUDE.md`** (can't be changed in a PR); these are the remaining committed-doc fixes.

### Fixes

1. **SSH certificate model was overstated.** The BAMF CA issues **only x509** certs and generates a **single shared Ed25519 SSH host key** for the `ssh-audit` bridge proxy (`services/bamf/auth/ca.py`). It does not sign per-host SSH certificates and there is no `@cert-authority` model.
   - `README.md`: "x509 and SSH certificates" → "x509 certificates".
   - `docs/comparison.md`: "Yes (x509 + SSH)" → "Yes (x509)".
   - `docs/guides/ssh.md`: rewrote **Host Key Verification** to reality — transparent `ssh` sees the target's own host key (standard TOFU); `ssh-audit` presents BAMF's shared host key; the mTLS tunnel is the security boundary; no `@cert-authority`.
2. **`helm-values.md` missing value groups.** Documented the two real, user-facing groups that were entirely absent: **`edge.proxy.*`** (the standalone `bamf-proxy`) and top-level **`kubamf`**.
3. **`api.md`**: documented `GET /resources/{name}` (exists in `resources.py`, was undocumented).

### Not done here (deliberately)
- The **SSH host-cert signing** feature itself is out of scope — the docs now match the code; issuing per-host SSH certs would be a separate enhancement.
- CLAUDE.md-only occurrences (in-API proxy description, `migrate`/`reconnect` SSE names, gRPC data path) are in a gitignored local file; their committed counterparts are already correct.

### Verification
`scripts/docs.sh build` (mkdocs `--strict`), `content-hygiene`, and `docs-xref` all pass.

Closes #126