### PR TITLE
feat(dx): one-command k3d evaluation quickstart (make eval)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 	release hooks dev dev-down \
 	security-scan security-scan-go security-scan-python \
 	pentest pentest-dast pentest-images pentest-sast \
-	smoke \
+	smoke eval eval-down \
 	clean clean-cache test-down \
 	db-migrate db-rollback db-reset \
 	migration-check docs-xref helm-config-contract \
@@ -114,6 +114,13 @@ security-scan-go:       ## Run govulncheck (Go vulnerability scanner)
 
 security-scan-python:   ## Run pip-audit (Python vulnerability scanner)
 	scripts/security-scan.sh python
+
+# ── Evaluation (throwaway k3d cluster) ──────────────────
+eval:               ## One-command throwaway k3d eval cluster (no domain, no build)
+	scripts/eval.sh up
+
+eval-down:          ## Delete the eval cluster
+	scripts/eval.sh down
 
 # ── Live Smoke (release gate F) ─────────────────────────
 smoke:              ## Live smoke vs a running stack (auth + cert issuance + tunnel authz)

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -3,6 +3,36 @@
 Get BAMF running in 10 minutes. This guide covers deploying the platform,
 registering an agent, and connecting to your first resource.
 
+## Evaluate in 5 minutes (k3d, no domain, no build)
+
+Just want to try it? One command spins up a throwaway [k3d](https://k3d.io)
+cluster with the whole stack — control plane, edge, a demo agent, bundled
+Postgres/Redis, and local auth — using published images. No domain, no
+`/etc/hosts` edits, no build.
+
+**Prerequisites:** Docker, [`k3d`](https://k3d.io), `helm`, `kubectl`, `openssl`.
+
+```sh
+make eval        # create the cluster and install BAMF
+# ... prints the URL, credentials, and next steps ...
+make eval-down   # delete everything when you're done
+```
+
+It uses [sslip.io](https://sslip.io) wildcard DNS (`bamf.127.0.0.1.sslip.io`
+and `*.tunnel.127.0.0.1.sslip.io`), so the tunnel hostnames resolve with no DNS
+setup. TLS is self-signed — accept the browser warning. Log in at the printed
+URL with **`admin` / `admin`**, and open the bundled demo web app at
+`https://demo.tunnel.127.0.0.1.sslip.io` to see BAMF proxying to it. Smoke the
+running stack with `BAMF_SMOKE_URL=<printed-url> make smoke`.
+
+If ports 443/80 are already in use, override them:
+`EVAL_HTTPS_PORT=8443 EVAL_HTTP_PORT=8080 make eval` (URLs then carry the port).
+Contributors testing local changes can install the local chart with
+`scripts/eval.sh up --local-build`.
+
+This eval profile is **not for production** — for a real deployment continue
+below.
+
 ## Prerequisites
 
 - Kubernetes cluster (1.27+) with **Traefik v3** or **Istio** as the ingress

--- a/helm/bamf/values-eval.yaml
+++ b/helm/bamf/values-eval.yaml
@@ -1,0 +1,91 @@
+# Evaluation profile — a throwaway, single-node k3d cluster with everything
+# co-located: control plane + edge + a demo agent, bundled Postgres/Redis, local
+# auth (admin/admin), and the Helm-generated internal CA. Driven by `make eval`
+# (scripts/eval.sh), which injects the dynamic bits (hostname, ports, TLS secret)
+# via --set. NOT for production — see docs/admin/deployment.md for that.
+
+core:
+  enabled: true
+  api:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    pdb:
+      enabled: false
+    resources:
+      requests: { cpu: 100m, memory: 256Mi }
+      limits: { cpu: "1", memory: 512Mi }
+    config:
+      log_level: info
+  web:
+    standalone: true
+    replicas: 1
+    resources:
+      requests: { cpu: 50m, memory: 128Mi }
+      limits: { cpu: 500m, memory: 512Mi }
+  auth:
+    local:
+      enabled: true
+  # Seed the initial admin user + an agent join token (post-install job).
+  bootstrap:
+    adminEmail: admin
+    adminPassword: admin
+    joinToken: eval-join-token
+  postgresql:
+    bundled:
+      enabled: true
+    external:
+      enabled: false
+  redis:
+    bundled:
+      enabled: true
+    external:
+      enabled: false
+  migrations:
+    enabled: true
+
+edge:
+  enabled: true
+  name: local
+  proxy:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    pdb:
+      enabled: false
+  bridge:
+    replicas: 1
+    autoscaling:
+      enabled: false
+    pdb:
+      enabled: false
+
+agent:
+  enabled: true
+  replicas: 1
+  clusterInternal: true
+  joinToken: eval-join-token
+  config:
+    name: eval-agent
+    labels:
+      env: eval
+    resources:
+      # A browser-visible demo target (traefik/whoami) deployed by eval.sh.
+      # Reachable at https://demo.tunnel.<host> once the stack is up.
+      - name: demo
+        type: http
+        hostname: bamf-eval-demo.bamf.svc.cluster.local
+        port: 80
+        tunnel_hostname: demo
+        labels:
+          env: eval
+
+gateway:
+  enabled: true
+  provider: traefik
+  # hostname / tunnelDomain / ports.https injected by eval.sh (sslip.io + k3d port).
+
+tls:
+  certManager:
+    enabled: false
+  # existingSecret injected by eval.sh (self-signed cert for the sslip.io names).

--- a/scripts/eval.sh
+++ b/scripts/eval.sh
@@ -1,0 +1,142 @@
+#!/usr/bin/env bash
+# Throwaway BAMF evaluation cluster — one command, no domain, no build.
+#
+#   scripts/eval.sh up      # create a k3d cluster and install BAMF (make eval)
+#   scripts/eval.sh down    # delete it                          (make eval-down)
+#   scripts/eval.sh up --local-build   # install the local chart instead of OCI
+#
+# Uses k3d (k3s-in-docker, ships Traefik v3 which BAMF needs for SNI passthrough)
+# and sslip.io wildcard DNS, so the *.tunnel.* hostnames resolve without a real
+# domain or /etc/hosts edits. NOT for production.
+#
+# Env overrides: EVAL_CLUSTER, EVAL_NAMESPACE, EVAL_IP (default 127.0.0.1),
+#   EVAL_HTTPS_PORT (443), EVAL_HTTP_PORT (80), EVAL_CHART_VERSION, EVAL_CHART_REF.
+set -euo pipefail
+
+CLUSTER="${EVAL_CLUSTER:-bamf-eval}"
+KCTX="k3d-${EVAL_CLUSTER:-bamf-eval}"   # explicit context — never switch the user's global one
+NS="${EVAL_NAMESPACE:-bamf}"
+IP="${EVAL_IP:-127.0.0.1}"
+HTTPS_PORT="${EVAL_HTTPS_PORT:-443}"
+HTTP_PORT="${EVAL_HTTP_PORT:-80}"
+CHART_REF="${EVAL_CHART_REF:-oci://ghcr.io/mattrobinsonsre/bamf}"
+CHART_VERSION="${EVAL_CHART_VERSION:-0.11.0}"
+TLS_SECRET="bamf-eval-tls"
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+HOST="bamf.${IP}.sslip.io"
+TUNNEL_DOMAIN="${IP}.sslip.io"
+PORT_SUFFIX=""; [ "$HTTPS_PORT" != "443" ] && PORT_SUFFIX=":${HTTPS_PORT}"
+BASE_URL="https://${HOST}${PORT_SUFFIX}"
+
+Y=$'\033[1;33m'; G=$'\033[0;32m'; NC=$'\033[0m'
+step() { echo "${Y}==>${NC} $*"; }
+need() { command -v "$1" >/dev/null 2>&1 || { echo "missing prerequisite: $1" >&2; exit 1; }; }
+
+gen_tls() {
+  local dir; dir="$(mktemp -d)"
+  openssl req -x509 -newkey rsa:2048 -nodes -days 30 \
+    -keyout "$dir/tls.key" -out "$dir/tls.crt" \
+    -subj "/CN=${HOST}" \
+    -addext "subjectAltName=DNS:${HOST},DNS:*.tunnel.${TUNNEL_DOMAIN}" 2>/dev/null
+  kubectl --context "$KCTX" -n "$NS" create secret tls "$TLS_SECRET" \
+    --cert="$dir/tls.crt" --key="$dir/tls.key" \
+    --dry-run=client -o yaml | kubectl --context "$KCTX" apply -f - >/dev/null
+  rm -rf "$dir"
+}
+
+up() {
+  local local_build=0
+  [ "${1:-}" = "--local-build" ] && local_build=1
+  need k3d; need docker; need helm; need kubectl; need openssl
+
+  if k3d cluster list -o json 2>/dev/null | grep -q "\"name\":\"${CLUSTER}\""; then
+    step "k3d cluster '${CLUSTER}' already exists — reusing"
+  else
+    step "Creating k3d cluster '${CLUSTER}' (host :${HTTPS_PORT}→443, :${HTTP_PORT}→80)"
+    k3d cluster create "$CLUSTER" \
+      --port "${HTTPS_PORT}:443@loadbalancer" \
+      --port "${HTTP_PORT}:80@loadbalancer" \
+      --kubeconfig-switch-context=false \
+      --wait
+  fi
+  # All operations target the eval cluster by explicit context — the user's
+  # current-context is never changed.
+  kubectl --context "$KCTX" create namespace "$NS" --dry-run=client -o yaml | kubectl --context "$KCTX" apply -f - >/dev/null
+
+  step "Waiting for Traefik (k3s built-in ingress)"
+  kubectl --context "$KCTX" -n kube-system rollout status deploy/traefik --timeout=150s || true
+
+  step "Generating a self-signed TLS cert for ${HOST} and *.tunnel.${TUNNEL_DOMAIN}"
+  gen_tls
+
+  step "Deploying the demo target (traefik/whoami)"
+  kubectl --context "$KCTX" apply -f "${REPO_ROOT}/scripts/eval/demo-target.yaml" >/dev/null
+
+  # Build the helm invocation as one always-non-empty array (bash 3.2 + set -u safe).
+  local helm_args
+  helm_args=(--kube-context "$KCTX" upgrade --install bamf)
+  if [ "$local_build" = 1 ]; then
+    helm_args+=("${REPO_ROOT}/helm/bamf")
+    step "Importing locally-built images into the cluster (--local-build)"
+    for img in bamf-api bamf-bridge bamf-agent bamf-web bamf-proxy; do
+      k3d image import -c "$CLUSTER" "ghcr.io/mattrobinsonsre/${img}:${EVAL_IMAGE_TAG:-latest}" 2>/dev/null || true
+    done
+    step "Installing BAMF (local chart)"
+  else
+    helm_args+=("$CHART_REF" --version "$CHART_VERSION")
+    step "Installing BAMF (${CHART_REF} ${CHART_VERSION})"
+  fi
+  helm_args+=(
+    -n "$NS"
+    -f "${REPO_ROOT}/helm/bamf/values-eval.yaml"
+    --set "gateway.hostname=${HOST}"
+    --set "gateway.tunnelDomain=${TUNNEL_DOMAIN}"
+    --set "gateway.ports.https=${HTTPS_PORT}"
+    --set "tls.existingSecret=${TLS_SECRET}"
+    --timeout 360s
+  )
+  # NB: no --wait. helm always waits for the post-install bootstrap hook (which
+  # seeds the admin user + agent join token) regardless; --wait would instead
+  # block on the *agent* becoming ready first, but the agent can't register
+  # until that hook has created its token — a deadlock. Without --wait the hook
+  # runs, the token appears, and the agent registers on its next retry.
+  helm "${helm_args[@]}" || true
+
+  step "Waiting for the stack to be ready"
+  for target in deploy/bamf-api statefulset/bamf-bridge deploy/bamf-proxy deploy/bamf-web deploy/bamf-agent; do
+    kubectl --context "$KCTX" -n "$NS" rollout status "$target" --timeout=180s || true
+  done
+
+  print_access
+}
+
+print_access() {
+  cat <<EOF
+
+${G}BAMF evaluation stack is up.${NC}
+
+  Web UI / API   ${BASE_URL}
+  API docs       ${BASE_URL}/api/docs
+  Login          admin / admin
+  Demo web app   https://demo.tunnel.${TUNNEL_DOMAIN}${PORT_SUFFIX}
+
+  TLS is self-signed — accept the browser warning (or use curl -k).
+  CLI:  bamf login --api ${BASE_URL}   then:  bamf ls
+
+  Smoke it:  BAMF_SMOKE_URL=${BASE_URL} make smoke
+  Tear down: make eval-down
+EOF
+}
+
+down() {
+  need k3d
+  step "Deleting k3d cluster '${CLUSTER}'"
+  k3d cluster delete "$CLUSTER"
+}
+
+case "${1:-}" in
+  up)   shift; up "${1:-}" ;;
+  down) down ;;
+  *)    echo "usage: $0 up [--local-build] | down" >&2; exit 1 ;;
+esac

