### PR TITLE
feat(ops): preflight identity/access doctor (make preflight-identity)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@
 	release hooks dev dev-down \
 	security-scan security-scan-go security-scan-python \
 	pentest pentest-dast pentest-images pentest-sast \
-	smoke eval eval-down test-e2e \
+	smoke eval eval-down test-e2e preflight-identity \
 	clean clean-cache test-down \
 	db-migrate db-rollback db-reset \
 	migration-check docs-xref helm-config-contract \
@@ -114,6 +114,10 @@ security-scan-go:       ## Run govulncheck (Go vulnerability scanner)
 
 security-scan-python:   ## Run pip-audit (Python vulnerability scanner)
 	scripts/security-scan.sh python
+
+# ── Preflight (identity/access doctor) ──────────────────
+preflight-identity: ## Doctor a deployed stack: API↔DB/Redis, CA init, agent impersonation RBAC
+	scripts/preflight.sh
 
 # ── Web E2E (Playwright on k3d) ─────────────────────────
 test-e2e:           ## Web E2E: boot core-only k3d stack + run Playwright (web/e2e)

--- a/scripts/preflight.sh
+++ b/scripts/preflight.sh
@@ -1,0 +1,76 @@
+#!/usr/bin/env bash
+# Preflight identity/access doctor — asserts a deployed BAMF stack is wired
+# correctly before the first tunnel fails:
+#   1. API ↔ Postgres / Redis are reachable  (/ready)
+#   2. the internal CA is initialized         (/certificates/ca is served)
+#   3. if an agent is deployed, its ServiceAccount can impersonate for
+#      Kubernetes access (the k8s-proxy identity path).
+#
+# Read-only. It never switches the global kube context — it uses the current
+# context, or BAMF_CONTEXT if set.
+#
+# Usage:  scripts/preflight.sh          (or: make preflight-identity)
+# Env:    BAMF_NAMESPACE (bamf), BAMF_RELEASE (bamf), BAMF_CONTEXT (current)
+set -uo pipefail   # deliberately NOT -e: run every check, then summarize.
+
+NS="${BAMF_NAMESPACE:-bamf}"
+RELEASE="${BAMF_RELEASE:-bamf}"
+CTX="${BAMF_CONTEXT:-}"
+
+K() { if [ -n "$CTX" ]; then kubectl --context "$CTX" "$@"; else kubectl "$@"; fi; }
+
+G=$'\033[0;32m'; R=$'\033[0;31m'; Y=$'\033[1;33m'; NC=$'\033[0m'
+FAIL=0
+ok()   { echo "  ${G}✓${NC} $*"; }
+bad()  { echo "  ${R}✗${NC} $*"; FAIL=1; }
+warn() { echo "  ${Y}!${NC} $*"; }
+hdr()  { echo; echo "${Y}==>${NC} $*"; }
+
+echo "BAMF preflight — context: $(K config current-context 2>/dev/null || echo '?'), namespace: $NS"
+
+hdr "Namespace"
+if K get ns "$NS" >/dev/null 2>&1; then ok "namespace '$NS' exists"; else bad "namespace '$NS' not found"; echo; echo "${R}Preflight aborted.${NC}"; exit 1; fi
+
+hdr "Control plane"
+if K -n "$NS" get deploy "${RELEASE}-api" >/dev/null 2>&1; then ok "API deployment present"; else bad "'${RELEASE}-api' deployment not found"; fi
+
+hdr "API ↔ Postgres / Redis"
+ready="$(K -n "$NS" exec "deploy/${RELEASE}-api" -- python -c '
+import urllib.request, urllib.error, json, sys
+try:
+    d = json.load(urllib.request.urlopen("http://localhost:8000/ready", timeout=5))
+except urllib.error.HTTPError as e:
+    d = json.load(e)          # 503 body still carries the per-service status
+except Exception as e:
+    print("unreachable:", e); sys.exit(0)
+c = d.get("checks", {})
+print(c.get("database", "?"), c.get("redis", "?"))
+' 2>/dev/null)"
+case "$ready" in
+  "healthy healthy") ok "Postgres reachable"; ok "Redis reachable" ;;
+  "") bad "could not reach the API pod to run the readiness check" ;;
+  *) bad "/ready reports: ${ready}" ;;
+esac
+
+hdr "Internal CA"
+if K -n "$NS" exec "deploy/${RELEASE}-api" -- python -c \
+  'import urllib.request; urllib.request.urlopen("http://localhost:8000/api/v1/certificates/ca", timeout=5)' >/dev/null 2>&1; then
+  ok "CA initialized (public cert served)"
+else
+  bad "CA public cert not available at /api/v1/certificates/ca"
+fi
+
+hdr "Agent Kubernetes impersonation RBAC"
+if K -n "$NS" get sa "${RELEASE}-agent" >/dev/null 2>&1; then
+  cani="$(K auth can-i impersonate users --as="system:serviceaccount:${NS}:${RELEASE}-agent" 2>/dev/null)"
+  case "$cani" in
+    yes) ok "agent SA can impersonate users" ;;
+    no)  bad "agent SA '${RELEASE}-agent' cannot impersonate users — Kubernetes-type resources will fail" ;;
+    *)   warn "couldn't evaluate impersonation (needs permission to create SubjectAccessReviews)" ;;
+  esac
+else
+  warn "no agent ServiceAccount in '$NS' — skipping (impersonation is only needed for kubernetes-type resources)"
+fi
+
+echo
+if [ "$FAIL" = 0 ]; then echo "${G}Preflight passed.${NC}"; else echo "${R}Preflight found problems (see ✗ above).${NC}"; exit 1; fi


### PR DESCRIPTION
## Summary

The last remaining piece of #139 (governance → #283, smoke harness → #284 are done). A `make preflight-identity` doctor that catches a misconfigured deployment **before the first tunnel fails**.

`scripts/preflight.sh` checks a deployed stack:

- Namespace + API deployment present.
- **API ↔ Postgres / Redis** reachable — execs the API pod's `/ready` and reads the per-service `checks`.
- **Internal CA initialized** — the public cert is served at `/api/v1/certificates/ca`.
- **Agent Kubernetes impersonation RBAC** — if an agent is deployed, its ServiceAccount can impersonate users (`kubectl auth can-i impersonate users --as=...`), the k8s-proxy identity path.

Read-only, and it **never switches the global kube context** (uses the current one, or `BAMF_CONTEXT`).

## Note on the CA check
The issue's "check `bamf-ca` Secret exists" is **obsolete** — the CA is DB-backed (`certificate_authority` table); there is no K8s CA secret (same fictional model #126 removed). The doctor verifies the CA is *initialized* via its public endpoint instead.

## Verified live
Against the local stack: all checks pass (exit 0). Negative path — a wrong namespace aborts with a clear `✗ namespace not found` (exit 1). Context stays put.

closes #139