### PR TITLE
ci: add Web E2E tier — Playwright on a core-only k3d stack

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -263,6 +263,25 @@ jobs:
       - name: Run npm audit
         run: npm audit --audit-level=high
 
+  # Boots a minimal core-only BAMF stack on k3d (API+Web+Postgres+Redis+bootstrap,
+  # built from this commit) and runs the Playwright suite (web/e2e) against it —
+  # the Web E2E tier the code↔tests contract requires. Self-contained: builds its
+  # own images and imports them, so it doesn't depend on the image-build jobs.
+  web-e2e:
+    name: Web E2E
+    needs: prepare
+    if: needs.prepare.outputs.images_exist != 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+      - name: Install k3d
+        run: |
+          curl -fsSL https://github.com/k3d-io/k3d/releases/download/v5.9.0/k3d-linux-amd64 \
+            -o /usr/local/bin/k3d && chmod +x /usr/local/bin/k3d && k3d version
+      - name: Web E2E (core-only k3d + Playwright)
+        run: scripts/e2e.sh
+
   # ── Helm ────────────────────────────────────────────────
   helm-lint:
     name: Helm Lint
@@ -737,6 +756,7 @@ jobs:
       - web-lint
       - web-build
       - web-audit
+      - web-e2e
       - helm-lint
       - sast
       - secret-scan
@@ -764,6 +784,7 @@ jobs:
             "${{ needs.web-lint.result }}"
             "${{ needs.web-build.result }}"
             "${{ needs.web-audit.result }}"
+            "${{ needs.web-e2e.result }}"
             "${{ needs.docs-xref.result }}"
             "${{ needs.docs-build.result }}"
             "${{ needs.content-hygiene.result }}"

--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 	release hooks dev dev-down \
 	security-scan security-scan-go security-scan-python \
 	pentest pentest-dast pentest-images pentest-sast \
-	smoke eval eval-down \
+	smoke eval eval-down test-e2e \
 	clean clean-cache test-down \
 	db-migrate db-rollback db-reset \
 	migration-check docs-xref helm-config-contract \
@@ -114,6 +114,10 @@ security-scan-go:       ## Run govulncheck (Go vulnerability scanner)
 
 security-scan-python:   ## Run pip-audit (Python vulnerability scanner)
 	scripts/security-scan.sh python