--- a/scripts/eval/demo-target.yaml
+++ b/scripts/eval/demo-target.yaml
@@ -1,0 +1,53 @@
+# A tiny browser-visible demo target for the evaluation stack. traefik/whoami
+# echoes the request headers, so you can see BAMF injecting identity headers
+# (X-Forwarded-Email, X-Forwarded-Roles) when you reach it through the proxy.
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: bamf-eval-demo
+  namespace: bamf
+  labels:
+    app.kubernetes.io/name: bamf-eval-demo
+    app.kubernetes.io/component: eval-demo
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: bamf-eval-demo
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: bamf-eval-demo
+    spec:
+      containers:
+        - name: whoami
+          image: traefik/whoami:v1.10.4
+          args: ["--port", "80"]
+          ports:
+            - containerPort: 80
+          resources:
+            requests: { cpu: 10m, memory: 16Mi }
+            limits: { cpu: 100m, memory: 32Mi }
+          securityContext:
+            allowPrivilegeEscalation: false
+            runAsNonRoot: true
+            runAsUser: 65532
+            capabilities:
+              drop: ["ALL"]
+            seccompProfile:
+              type: RuntimeDefault
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: bamf-eval-demo
+  namespace: bamf
+  labels:
+    app.kubernetes.io/name: bamf-eval-demo
+spec:
+  selector:
+    app.kubernetes.io/name: bamf-eval-demo
+  ports:
+    - name: http
+      port: 80
+      targetPort: 80


