### PR TITLE
fix(deps): refresh CI-flagged vulnerable deps — click 8.4.2 + base-image curl patch

### DIFF
--- a/docker/Dockerfile.api
+++ b/docker/Dockerfile.api
@@ -37,7 +37,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/bamf
 # Runtime-only libraries (no gcc, no -dev headers, no Poetry). apt-get upgrade
 # pulls base-OS security patches; bump APT_REFRESH to bust the cached layer and
 # re-pull freshly-published Debian patches.
-ARG APT_REFRESH=2026-07-06
+ARG APT_REFRESH=2026-07-13
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl xmlsec1 libxmlsec1-openssl \

--- a/docker/Dockerfile.proxy
+++ b/docker/Dockerfile.proxy
@@ -33,7 +33,7 @@ LABEL org.opencontainers.image.source=https://github.com/mattrobinsonsre/bamf
 
 # Runtime-only libraries (no gcc, no Poetry). apt-get upgrade pulls base-OS
 # security patches; bump APT_REFRESH to bust the cache and re-pull new patches.
-ARG APT_REFRESH=2026-07-06
+ARG APT_REFRESH=2026-07-13
 RUN echo "apt-refresh=${APT_REFRESH}" \
     && apt-get update && apt-get upgrade -y && apt-get install -y --no-install-recommends \
     curl \

--- a/services/poetry.lock
+++ b/services/poetry.lock
@@ -276,14 +276,14 @@ pycparser = {version = "*", markers = "implementation_name != \"PyPy\""}
 
 [[package]]
 name = "click"
-version = "8.3.1"
+version = "8.4.2"
 description = "Composable command line interface toolkit"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "click-8.3.1-py3-none-any.whl", hash = "sha256:981153a64e25f12d547d3426c367a4857371575ee7ad18df2a6183ab0545b2a6"},
-    {file = "click-8.3.1.tar.gz", hash = "sha256:12ff4785d337a1bb490bb7e9c2b1ee5da3112e94a8622f26a6c77f5d2fc6842a"},
+    {file = "click-8.4.2-py3-none-any.whl", hash = "sha256:e6f9f66136c816745b9d65817da91d61d957fb16e02e4dcd0552553c5a197b76"},
+    {file = "click-8.4.2.tar.gz", hash = "sha256:9a6cea6e60b17ebe0a44c5cc636d94f09bd66142c1cd7d8b4cd731c4917a15f6"},
 ]
 
 [package.dependencies]


### PR DESCRIPTION
Three live-DB advisories surfaced today (2026-07-13) and fail CI on `main` and every open PR — none of them from Dependabot (0 open Dependabot PRs/alerts). This refreshes them per SECURITY.md (fix, don't suppress, when a fix exists):

- **click 8.3.1 → 8.4.2** (`PYSEC-2026-2132`) — a transitive Python dep flagged by pip-audit (PyPI advisory DB, faster than GitHub's). `poetry update click` (lock-only, no `pyproject` change).
- **curl / libcurl4t64 `8.14.1-2+deb13u3` → `u4`** (`CVE-2026-5773`, `CVE-2026-6276`) — a debian base-image package (the container HEALTHCHECK's `curl`) flagged by Trivy on the `bamf-api` / `bamf-proxy` images. Bumped `APT_REFRESH` in `Dockerfile.api` / `Dockerfile.proxy` so the runtime layer's `apt-get upgrade` re-pulls the patched build.

Verified locally: pip-audit reports no known vulnerabilities and the Python tests import/run cleanly with click 8.4.2. (The grpc CVE from the same wave is fixed separately in #292 — it's in the nested terraform-provider module, outside Dependabot's `directory: /` scope.)