### PR TITLE
perf(edge): enumerate edges from a registry SET, not a per-heartbeat keyspace SCAN

### DIFF
--- a/services/bamf/api/bridge_relay.py
+++ b/services/bamf/api/bridge_relay.py
@@ -19,6 +19,7 @@ from bamf.api.agent_commands import enqueue_agent_command
 from bamf.auth.ca import get_ca
 from bamf.config import settings
 from bamf.logging_config import get_logger
+from bamf.redis_keys import edges_registry_key
 from bamf.services.bridge_routing import resolve_agent_bridge_endpoint
 
 logger = get_logger(__name__)
@@ -198,27 +199,21 @@ async def build_agent_edge_probe_targets(r, agent_id: str) -> list[tuple[str, st
     selection silently fell back to the default edge. Now every online agent
     measures every reachable edge.
     """
-    prefix = "bridges:available:"
+    # Enumerate edges from the registry SET (#280) rather than a per-heartbeat
+    # SCAN of the whole keyspace. Each edge is still gated on a live bridge, so a
+    # stale registry entry for a drained edge is skipped.
     targets: list[tuple[str, str, int]] = []
-    seen: set[str] = set()
-    cursor = "0"
-    while True:
-        cursor, keys = await r.scan(cursor=cursor, match=f"{prefix}*", count=50)
-        for key in keys:
-            edge = key[len(prefix) :]
-            if not edge or edge in seen:
-                continue
-            seen.add(edge)
-            bridges = await r.zrangebyscore(key, "-inf", "+inf", start=0, num=1)
-            if not bridges:
-                continue
-            bridge_id = bridges[0]
-            info = await r.hgetall(f"bridge:{bridge_id}")
-            hostname = info.get("hostname")
-            if not hostname:
-                continue
-            host, port = await resolve_agent_bridge_endpoint(r, agent_id, bridge_id, hostname)
-            targets.append((edge, host, port))
-        if cursor == 0 or cursor == "0":
-            break
+    for edge in await r.smembers(edges_registry_key()):
+        if not edge:
+            continue
+        bridges = await r.zrangebyscore(f"bridges:available:{edge}", "-inf", "+inf", start=0, num=1)
+        if not bridges:
+            continue
+        bridge_id = bridges[0]
+        info = await r.hgetall(f"bridge:{bridge_id}")
+        hostname = info.get("hostname")
+        if not hostname:
+            continue
+        host, port = await resolve_agent_bridge_endpoint(r, agent_id, bridge_id, hostname)
+        targets.append((edge, host, port))
     return targets

--- a/services/bamf/api/routers/internal_bridges.py
+++ b/services/bamf/api/routers/internal_bridges.py
@@ -57,7 +57,7 @@ from bamf.db.models import Edge, SessionRecording, utc_now
 from bamf.db.session import async_session_factory_read, get_db
 from bamf.logging_config import get_logger
 from bamf.redis.client import get_redis
-from bamf.redis_keys import tunnel_session_creds_key, tunnel_session_key
+from bamf.redis_keys import edges_registry_key, tunnel_session_creds_key, tunnel_session_key
 from bamf.services.audit_service import log_audit_event
 
 router = APIRouter(prefix="/internal", tags=["internal"])
@@ -245,9 +245,12 @@ async def register_bridge(
 
     # Add to available bridges sorted set (score = 0 active tunnels)
     await r.zadd("bridges:available", {request.bridge_id: 0})
-    # Also add to per-edge sorted set if edge is known
+    # Also add to per-edge sorted set if edge is known, and record the edge in
+    # the registry set so probe-target building can enumerate edges without a
+    # keyspace SCAN (#280).
     if sat:
         await r.zadd(f"bridges:available:{sat}", {request.bridge_id: 0})
+        await r.sadd(edges_registry_key(), sat)
 
     logger.info(
         "Bridge registered",

--- a/services/bamf/redis_keys.py
+++ b/services/bamf/redis_keys.py
@@ -36,3 +36,16 @@ def agent_edge_rtt_key(agent_id: str, edge: str) -> str:
     assignment key, so per-agent cleanup scans reach it.
     """
     return f"agent:{agent_id}:edge_rtt:{edge}"
+
+
+def edges_registry_key() -> str:
+    """Redis SET of known edge names (#280).
+
+    A bridge SADDs its edge here on registration. It lets the agent probe-target
+    builder enumerate edges with a single SMEMBERS instead of a per-heartbeat
+    ``SCAN bridges:available:*`` over the whole keyspace. Membership is not
+    reaped (edge names are a small, stable set), which is safe: the builder gates
+    every edge on a live bridge (``bridges:available:{edge}``), so a stale entry
+    for a fully-drained edge is simply skipped.
+    """
+    return "bamf:edges"

--- a/services/tests/test_api/test_agents_router.py
+++ b/services/tests/test_api/test_agents_router.py
@@ -60,6 +60,7 @@ def _make_mock_redis():
     r.hgetall = AsyncMock(return_value={})
     r.publish = AsyncMock()
     r.scan = AsyncMock(return_value=("0", []))
+    r.smembers = AsyncMock(return_value=set())
     return r
 
 

--- a/services/tests/test_api/test_bridge_relay.py
+++ b/services/tests/test_api/test_bridge_relay.py
@@ -10,16 +10,15 @@ from bamf.api.bridge_relay import build_agent_edge_probe_targets
 
 
 def _redis_with(edges: dict[str, list[str]], bridges: dict[str, dict]):
-    """A mock async Redis whose SCAN yields ``bridges:available:{edge}`` keys.
+    """A mock async Redis whose ``bamf:edges`` SET holds the edge names.
 
     ``edges`` maps edge name → the bridge ids in its available set (order =
     score order). ``bridges`` maps bridge id → its ``bridge:{id}`` hash.
     """
     r = AsyncMock()
 
-    async def scan(cursor="0", match=None, count=None):
-        keys = [f"bridges:available:{e}" for e in edges]
-        return ("0", keys)
+    async def smembers(key):
+        return set(edges.keys())
 
     async def zrangebyscore(key, *a, **k):
         edge = key.removeprefix("bridges:available:")
@@ -28,7 +27,7 @@ def _redis_with(edges: dict[str, list[str]], bridges: dict[str, dict]):
     async def hgetall(key):
         return bridges.get(key.removeprefix("bridge:"), {})
 
-    r.scan = scan
+    r.smembers = smembers
     r.zrangebyscore = zrangebyscore
     r.hgetall = hgetall
     return r

--- a/services/tests/test_api/test_bridges_router.py
+++ b/services/tests/test_api/test_bridges_router.py
@@ -33,6 +33,7 @@ def _make_mock_redis():
     r.set = AsyncMock()
     r.delete = AsyncMock()
     r.srem = AsyncMock()
+    r.sadd = AsyncMock()
     r.exists = AsyncMock(return_value=True)
     r.hset = AsyncMock()
     r.hget = AsyncMock(return_value=None)
@@ -194,6 +195,8 @@ class TestRegisterBridge:
         assert resp.status_code == 200
         # Should add to both global and per-edge sorted sets
         assert mock_redis.zadd.call_count == 2
+        # ...and record the edge in the registry set for probe-target building (#280)
+        mock_redis.sadd.assert_called_once_with("bamf:edges", "eu")
 
 
 # ── Tests: Heartbeat ──────────────────────────────────────────────────

--- a/services/tests/test_redis_keys.py
+++ b/services/tests/test_redis_keys.py
@@ -12,6 +12,7 @@ import bamf
 from bamf.auth.sessions import SESSION_PREFIX
 from bamf.redis_keys import (
     agent_edge_rtt_key,
+    edges_registry_key,
     tunnel_session_creds_key,
     tunnel_session_key,
 )
@@ -22,6 +23,10 @@ _BAMF_SRC = Path(bamf.__file__).resolve().parent
 def test_tunnel_session_key_formats():
     assert tunnel_session_key("abc") == "session:abc"
     assert tunnel_session_creds_key("abc") == "session:abc:client_creds"
+
+
+def test_edges_registry_key_format():
+    assert edges_registry_key() == "bamf:edges"
 
 
 def test_agent_edge_rtt_key_format():


### PR DESCRIPTION
## Summary

`build_agent_edge_probe_targets` ran `SCAN bridges:available:*` over the **whole keyspace** on every agent heartbeat (~60s) to enumerate edges. `SCAN` with `MATCH` still traverses the entire keyspace (filtering after), so at scale (many `session:`/`agent:`/`bridge:` keys × many agents) it's meaningful, continuous Redis load the pre-#278 heartbeat didn't have. (Non-blocking — it's awaited async I/O — but wasteful.)

## Fix

Maintain an explicit **`bamf:edges` SET** (`redis_keys.edges_registry_key`): a bridge `SADD`s its edge on registration, and the builder reads it with a single `SMEMBERS`. Each edge is still gated on a live bridge (`bridges:available:{edge}`), so a stale registry entry for a fully-drained edge is simply skipped — no reaping needed (edge names are a small, stable set).

## Tests

- `test_redis_keys.py`: `edges_registry_key()` format.
- `test_bridges_router.py`: register `SADD`s `bamf:edges`.
- `test_bridge_relay.py`: builder enumerates via `SMEMBERS` (updated the mock; skip-empty/bridgeless cases preserved).
- Full affected suite (51 tests) green; ruff clean.

closes #280