### PR DESCRIPTION
## Summary

A stranger can now try BAMF in ~5 minutes — **no domain, no `/etc/hosts` edits, no build**:

```sh
make eval        # throwaway k3d cluster + full stack from published images
make eval-down
```

Closes #135.

## What's in it

- **`scripts/eval.sh` up|down** — creates/deletes a k3d cluster (k3s ships Traefik v3, which BAMF needs for SNI-passthrough tunnels), generates a self-signed TLS cert for the sslip.io hostnames, deploys a demo target, and installs the published OCI chart. Uses [sslip.io](https://sslip.io) wildcard DNS (`bamf.127.0.0.1.sslip.io` + `*.tunnel.127.0.0.1.sslip.io`) so tunnel hostnames resolve with zero DNS setup. Prints URL + credentials + next steps. Ports overridable (`EVAL_HTTPS_PORT`) when 443/80 are busy; `--local-build` installs the local chart for contributors.
- **`helm/bamf/values-eval.yaml`** — co-located core+edge+agent, bundled Postgres/Redis, local auth (`admin`/`admin`) via the bootstrap job, Helm-generated CA, small resources, and a browser-visible demo `http` resource.
- **`scripts/eval/demo-target.yaml`** — `traefik/whoami`, so you can see BAMF injecting identity headers through the proxy.
- **`docs/getting-started.md`** — "Evaluate in 5 minutes (k3d)" section.

## Safe with your kubeconfig

The driver **never changes the global kube context** — every `kubectl`/`helm` call is pinned with `--context`, and k3d is created with `--kubeconfig-switch-context=false`.

## Verified live

`make eval` (on alt ports, to avoid a busy 443/80) boots the whole stack on k3d, and `BAMF_SMOKE_URL=<printed-url> make smoke` passes end-to-end: login → the agent-registered `demo` resource → connect → session cert with authorization SANs.

## Depends on
**#285** (bundled-migrations deadlock fix) — the eval uses bundled Postgres, which won't install cleanly without it. Merge #285 first.

closes #135