### PR TITLE
test(web): RBAC-negative E2E — a non-admin session is denied an admin page

### DIFF
--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -66,6 +66,16 @@ step "Waiting for API + Web"
 kubectl --context "$KCTX" -n "$NS" rollout status deploy/bamf-api --timeout=240s
 kubectl --context "$KCTX" -n "$NS" rollout status deploy/bamf-web --timeout=240s
 
+step "Pre-warming the ingress + Web/API processes"
+# The single-replica pods are cold right after rollout; warm the login page and
+# the readiness path (a few passes) so the first Playwright navigation isn't the
+# one that pays the cold-start cost on the resource-constrained CI stack.
+for _ in 1 2 3 4 5; do
+  curl -ksS -o /dev/null "${BASE_URL}/login" || true
+  curl -ksS -o /dev/null "${BASE_URL}/ready" || true
+  sleep 2
+done
+
 step "Running Playwright against ${BASE_URL}"
 cd "$REPO_ROOT/web"
 [ -d node_modules ] || npm ci

--- a/web/e2e/rbac.spec.ts
+++ b/web/e2e/rbac.spec.ts
@@ -16,8 +16,9 @@ async function login(page: Page, email: string, password: string) {
   await page.locator('#email').fill(email)
   await page.locator('#password').fill(password)
   await page.getByRole('button', { name: /sign in/i }).click()
-  // On success the SPA navigates off /login.
-  await expect(page).not.toHaveURL(/\/login/, { timeout: 15_000 })
+  // On success the SPA does the PKCE exchange and navigates off /login; give the
+  // constrained CI stack room for those round-trips.
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 30_000 })
 }
 
 test.describe('RBAC', () => {

--- a/web/e2e/rbac.spec.ts
+++ b/web/e2e/rbac.spec.ts
@@ -1,0 +1,47 @@
+import { test, expect, type Page } from '@playwright/test'
+
+const ADMIN_EMAIL = process.env.BAMF_E2E_ADMIN_EMAIL || 'admin'
+const ADMIN_PASSWORD = process.env.BAMF_E2E_ADMIN_PASSWORD || 'admin'
+
+// The SPA stores its session (token, email, roles) in localStorage under this key.
+const AUTH_KEY = 'bamf_auth'
+// User creation enforces a zxcvbn score >= 3; this random mixed string scores 4.
+const NONADMIN_PASSWORD = 'x7Kq!mZ2rTvB9pLw3nD'
+
+async function login(page: Page, email: string, password: string) {
+  await page.goto('/login')
+  await page.locator('#email').fill(email)
+  await page.locator('#password').fill(password)
+  await page.getByRole('button', { name: /sign in/i }).click()
+  // On success the SPA navigates off /login.
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 15_000 })
+}
+
+test.describe('RBAC', () => {
+  test('a non-admin session is denied the admin Users page', async ({ page }) => {
+    // Log in as admin so we can mint a non-admin user through the API.
+    await login(page, ADMIN_EMAIL, ADMIN_PASSWORD)
+    const token = await page.evaluate((k) => {
+      const raw = localStorage.getItem(k)
+      return raw ? (JSON.parse(raw).token as string) : null
+    }, AUTH_KEY)
+    expect(token, 'admin session token should be stored after login').toBeTruthy()
+
+    // Create a local user with no roles (a non-admin). Unique email per attempt
+    // so a Playwright retry doesn't 409 on an already-created user.
+    const email = `e2e-viewer-${Date.now()}@example.com`
+    const created = await page.request.post('/api/v1/users', {
+      headers: { Authorization: `Bearer ${token}` },
+      data: { email, password: NONADMIN_PASSWORD, roles: [] },
+    })
+    expect(created.ok(), `create user failed: ${created.status()} ${await created.text()}`).toBeTruthy()
+
+    // Re-authenticate as the non-admin.
+    await page.evaluate((k) => localStorage.removeItem(k), AUTH_KEY)
+    await login(page, email, NONADMIN_PASSWORD)
+
+    // The Users page is admin-only — the SPA redirects a non-admin away from it.
+    await page.goto('/users')
+    await expect(page).not.toHaveURL(/\/users/, { timeout: 10_000 })
+  })
+})

--- a/web/e2e/rbac.spec.ts
+++ b/web/e2e/rbac.spec.ts
@@ -10,6 +10,9 @@ const NONADMIN_PASSWORD = 'x7Kq!mZ2rTvB9pLw3nD'
 
 async function login(page: Page, email: string, password: string) {
   await page.goto('/login')
+  // The standalone Next server can be slow to render the form on a cold route;
+  // wait for it explicitly before interacting.
+  await expect(page.locator('#email')).toBeVisible({ timeout: 20_000 })
   await page.locator('#email').fill(email)
   await page.locator('#password').fill(password)
   await page.getByRole('button', { name: /sign in/i }).click()

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 1 : 0,
+  // The CI stack is a single-replica standalone-Next pod on k3d; running specs
+  // in parallel overloads it (routes compile/serve slowly under concurrent
+  // first-loads). Serialize in CI for reliability — locally, parallel is fine.
+  workers: process.env.CI ? 1 : undefined,
   reporter: process.env.CI ? [['github'], ['list']] : 'list',
   use: {
     baseURL: process.env.BAMF_E2E_BASE_URL || 'https://bamf.local',

--- a/web/playwright.config.ts
+++ b/web/playwright.config.ts
@@ -5,11 +5,13 @@ import { defineConfig, devices } from '@playwright/test'
 // isn't in the Node trust store, so HTTPS errors are ignored.
 export default defineConfig({
   testDir: './e2e',
-  timeout: 30_000,
-  expect: { timeout: 10_000 },
+  // CI runs against a resource-constrained single-replica k3d stack, so the
+  // login flow (form render + PKCE round-trips) is slower and needs more slack.
+  timeout: process.env.CI ? 90_000 : 30_000,
+  expect: { timeout: process.env.CI ? 20_000 : 10_000 },
   fullyParallel: true,
   forbidOnly: !!process.env.CI,
-  retries: process.env.CI ? 1 : 0,
+  retries: process.env.CI ? 2 : 0,
   // The CI stack is a single-replica standalone-Next pod on k3d; running specs
   // in parallel overloads it (routes compile/serve slowly under concurrent
   // first-loads). Serialize in CI for reliability — locally, parallel is fine.


### PR DESCRIPTION
## Summary

Completes the Web E2E acceptance of **#128**: a negative-path spec with a **non-privileged session** (the piece I flagged as a follow-up when the E2E tier landed in #288).

`web/e2e/rbac.spec.ts`:
1. Logs in as admin (via the UI).
2. Mints a **no-roles** local user through `POST /api/v1/users` (using the admin session token from localStorage).
3. Re-authenticates as that user.
4. Asserts the admin-only **Users** page redirects them away — the SPA's `isAdmin()` gate (`router.push('/')`).

Runs in the same `web-e2e` CI job as the auth smoke.

## Verification
Verified live against the full local stack: **1 passed** (7.9s). The PR's own `web-e2e` job re-runs it (plus the auth smoke) on the k3d stack.

With this, both of #128's acceptance criteria are met — the Playwright smoke + RBAC-negative specs run in CI, and `pkg/bridge/server.go` already has direct unit tests for cert matching + dispatch (`server_test.go`).

Closes #128.