### PR TITLE
chore(smoke): runnable live smoke harness backing release gate F

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,7 @@
 	release hooks dev dev-down \
 	security-scan security-scan-go security-scan-python \
 	pentest pentest-dast pentest-images pentest-sast \
+	smoke \
 	clean clean-cache test-down \
 	db-migrate db-rollback db-reset \
 	migration-check docs-xref helm-config-contract \
@@ -113,6 +114,10 @@ security-scan-go:       ## Run govulncheck (Go vulnerability scanner)
 
 security-scan-python:   ## Run pip-audit (Python vulnerability scanner)
 	scripts/security-scan.sh python
+
+# ── Live Smoke (release gate F) ─────────────────────────
+smoke:              ## Live smoke vs a running stack (auth + cert issuance + tunnel authz)
+	scripts/smoke/run.sh
 
 # ── Penetration Testing ─────────────────────────────────
 pentest:            ## Run all pen tests (DAST + image scan + SAST)

--- a/scripts/smoke/lib.sh
+++ b/scripts/smoke/lib.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Shared helpers for the BAMF live smoke harness.
+#
+# The smoke harness backs AGENTS.md release gate F ("live smoke for destructive /
+# high-blast-radius surfaces … end-to-end"): it drives real authentication,
+# certificate issuance, and tunnel authorization against a running stack, rather
+# than trusting unit tests. It talks only to the public HTTP API, so it is
+# stack-agnostic (local Tilt/k3d or a remote deployment) — point it with
+# BAMF_SMOKE_URL.
+#
+# Env:
+#   BAMF_SMOKE_URL       Base URL of the stack        (default https://bamf.local)
+#   BAMF_SMOKE_EMAIL     Local admin email            (default admin)
+#   BAMF_SMOKE_PASSWORD  Local admin password         (default admin)
+#   BAMF_SMOKE_INSECURE  curl -k for self-signed TLS  (default 1 — mkcert/dev)
+
+set -euo pipefail
+
+BAMF_SMOKE_URL="${BAMF_SMOKE_URL:-https://bamf.local}"
+BAMF_SMOKE_EMAIL="${BAMF_SMOKE_EMAIL:-admin}"
+BAMF_SMOKE_PASSWORD="${BAMF_SMOKE_PASSWORD:-admin}"
+BAMF_SMOKE_INSECURE="${BAMF_SMOKE_INSECURE:-1}"
+
+API="${BAMF_SMOKE_URL%/}/api/v1"
+
+_curl_opts=(--fail-with-body -sS --max-time 20)
+[ "$BAMF_SMOKE_INSECURE" = "1" ] && _curl_opts+=(-k)
+
+RED=$'\033[0;31m'; GREEN=$'\033[0;32m'; YELLOW=$'\033[1;33m'; NC=$'\033[0m'
+info()  { echo "${YELLOW}==>${NC} $*"; }
+pass()  { echo "${GREEN}  ✓${NC} $*"; }
+fail()  { echo "${RED}  ✗ $*${NC}" >&2; exit 1; }
+
+req() { curl "${_curl_opts[@]}" "$@"; }
+
+# base64url without padding.
+_b64url() { openssl base64 -A | tr '+/' '-_' | tr -d '='; }
+
+# pkce_verifier / pkce_challenge — RFC 7636 S256.
+pkce_verifier()  { openssl rand -hex 32; }              # 64 unreserved chars
+pkce_challenge() { printf '%s' "$1" | openssl dgst -binary -sha256 | _b64url; }
+
+# smoke_login — drive the scriptable local PKCE flow and echo a session token.
+# POST /auth/local/authorize (JSON creds + PKCE) -> code -> POST /auth/token.
+smoke_login() {
+  local verifier challenge code token
+  verifier="$(pkce_verifier)"
+  challenge="$(pkce_challenge "$verifier")"
+
+  code="$(req -X POST "$API/auth/local/authorize" \
+    -H 'Content-Type: application/json' \
+    -d "$(printf '{"email":"%s","password":"%s","code_challenge":"%s","code_challenge_method":"S256","state":"smoke"}' \
+          "$BAMF_SMOKE_EMAIL" "$BAMF_SMOKE_PASSWORD" "$challenge")" \
+    | sed -n 's/.*"code"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  [ -n "$code" ] || return 1
+
+  token="$(req -X POST "$API/auth/token" \
+    -H 'Content-Type: application/x-www-form-urlencoded' \
+    --data-urlencode 'grant_type=authorization_code' \
+    --data-urlencode "code=$code" \
+    --data-urlencode "code_verifier=$verifier" \
+    | sed -n 's/.*"session_token"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+  [ -n "$token" ] || return 1
+  printf '%s' "$token"
+}
+
+# guard_local — refuse to run against something that looks like production unless
+# BAMF_SMOKE_FORCE=1. The smoke creates real (short-lived) sessions and certs.
+guard_local() {
+  case "$BAMF_SMOKE_URL" in
+    *bamf.local*|*localhost*|*127.0.0.1*|*.svc*|*:8000*) return 0 ;;
+  esac
+  if [ "${BAMF_SMOKE_FORCE:-0}" != "1" ]; then
+    fail "BAMF_SMOKE_URL='$BAMF_SMOKE_URL' doesn't look local. Set BAMF_SMOKE_FORCE=1 to run against it anyway."
+  fi
+}