+
+# ── Web E2E (Playwright on k3d) ─────────────────────────
+test-e2e:           ## Web E2E: boot core-only k3d stack + run Playwright (web/e2e)
+	scripts/e2e.sh
 
 # ── Evaluation (throwaway k3d cluster) ──────────────────
 eval:               ## One-command throwaway k3d eval cluster (no domain, no build)

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+# Web E2E — boot a minimal core-only BAMF stack on k3d and run the Playwright
+# suite (web/e2e) against it. Runnable locally (`make test-e2e`) and in CI.
+#
+# Core-only (API + Web + Postgres + Redis + bootstrap admin) — no bridge/agent/
+# proxy, since the UI E2E only needs login + RBAC-gated pages. Builds the API and
+# Web images from the current tree so it tests the branch code, imports them into
+# k3d, installs the local chart, and runs Playwright against the sslip.io URL.
+#
+# Env: E2E_HTTPS_PORT (default 443), E2E_IP (127.0.0.1), E2E_IMAGE_TAG (e2e),
+#      E2E_KEEP=1 to skip teardown for debugging.
+set -euo pipefail
+
+CLUSTER="${E2E_CLUSTER:-bamf-e2e}"
+KCTX="k3d-${CLUSTER}"     # explicit context — never switch the user's global one
+NS=bamf
+IP="${E2E_IP:-127.0.0.1}"
+HTTPS_PORT="${E2E_HTTPS_PORT:-443}"
+TAG="${E2E_IMAGE_TAG:-e2e}"
+TLS_SECRET=bamf-e2e-tls
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+HOST="bamf.${IP}.sslip.io"
+TUNNEL_DOMAIN="${IP}.sslip.io"
+PORT_SUFFIX=""; [ "$HTTPS_PORT" != "443" ] && PORT_SUFFIX=":${HTTPS_PORT}"
+BASE_URL="https://${HOST}${PORT_SUFFIX}"
+
+Y=$'\033[1;33m'; NC=$'\033[0m'
+step() { echo "${Y}==>${NC} $*"; }
+
+cleanup() { [ "${E2E_KEEP:-0}" = "1" ] || k3d cluster delete "$CLUSTER" >/dev/null 2>&1 || true; }
+trap cleanup EXIT
+
+step "Building API + Web images from the current tree (tag: $TAG)"
+docker build -q -f "$REPO_ROOT/docker/Dockerfile.api" -t "bamf-api:$TAG" "$REPO_ROOT" >/dev/null
+docker build -q -f "$REPO_ROOT/docker/Dockerfile.web" -t "bamf-web:$TAG" "$REPO_ROOT" >/dev/null
+
+step "Creating k3d cluster '$CLUSTER' (host :$HTTPS_PORT → 443)"
+k3d cluster create "$CLUSTER" \
+  --port "${HTTPS_PORT}:443@loadbalancer" \
+  --kubeconfig-switch-context=false --wait
+k3d image import -c "$CLUSTER" "bamf-api:$TAG" "bamf-web:$TAG"
+kubectl --context "$KCTX" create namespace "$NS" --dry-run=client -o yaml | kubectl --context "$KCTX" apply -f - >/dev/null
+kubectl --context "$KCTX" -n kube-system rollout status deploy/traefik --timeout=150s || true
+
+step "Self-signed TLS for ${HOST}"
+tlsdir="$(mktemp -d)"
+openssl req -x509 -newkey rsa:2048 -nodes -days 7 \
+  -keyout "$tlsdir/tls.key" -out "$tlsdir/tls.crt" \
+  -subj "/CN=${HOST}" -addext "subjectAltName=DNS:${HOST},DNS:*.tunnel.${TUNNEL_DOMAIN}" 2>/dev/null
+kubectl --context "$KCTX" -n "$NS" create secret tls "$TLS_SECRET" \
+  --cert="$tlsdir/tls.crt" --key="$tlsdir/tls.key" --dry-run=client -o yaml \
+  | kubectl --context "$KCTX" apply -f - >/dev/null
+rm -rf "$tlsdir"
+
+step "Installing BAMF (core-only) from the local chart"
+helm --kube-context "$KCTX" upgrade --install bamf "$REPO_ROOT/helm/bamf" -n "$NS" \
+  -f "$REPO_ROOT/helm/bamf/values-eval.yaml" \
+  --set edge.enabled=false --set agent.enabled=false \
+  --set gateway.hostname="$HOST" --set gateway.tunnelDomain="$TUNNEL_DOMAIN" \
+  --set gateway.ports.https="$HTTPS_PORT" --set tls.existingSecret="$TLS_SECRET" \
+  --set core.api.image.repository=bamf-api --set core.api.image.tag="$TAG" --set core.api.image.pullPolicy=Never \
+  --set core.web.image.repository=bamf-web --set core.web.image.tag="$TAG" --set core.web.image.pullPolicy=Never \
+  --timeout 300s
+
+step "Waiting for API + Web"
+kubectl --context "$KCTX" -n "$NS" rollout status deploy/bamf-api --timeout=240s
+kubectl --context "$KCTX" -n "$NS" rollout status deploy/bamf-web --timeout=240s
+
+step "Running Playwright against ${BASE_URL}"
+cd "$REPO_ROOT/web"
+[ -d node_modules ] || npm ci
+npx playwright install --with-deps chromium
+BAMF_E2E_BASE_URL="$BASE_URL" BAMF_E2E_ADMIN_EMAIL=admin BAMF_E2E_ADMIN_PASSWORD=admin npm run e2e


### PR DESCRIPTION
## Summary

Wires the existing Playwright specs (`web/e2e/`) into CI — the last missing tier of the code↔tests contract (**#128**) and the "wire up the Web E2E tier" item of the CI-hardening list (**#127**).

- **`scripts/e2e.sh`** — builds the API + Web images from the current tree, boots a **core-only** stack on k3d (API + Web + Postgres + Redis + bootstrap admin; no bridge/agent/proxy — the UI E2E only needs login + RBAC-gated pages), installs the local chart, and runs `npm run e2e` against the sslip.io URL. Self-contained (builds + imports its own images), stack-agnostic, and never switches the global kube context (explicit `--context`, `--kubeconfig-switch-context=false`). Runnable locally as **`make test-e2e`**.
- **`ci.yml`** — a `web-e2e` job (installs a pinned k3d v5.9.0, runs `scripts/e2e.sh`) wired into the **`ci-pass`** gate. Gated on `images_exist` like the other web jobs, so a tag re-push (already validated on the same commit's main push) skips it.

It reuses `helm/bamf/values-eval.yaml` with `edge`+`agent` disabled (core-only render verified clean).

## Verification

The real target environment is CI itself — **this PR's own `web-e2e` job is the live verification**. It boots the k3d stack in the GitHub runner and runs the suite: login page renders, unauthenticated access to a protected page redirects to login (negative path), and admin can log in with local credentials.

## Follow-up
A dedicated **RBAC-negative** spec (a non-privileged session denied an admin page) needs the create-non-admin-user flow — a small follow-up on top of this infra.

Closes the E2E items of #127 and #128.