### PR TITLE
chore(repo): issue/PR templates, CODEOWNERS, FUNDING, secret-scan ignores, CONTRIBUTING polish

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,10 @@
+# Code owners are requested for review automatically on every PR.
+# See https://docs.github.com/articles/about-code-owners
+
+# Default owner for everything in the repo.
+*                       @mattrobinsonsre
+
+# Release + CI machinery and the shared contributor contracts warrant extra care.
+/.github/               @mattrobinsonsre
+/AGENTS.md              @mattrobinsonsre
+/helm/                  @mattrobinsonsre

--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,3 @@
+# Funding links shown on the repo's sidebar. The Sponsor button only appears if
+# the account has GitHub Sponsors enabled; otherwise this is a no-op.
+github: [mattrobinsonsre]

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: Report something that doesn't work as documented
+labels: [bug]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting. Please check existing issues first. For security
+        vulnerabilities, do **not** open a public issue — follow
+        [`SECURITY.md`](../blob/main/SECURITY.md).
+  - type: textarea
+    id: what-happened
+    attributes:
+      label: What happened
+      description: What did you observe, and what did you expect instead?
+      placeholder: "`bamf ssh web-prod` fails with … but the docs say …"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce
+      description: Minimal steps. Include the exact commands.
+      placeholder: |
+        1. helm install bamf … with values …
+        2. bamf login; bamf ssh …
+        3. see error
+    validations:
+      required: true
+  - type: textarea
+    id: env
+    attributes:
+      label: Environment
+      description: BAMF version (image tag / chart version / `bamf version`), Kubernetes distro + version, ingress provider (Traefik/Istio), and whether core/edge/agent are co-located or split.
+      placeholder: "BAMF v0.11.0, chart 0.11.0, k3d 1.30, Traefik, co-located core+edge"
+    validations:
+      required: true
+  - type: textarea
+    id: logs
+    attributes:
+      label: Relevant logs
+      description: API / bridge / agent logs or CLI output. Scrub any secrets and internal hostnames first.
+      render: shell
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+        - label: This is not a security vulnerability (those go via SECURITY.md, not a public issue)
+          required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Security vulnerability
+    url: https://github.com/mattrobinsonsre/bamf/blob/main/SECURITY.md
+    about: Do not file a public issue for vulnerabilities — follow the security policy.
+  - name: Question or usage help
+    url: https://github.com/mattrobinsonsre/bamf/discussions
+    about: Ask in Discussions rather than opening an issue.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,38 @@
+name: Feature request
+description: Propose a new capability or an enhancement
+labels: [enhancement]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for the idea. BAMF favours simplicity — see the Non-Goals in the
+        docs before proposing MFA, a VPN/L3 layer, or workload identity, which
+        are deliberately out of scope.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / use case
+      description: What are you trying to do that BAMF doesn't support today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed solution
+      description: What should BAMF do? Note any new CLI command, API endpoint, Helm value, or agent-config field it would add.
+    validations:
+      required: true
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: Other approaches, and why the proposal is preferable.
+  - type: checkboxes
+    id: checks
+    attributes:
+      label: Confirmations
+      options:
+        - label: I searched existing issues and this isn't a duplicate
+          required: true
+        - label: This fits BAMF's scope (not an explicit Non-Goal)
+          required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+Conventional-commit title: feat: / fix: / docs: / chore: / refactor: / test: / ci:
+-->
+
+## What & why
+
+<!-- One or two sentences. Link the issue this closes (required for anything
+     beyond a genuinely trivial tweak). -->
+
+Closes #
+
+## Changes
+
+<!-- Bullet the notable changes. -->
+
+-
+
+## Checklist
+
+- [ ] References an issue (`Closes #N`) — or is a genuinely trivial tweak (typo/formatting)
+- [ ] Ships with tests at the right tier (AGENTS.md → Code↔Tests contract)
+- [ ] Updated every consumer an API change touches (`pkg/apiclient`, `web`, CLI)
+- [ ] `values.schema.json` kept in sync with `values.yaml` (if Helm values changed)
+- [ ] `llms.txt` + README/docs feature tables updated (if a user-visible feature changed)
+- [ ] No internal references; peer projects respected (content hygiene)
+- [ ] CI is green (lint, test, build)

--- a/.github/secret_scanning.yml
+++ b/.github/secret_scanning.yml
@@ -1,0 +1,8 @@
+# Paths excluded from GitHub secret scanning / push protection.
+# These hold intentional non-secret material that trips generic high-entropy
+# detectors: test fixtures and golden contract certs, pentest scanner config,
+# and Alembic revision hashes.
+paths-ignore:
+  - "services/tests/**"
+  - "pentest/**"
+  - "alembic/versions/**"

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -48,6 +48,28 @@ code↔tests contracts, and the conventions.
    commit title (`feat:`, `fix:`, `docs:`, `chore:`, `refactor:`, `test:`,
    `ci:`). CI (lint, test, build) must be green.
 
+## Good first issues
+
+New contributors: look for issues labelled
+[`good first issue`](https://github.com/mattrobinsonsre/bamf/labels/good%20first%20issue)
+and [`documentation`](https://github.com/mattrobinsonsre/bamf/labels/documentation).
+Comment on the issue to claim it before starting so work isn't duplicated.
+
+## Maintainers
+
+BAMF is currently maintained by [@mattrobinsonsre](https://github.com/mattrobinsonsre),
+who reviews and squash-merges PRs (see [`CODEOWNERS`](.github/CODEOWNERS)). If
+you'd like to become a maintainer, the path is a track record of merged,
+well-tested PRs — open a discussion once you're there.
+
+## License
+
+BAMF is [MPL-2.0](LICENSE), and there is **no CLA**. Contributions are
+inbound=outbound: by opening a PR you agree that your contribution is licensed
+under the MPL-2.0, and you confirm you have the right to submit it (you wrote it,
+or it's compatibly licensed and attributed). MPL-2.0 is file-level copyleft — new
+files should carry the same license as the surrounding code.
+
 ## Content hygiene (please read)
 
 BAMF's history and source are public forever. Two hard rules:


### PR DESCRIPTION
## Summary

Repo-governance items for a public, AI-contribution-friendly project (part of #139), plus the secret-scanning paths-ignore from the CI-hardening list (#127).

- **Issue templates** — `bug_report.yml` + `feature_request.yml` (structured forms) + `config.yml` that disables blank issues, routes security reports to `SECURITY.md`, and points questions at Discussions.
- **PR template** — mechanically prompts for `Closes #N` and a tests-included / consumer-sync / schema-sync / content-hygiene checklist (backs the AGENTS.md contracts at PR time).
- **CODEOWNERS** — default owner + extra ownership on `.github`, `AGENTS.md`, `helm/`.
- **FUNDING.yml** — sidebar sponsor link (no-op unless GitHub Sponsors is enabled; trivially removable).
- **secret_scanning.yml** — `paths-ignore` for test fixtures/golden certs, pentest config, and Alembic revision hashes (intentional non-secret high-entropy).
- **CONTRIBUTING.md** — added Good-first-issues, Maintainers (who merges / how to join), and a License paragraph (MPL-2.0, no CLA, inbound=outbound).

## Not in this PR (tracked, remaining under #139 / #127 / #128)
- `scripts/smoke/` harness + `make` target (backs release gate F) and the preflight-identity doctor — heavier, separate PR.
- Wiring the existing Playwright E2E (`web/e2e/`) into CI — needs a k3d stack job (shared with #128); separate PR.

All new YAML validated; content-hygiene clean.

Part of #139; addresses the secret_scanning item of #127.