--- a/scripts/smoke/run.sh
+++ b/scripts/smoke/run.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+# Run the full BAMF live smoke suite against a running stack.
+# Backs AGENTS.md release gate F. Usage: scripts/smoke/run.sh  (or: make smoke)
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=scripts/smoke/lib.sh
+source ./lib.sh
+guard_local
+
+echo "BAMF smoke — target: $BAMF_SMOKE_URL"
+echo
+
+res="$(./seed-fixture.sh)"
+echo "$res"
+resource="$(printf '%s' "$res" | sed -n 's/^RESOURCE=//p' | tail -1)"
+echo
+
+RESOURCE="$resource" ./smoke-cert-issue.sh
+echo
+echo "${GREEN}All smoke checks passed.${NC}"

--- a/scripts/smoke/seed-fixture.sh
+++ b/scripts/smoke/seed-fixture.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+# Smoke: assert the stack is up and has an agent-provided resource to target.
+# Prints the name of a usable resource on stdout (consumed by smoke-tunnel.sh).
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=scripts/smoke/lib.sh
+source ./lib.sh
+guard_local
+
+info "Health / readiness"
+req "$BAMF_SMOKE_URL/health" >/dev/null || fail "/health unreachable at $BAMF_SMOKE_URL"
+req "$BAMF_SMOKE_URL/ready"  >/dev/null || fail "/ready not ready"
+pass "API healthy and ready"
+
+info "Login (local admin, PKCE)"
+token="$(smoke_login)" || fail "login flow failed"
+pass "session issued (${#token}-char token)"
+
+info "Resource catalogue (agent-provided)"
+resources_json="$(req "$API/resources" -H "Authorization: Bearer $token")" || fail "GET /resources failed"
+name="$(printf '%s' "$resources_json" | sed -n 's/.*"name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' | head -1)"
+[ -n "$name" ] || fail "no resources registered — is an agent online? ($resources_json)"
+pass "found resource: $name"
+
+# Emit the resource name for the tunnel smoke (last line = machine-readable).
+printf 'RESOURCE=%s\n' "$name"

