### PR TITLE
fix(helm): run migrations as a normal Job (init-wait) for bundled PostgreSQL

### DIFF
--- a/helm/bamf/templates/job-migrations.yaml
+++ b/helm/bamf/templates/job-migrations.yaml
@@ -7,10 +7,18 @@ metadata:
   labels:
     {{- include "bamf.labels" . | nindent 4 }}
     app.kubernetes.io/component: migrations
+  {{- if not .Values.core.postgresql.bundled.enabled }}
+  # External PostgreSQL exists before the release, so migrations run as a
+  # pre-install/upgrade hook (schema is ready before the app rolls out).
   annotations:
     "helm.sh/hook": pre-install,pre-upgrade
     "helm.sh/hook-weight": "-5"
     "helm.sh/hook-delete-policy": before-hook-creation,hook-succeeded
+  {{- end }}
+  # Bundled PostgreSQL is deployed by this same release, so migrations must NOT
+  # be a pre-install hook — the hook would run before the bundled DB Secret and
+  # StatefulSet exist and deadlock. Instead it runs as a normal Job with an
+  # init container that waits for PostgreSQL to accept connections (#285).
 spec:
   ttlSecondsAfterFinished: 600
   template:
@@ -28,6 +36,21 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       restartPolicy: OnFailure
+      {{- if .Values.core.postgresql.bundled.enabled }}
+      initContainers:
+        - name: wait-for-postgres
+          image: busybox:1.36
+          command:
+            - sh
+            - -c
+            - |
+              until nc -z {{ include "bamf.fullname" . }}-postgresql 5432; do
+                echo "waiting for postgresql..."; sleep 2
+              done
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { cpu: 100m, memory: 32Mi }
+      {{- end }}
       containers:
         - name: migrations
           image: {{ include "bamf.api.image" . }}


### PR DESCRIPTION
## Summary

A fresh `helm install` with **bundled PostgreSQL** deadlocked. Found while booting the k3d eval (#135) — the first time anything does a real fresh bundled install (CI's `helm-smoke` only `helm template`s, which renders fine because the hook-ordering bug only bites at install time).

## Root cause

`job-migrations.yaml` was unconditionally a `helm.sh/hook: pre-install,pre-upgrade`. The bundled DB Secret (`secret-database.yaml`) and the Postgres StatefulSet are **normal resources**. Helm runs pre-install hooks *before* normal resources, so on a fresh bundled install the migrations hook ran before its `bamf-postgresql` Secret existed → `CreateContainerConfigError: secret "bamf-postgresql" not found`, release stuck `pending-install`, nothing else deploys. External PG is unaffected (DB + secret pre-exist the release).

The CLAUDE.md-documented design ("bundled → no hook, init container waits for PostgreSQL") was never actually implemented.

## Fix

- **External PG** — migrations stay a `pre-install,pre-upgrade` hook (schema ready before rollout).
- **Bundled PG** — migrations run as a **normal Job** with a `wait-for-postgres` init container (busybox `nc -z …-postgresql 5432`), created alongside Postgres in the main phase.

## Verification

- Bundled render: init container present, **no** hook. External render: hook present, **no** init. `helm lint` clean.
- **Live:** a real fresh bundled `helm install` on k3d now migrates cleanly (migrations Job `Completed`, Postgres/Redis/API/bridge/proxy/web all come up) where it previously deadlocked at `pending-install`.

closes #285