--- a/scripts/smoke/smoke-cert-issue.sh
+++ b/scripts/smoke/smoke-cert-issue.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# Smoke: certificate issuance + tunnel authorization (the high-blast-radius path).
+#
+# Drives POST /connect for a real resource and asserts the API returns a
+# BAMF-CA-issued session certificate whose SAN URIs encode the authorization
+# decision (session / resource / bridge). This exercises the CA, RBAC, and
+# bridge assignment end-to-end — the session cert IS the authorization, so a
+# valid one proves the whole issuance path works on the live stack.
+set -euo pipefail
+cd "$(dirname "$0")"
+# shellcheck source=scripts/smoke/lib.sh
+source ./lib.sh
+guard_local
+
+RESOURCE="${1:-${RESOURCE:-}}"
+if [ -z "$RESOURCE" ]; then
+  RESOURCE="$(./seed-fixture.sh | sed -n 's/^RESOURCE=//p' | tail -1)"
+fi
+[ -n "$RESOURCE" ] || fail "no resource to connect to"
+
+info "Login"
+token="$(smoke_login)" || fail "login failed"
+pass "session issued"
+
+info "Connect to '$RESOURCE' (issues a session certificate)"
+resp="$(req -X POST "$API/connect" \
+  -H "Authorization: Bearer $token" \
+  -H 'Content-Type: application/json' \
+  -d "$(printf '{"resource_name":"%s"}' "$RESOURCE")")" || fail "POST /connect failed for '$RESOURCE'"
+
+bridge="$(printf '%s' "$resp" | sed -n 's/.*"bridge_hostname"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p')"
+[ -n "$bridge" ] || fail "no bridge_hostname in connect response ($resp)"
+pass "bridge assigned: $bridge"
+
+# Extract the PEM session cert (JSON-escaped \n) and verify its SAN URIs.
+cert="$(printf '%s' "$resp" \
+  | sed -n 's/.*"session_cert"[[:space:]]*:[[:space:]]*"\(-----BEGIN[^"]*\)".*/\1/p' \
+  | sed 's/\\n/\n/g')"
+[ -n "$cert" ] || fail "no session_cert in connect response"
+
+sans="$(printf '%s' "$cert" | openssl x509 -noout -text 2>/dev/null | grep -A1 'Subject Alternative Name' | tr ',' '\n')"
+printf '%s' "$sans" | grep -q 'bamf://session/'  || fail "session cert missing bamf://session SAN"
+printf '%s' "$sans" | grep -q "bamf://resource/$RESOURCE" || fail "session cert missing bamf://resource/$RESOURCE SAN"
+printf '%s' "$sans" | grep -q 'bamf://bridge/'   || fail "session cert missing bamf://bridge SAN"
+pass "session cert issued with authorization SANs (session, resource=$RESOURCE, bridge)"
+
+info "Certificate-issuance + tunnel-authorization smoke passed"


### PR DESCRIPTION
## Summary

AGENTS.md release gate F ("live smoke for destructive / high-blast-radius surfaces … end-to-end") existed only as prose — I ran it by hand for v0.11.0. This makes it a runnable **`make smoke`** target that drives the real auth, certificate-issuance, and tunnel-authorization paths against a running stack. Part of #139.

## What it does

1. **seed-fixture.sh** — asserts `/health` + `/ready`, logs in, discovers an agent-provided resource.
2. **smoke-cert-issue.sh** — `POST /connect` for that resource and verifies the API returns a BAMF-CA **session certificate** whose SAN URIs encode the authorization (`bamf://session`, `bamf://resource/<name>`, `bamf://bridge`). The session cert *is* the authorization, so a valid one proves CA + RBAC + bridge assignment end-to-end.
3. **lib.sh** — a **scriptable** local PKCE login (`POST /auth/local/authorize` → `POST /auth/token`, no browser callback), curl wrappers, and a `guard_local` that refuses non-local `BAMF_SMOKE_URL` without `BAMF_SMOKE_FORCE=1`.

Talks only to the public HTTP API, so it's **stack-agnostic** — local Tilt/k3d by default (`https://bamf.local`), or any deployment via `BAMF_SMOKE_URL` / `BAMF_SMOKE_EMAIL` / `BAMF_SMOKE_PASSWORD`.

## Verified live

Ran `make smoke` against the local stack:
```
✓ API healthy and ready
✓ session issued (43-char token)
✓ found resource: test-ssh-audit
✓ bridge assigned: 0.bridge.local.tunnel.bamf.local
✓ session cert issued with authorization SANs (session, resource=test-ssh-audit, bridge)
All smoke checks passed.
```

## Remaining under #139
- Preflight-identity doctor (`make preflight-identity` — SA impersonation RBAC, `bamf-ca` Secret, API↔DB/Redis reachability) — separate PR.

Part of #139.